### PR TITLE
Show data usage policy on Scoreset page

### DIFF
--- a/src/components/screens/ScoreSetView.vue
+++ b/src/components/screens/ScoreSetView.vue
@@ -40,6 +40,12 @@
           <div class="mave-scoreset-section-title">Method</div>
           <div v-html="markdownToHtml(item.methodText)" class="mave-scoreset-abstract"></div>
         </div>
+        <div class="mave-scoreset-section-title">Data Usage Policy</div>
+          <div v-if="item.dataUsagePolicy">
+            <div v-html="markdownToHtml(item.dataUsagePolicy)" class="mave-scoreset-abstract"></div>
+          </div>
+          <div v-else>Not specified</div>
+        
         <div v-if="item.keywords && item.keywords.length > 0">
           <div class="mave-scoreset-section-title">Keywords</div>
           <div class="mave-scoreset-keywords">


### PR DESCRIPTION
For all users, the scoreset detail screen displays the data usage policy. If this scoreset property is null, the screen displays “Not specified.”