### PR TITLE
Update Publication Model and Allow Primary/Secondary Publications

### DIFF
--- a/src/components/screens/ExperimentEditor.vue
+++ b/src/components/screens/ExperimentEditor.vue
@@ -64,19 +64,19 @@
               <div class="field">
                 <span class="p-float-label">
                   <AutoComplete
-                      ref="pubmedIdentifiersInput"
-                      v-model="pubmedIdentifiers"
-                      :id="$scopedId('input-pubmedIdentifiers')"
+                      ref="publicationIdentifiersInput"
+                      v-model="publicationIdentifiers"
+                      :id="$scopedId('input-publicationIdentifiers')"
                       field="identifier"
                       :multiple="true"
-                      :suggestions="pubmedIdentifierSuggestionsList"
-                      @complete="searchPubmedIdentifiers"
-                      @keyup.enter="acceptNewPubmedIdentifier"
-                      @keyup.escape="clearPubmedIdentifierSearch"
+                      :suggestions="publicationIdentifierSuggestionsList"
+                      @complete="searchPublicationIdentifiers"
+                      @keyup.enter="acceptNewPublicationIdentifier"
+                      @keyup.escape="clearPublicationIdentifierSearch"
                   />
-                  <label :for="$scopedId('input-pubmedIdentifiers')">PubMed IDs</label>
+                  <label :for="$scopedId('input-publicationIdentifiers')">PubMed IDs</label>
                 </span>
-                <span v-if="validationErrors.pubmedIdentifiers" class="mave-field-error">{{validationErrors.pubmedIdentifiers}}</span>
+                <span v-if="validationErrors.publicationIdentifiers" class="mave-field-error">{{validationErrors.publicationIdentifiers}}</span>
               </div>
               <div class="field">
                 <span class="p-float-label">
@@ -194,7 +194,7 @@ export default {
 
   setup: () => {
     const doiIdentifierSuggestions = useItems({itemTypeName: 'doi-identifier-search'})
-    const pubmedIdentifierSuggestions = useItems({itemTypeName: 'pubmed-identifier-search'})
+    const publicationIdentifierSuggestions = useItems({itemTypeName: 'pubmed-identifier-search'})
     const rawReadIdentifierSuggestions = useItems({itemTypeName: 'raw-read-identifier-search'})
     const {errors: validationErrors, handleSubmit, setErrors: setValidationErrors} = useForm()
     return {
@@ -202,8 +202,8 @@ export default {
       ...useItem({itemTypeName: 'experiment'}),
       doiIdentifierSuggestions: doiIdentifierSuggestions.items,
       setDoiIdentifierSearch: (text) => doiIdentifierSuggestions.setRequestBody({text}),
-      pubmedIdentifierSuggestions: pubmedIdentifierSuggestions.items,
-      setPubmedIdentifierSearch: (text) => pubmedIdentifierSuggestions.setRequestBody({text}),
+      publicationIdentifierSuggestions: publicationIdentifierSuggestions.items,
+      setPublicationIdentifierSearch: (text) => publicationIdentifierSuggestions.setRequestBody({text}),
       rawReadIdentifierSuggestions: rawReadIdentifierSuggestions.items,
       setRawReadIdentifierSearch: (text) => rawReadIdentifierSuggestions.setRequestBody({text}),
       handleSubmit,
@@ -227,7 +227,7 @@ export default {
     methodText: null,
     keywords: [],
     doiIdentifiers: [],
-    pubmedIdentifiers: [],
+    publicationIdentifiers: [],
     rawReadIdentifiers: [],
     extraMetadata: {},
 
@@ -247,10 +247,10 @@ export default {
       // This causes the drop-down to stop appearing when we later populate the list.
       return this.doiIdentifierSuggestions || [{}]
     },
-    pubmedIdentifierSuggestionsList: function() {
+    publicationIdentifierSuggestionsList: function() {
       // The PrimeVue AutoComplete doesn't seem to like it if we set the suggestion list to [].
       // This causes the drop-down to stop appearing when we later populate the list.
-      return this.pubmedIdentifierSuggestions || [{}]
+      return this.publicationIdentifierSuggestions || [{}]
     },
     rawReadIdentifierSuggestionsList: function() {
       // The PrimeVue AutoComplete doesn't seem to like it if we set the suggestion list to [].
@@ -309,12 +309,12 @@ export default {
       }
     },
 
-    acceptNewPubmedIdentifier: function() {
-      const input = this.$refs.pubmedIdentifiersInput
+    acceptNewPublicationIdentifier: function() {
+      const input = this.$refs.publicationIdentifiersInput
       const searchText = (input.inputTextValue || '').trim()
       if (validatePubmedId(searchText)) {
         const pubmedId = normalizePubmedId(searchText)
-        this.pubmedIdentifiers = _.uniqBy([...this.pubmedIdentifiers, {identifier: pubmedId}])
+        this.publicationIdentifiers = _.uniqBy([...this.publicationIdentifiers, {identifier: pubmedId}])
         input.inputTextValue = null
 
         // Clear the text input.
@@ -323,8 +323,8 @@ export default {
       }
     },
 
-    clearPubmedIdentifierSearch: function() {
-      const input = this.$refs.pubmedIdentifiersInput
+    clearPublicationIdentifierSearch: function() {
+      const input = this.$refs.publicationIdentifiersInput
       input.inputTextValue = null
 
       // Clear the text input.
@@ -332,10 +332,10 @@ export default {
       input.$refs.input.value = ''
     },
 
-    searchPubmedIdentifiers: function(event) {
+    searchPublicationIdentifiers: function(event) {
       const searchText = (event.query || '').trim()
       if (searchText.length > 0) {
-        this.setPubmedIdentifierSearch(event.query)
+        this.setPublicationIdentifierSearch(event.query)
       }
     },
 
@@ -425,7 +425,7 @@ export default {
         this.methodText = this.item.methodText
         this.keywords = this.item.keywords
         this.doiIdentifiers = this.item.doiIdentifiers
-        this.pubmedIdentifiers = this.item.pubmedIdentifiers
+        this.publicationIdentifiers = this.item.publicationIdentifiers
         this.rawReadIdentifiers = this.item.rawReadIdentifiers
         this.extraMetadata = this.item.extraMetadata
       } else {
@@ -435,7 +435,7 @@ export default {
         this.methodText = null
         this.keywords = []
         this.doiIdentifiers = []
-        this.pubmedIdentifiers = []
+        this.publicationIdentifiers = []
         this.rawReadIdentifiers = []
         this.extraMetadata = {}
       }
@@ -456,7 +456,7 @@ export default {
         methodText: this.methodText,
         keywords: this.keywords,
         doiIdentifiers: this.doiIdentifiers.map((identifier) => _.pick(identifier, 'identifier')),
-        pubmedIdentifiers: this.pubmedIdentifiers.map((identifier) => _.pick(identifier, 'identifier')),
+        publicationIdentifiers: this.publicationIdentifiers.map((identifier) => _.pick(identifier, 'identifier')),
         rawReadIdentifiers: this.rawReadIdentifiers.map((identifier) => _.pick(identifier, 'identifier')),
         extraMetadata: {}
       }

--- a/src/components/screens/ExperimentEditor.vue
+++ b/src/components/screens/ExperimentEditor.vue
@@ -74,7 +74,7 @@
                       @keyup.enter="acceptNewPublicationIdentifier"
                       @keyup.escape="clearPublicationIdentifierSearch"
                   />
-                  <label :for="$scopedId('input-publicationIdentifiers')">PubMed IDs</label>
+                  <label :for="$scopedId('input-publicationIdentifiers')">Publication Identifiers</label>
                 </span>
                 <span v-if="validationErrors.publicationIdentifiers" class="mave-field-error">{{validationErrors.publicationIdentifiers}}</span>
               </div>
@@ -194,7 +194,7 @@ export default {
 
   setup: () => {
     const doiIdentifierSuggestions = useItems({itemTypeName: 'doi-identifier-search'})
-    const publicationIdentifierSuggestions = useItems({itemTypeName: 'pubmed-identifier-search'})
+    const publicationIdentifierSuggestions = useItems({itemTypeName: 'publication-identifier-search'})
     const rawReadIdentifierSuggestions = useItems({itemTypeName: 'raw-read-identifier-search'})
     const {errors: validationErrors, handleSubmit, setErrors: setValidationErrors} = useForm()
     return {
@@ -313,8 +313,8 @@ export default {
       const input = this.$refs.publicationIdentifiersInput
       const searchText = (input.inputTextValue || '').trim()
       if (validatePubmedId(searchText)) {
-        const pubmedId = normalizePubmedId(searchText)
-        this.publicationIdentifiers = _.uniqBy([...this.publicationIdentifiers, {identifier: pubmedId}])
+        const publicationId = normalizePubmedId(searchText)
+        this.publicationIdentifiers = _.uniqBy([...this.publicationIdentifiers, {identifier: publicationId}])
         input.inputTextValue = null
 
         // Clear the text input.

--- a/src/components/screens/ExperimentEditor.vue
+++ b/src/components/screens/ExperimentEditor.vue
@@ -446,7 +446,7 @@ export default {
         // So that the multiselect can populate correctly, build the primary publication identifiers
         // indirectly by filtering publication identifiers list for those publications we know to be
         // primary.
-        this.publicationIdentifiers = _.concat(this.item.primaryPublicationIdentifiers, this.item.publicationIdentifiers)
+        this.publicationIdentifiers = _.concat(this.item.primaryPublicationIdentifiers, this.item.secondaryPublicationIdentifiers)
         this.primaryPublicationIdentifiers = this.item.primaryPublicationIdentifiers.filter((publication) => {
           return this.publicationIdentifiers.some((primary) => {
             return primary.identifier === publication.identifier

--- a/src/components/screens/ExperimentView.vue
+++ b/src/components/screens/ExperimentView.vue
@@ -17,7 +17,7 @@
       <div class="mave-1000px-col">
         <div v-if="item.creationDate">Created {{formatDate(item.creationDate)}} <span v-if="item.createdBy">
           <a :href="`https://orcid.org/${item.createdBy.orcidId}`" target="blank"><img src="@/assets/ORCIDiD_icon.png" alt="ORCIDiD">{{item.createdBy.firstName}} {{item.createdBy.lastName}}</a></span></div>
-        <div v-if="item.modificationDate">Last updated {{formatDate(item.modificationDate)}} <span v-if="item.modifiedBy"> 
+        <div v-if="item.modificationDate">Last updated {{formatDate(item.modificationDate)}} <span v-if="item.modifiedBy">
           <a :href="`https://orcid.org/${item.modifiedBy.orcidId}`" target="blank"><img src="@/assets/ORCIDiD_icon.png" alt="ORCIDiD">{{item.modifiedBy.firstName}} {{item.modifiedBy.lastName}}</a></span></div>
         <div v-if="item.publishedDate">Published {{formatDate(item.publishedDate)}}</div>
         <div v-if="item.experimentSetUrn">Member of <router-link :to="{name: 'experimentset', params: {urn: item.experimentSetUrn}}">{{item.experimentSetUrn}}</router-link></div>
@@ -43,9 +43,9 @@
         </div>
         <!--Temporary codes to show references. Will change it in the future.-->
         <div class="mave-scoreset-section-title">References</div>
-          <div v-if="item.pubmedIdentifiers.length > 0">
+          <div v-if="item.publicationIdentifiers.length > 0">
             <ul style="list-style-type:square">
-              <div v-for="pubmed in item.pubmedIdentifiers" :key="pubmed">
+              <div v-for="pubmed in item.publicationIdentifiers" :key="pubmed">
                 <li v-html="markdownToHtml(pubmed.referenceHtml)" ></li>PMID: <a :href="`${pubmed.url}`" target="_blank">{{pubmed.identifier}}</a>
               </div>
             </ul>
@@ -182,7 +182,7 @@ export default {
               console.log('Deleted item')
               this.$router.replace({path: `/dashboard`})
               this.$toast.add({severity:'success', summary: 'Your experiment was successfully deleted.', life: 3000})
-              
+
             } else if (response.data && response.data.detail) {
               const formValidationErrors = {}
               for (const error of response.data.detail) {
@@ -194,7 +194,7 @@ export default {
                 formValidationErrors[path] = error.msg
               }
             }
-          } 
+          }
         },
         reject: () => {
             //callback to execute when user rejects the action

--- a/src/components/screens/ExperimentView.vue
+++ b/src/components/screens/ExperimentView.vue
@@ -52,8 +52,8 @@
           </div>
           <div v-else>No associated primary publications.</div>
           <div class="mave-scoreset-section-title">Secondary References</div>
-          <div v-if="item.publicationIdentifiers.length > 0">
-            <div v-for="publication in item.publicationIdentifiers" :key="publication">
+          <div v-if="item.secondaryPublicationIdentifiers.length > 0">
+            <div v-for="publication in item.secondaryPublicationIdentifiers" :key="publication">
                 <ul style="list-style-type:square;">
                   <li v-html="markdownToHtml(publication.referenceHtml)" ></li>Publication: <a :href="`${publication.url}`" target="_blank">{{publication.identifier}}</a>
                 </ul>

--- a/src/components/screens/ExperimentView.vue
+++ b/src/components/screens/ExperimentView.vue
@@ -42,15 +42,24 @@
           <div v-html="markdownToHtml(item.methodText)" class="mave-scoreset-abstract"></div>
         </div>
         <!--Temporary codes to show references. Will change it in the future.-->
-        <div class="mave-scoreset-section-title">References</div>
+        <div class="mave-scoreset-section-title">Primary References</div>
+          <div v-if="item.primaryPublicationIdentifiers.length > 0">
+            <div v-for="publication in item.primaryPublicationIdentifiers" :key="publication">
+                <ul style="list-style-type:square;">
+                  <li v-html="markdownToHtml(publication.referenceHtml)" ></li>Publication: <a :href="`${publication.url}`" target="_blank">{{publication.identifier}}</a>
+                </ul>
+            </div>
+          </div>
+          <div v-else>No associated primary publications.</div>
+          <div class="mave-scoreset-section-title">Secondary References</div>
           <div v-if="item.publicationIdentifiers.length > 0">
-            <ul style="list-style-type:square">
-              <div v-for="pubmed in item.publicationIdentifiers" :key="pubmed">
-                <li v-html="markdownToHtml(pubmed.referenceHtml)" ></li>PMID: <a :href="`${pubmed.url}`" target="_blank">{{pubmed.identifier}}</a>
-              </div>
-            </ul>
-        </div>
-        <div v-else>No associated publication.</div>
+            <div v-for="publication in item.publicationIdentifiers" :key="publication">
+                <ul style="list-style-type:square;">
+                  <li v-html="markdownToHtml(publication.referenceHtml)" ></li>Publication: <a :href="`${publication.url}`" target="_blank">{{publication.identifier}}</a>
+                </ul>
+            </div>
+          </div>
+          <div v-else>No associated secondary publications.</div>
         <div v-if="item.keywords && item.keywords.length > 0">
           <div class="mave-scoreset-section-title">Keywords</div>
           <div class="mave-scoreset-keywords">

--- a/src/components/screens/ScoreSetView.vue
+++ b/src/components/screens/ScoreSetView.vue
@@ -63,8 +63,8 @@
         <div class="mave-scoreset-section-title">References</div>
           <div v-if="item.experiment.publicationIdentifiers.length!=0 || item.publicationIdentifiers.length!=0">
             <ul style="list-style-type:square">
-              <div v-for="pubmed in uniquePublicationIdentifiers" :key="pubmed">
-                <li v-html="markdownToHtml(pubmed.referenceHtml)"></li>PMID: <a :href="`${pubmed.url}`" target="_blank">{{pubmed.identifier}}</a>
+              <div v-for="publication in uniquePublicationIdentifiers" :key="publication">
+                <li v-html="markdownToHtml(publication.referenceHtml)"></li>PMID: <a :href="`${publication.url}`" target="_blank">{{publication.identifier}}</a>
               </div>
             </ul>
         </div>

--- a/src/components/screens/ScoreSetView.vue
+++ b/src/components/screens/ScoreSetView.vue
@@ -25,7 +25,7 @@
         <div v-if="item.creationDate">Created {{formatDate(item.creationDate)}} <span v-if="item.createdBy">
           <a :href="`https://orcid.org/${item.createdBy.orcidId}`" target="blank"><img src="@/assets/ORCIDiD_icon.png" alt="ORCIDiD">{{item.createdBy.firstName}} {{item.createdBy.lastName}}</a></span>
         </div>
-        <div v-if="item.modificationDate">Last updated {{formatDate(item.modificationDate)}} <span v-if="item.modifiedBy"> 
+        <div v-if="item.modificationDate">Last updated {{formatDate(item.modificationDate)}} <span v-if="item.modifiedBy">
           <a :href="`https://orcid.org/${item.modifiedBy.orcidId}`" target="blank"><img src="@/assets/ORCIDiD_icon.png" alt="ORCIDiD">{{item.modifiedBy.firstName}} {{item.modifiedBy.lastName}}</a></span>
         </div>
         <div v-if="item.publishedDate">Published {{formatDate(item.publishedDate)}}</div>
@@ -38,14 +38,14 @@
         <div v-if="item.experiment">Member of <router-link :to="{name: 'experiment', params: {urn: item.experiment.urn}}">{{item.experiment.urn}}</router-link></div>
         <div v-if="item.supersedingScoreset">Current version <router-link :to="{name: 'scoreset', params: {urn: item.supersedingScoreset.urn}}">{{item.supersedingScoreset.urn}}</router-link></div>
         <div v-else>Current version <router-link :to="{name: 'scoreset', params: {urn: item.urn}}">{{item.urn}}</router-link></div>
-        <div v-if="item.metaAnalysisSourceScoresets.length!=0">Meta-analyzes 
+        <div v-if="item.metaAnalysisSourceScoresets.length!=0">Meta-analyzes
           <template v-for="(scoreset,index) in sortedMetaAnalysis" :key="scoreset">
             <router-link :to="{name: 'scoreset', params: {urn: scoreset.urn}}">{{scoreset.urn}}</router-link>
             <template v-if="index !== item.metaAnalysisSourceScoresets.length-1"> · </template>
           </template>
         </div>
         <div>Download files <Button class="p-button-outlined p-button-sm" @click="downloadFile('scores')">Scores</Button>&nbsp;
-          <template v-if="countColumns.length!=0"> 
+          <template v-if="countColumns.length!=0">
             <Button class="p-button-outlined p-button-sm" @click="downloadFile('counts')">Counts</Button>&nbsp;
           </template>
           <template v-if="isMetaDataEmpty!=true">
@@ -61,9 +61,9 @@
           <div v-html="markdownToHtml(item.methodText)" class="mave-scoreset-abstract"></div>
         </div>
         <div class="mave-scoreset-section-title">References</div>
-          <div v-if="item.experiment.pubmedIdentifiers.length!=0 || item.pubmedIdentifiers.length!=0">
+          <div v-if="item.experiment.publicationIdentifiers.length!=0 || item.publicationIdentifiers.length!=0">
             <ul style="list-style-type:square">
-              <div v-for="pubmed in uniquePubmedIdentifiers" :key="pubmed">
+              <div v-for="pubmed in uniquePublicationIdentifiers" :key="pubmed">
                 <li v-html="markdownToHtml(pubmed.referenceHtml)"></li>PMID: <a :href="`${pubmed.url}`" target="_blank">{{pubmed.identifier}}</a>
               </div>
             </ul>
@@ -74,7 +74,7 @@
             <div v-html="markdownToHtml(item.dataUsagePolicy)" class="mave-scoreset-abstract"></div>
           </div>
           <div v-else>Not specified</div>
-        
+
         <div v-if="item.keywords && item.keywords.length > 0">
           <div class="mave-scoreset-section-title">Keywords</div>
           <div class="mave-scoreset-keywords">
@@ -110,7 +110,7 @@
             </div>
           </div>
         </div>
-        
+
         <div class="mave-scoreset-section-title">External identifier</div>
         <strong>DOI: </strong>
         <div v-if="item.doiIdentifiers.length!=0">
@@ -120,13 +120,13 @@
         </div><template v-else>No associated DOIs<br/></template>
 
         <div class="mave-scoreset-section-title">Variants</div>
-        <div v-if="item.numVariants > 10">Below is a sample of the first 10 variants. 
+        <div v-if="item.numVariants > 10">Below is a sample of the first 10 variants.
             Please download the file on the top page if you want to read the whole variants list.</div>
         <br/>
         <TabView style="height:585px">
           <TabPanel header="Scores">
-            <!--Default table-layout is fixed meaning the cell widths do not depend on their content. 
-            If you require cells to scale based on their contents set autoLayout property to true. 
+            <!--Default table-layout is fixed meaning the cell widths do not depend on their content.
+            If you require cells to scale based on their contents set autoLayout property to true.
             Note that Scrollable and/or Resizable tables do not support auto layout due to technical limitations.
             Scrollable, column can be frozen but columns and rows don't match so that add width;
             Autolayout, column can't be frozen but columns and rows can match
@@ -134,11 +134,11 @@
             <!---->
             <div style="overflow-y: scroll; overflow-x: scroll; height:600px;">
               <DataTable :value="scoresTable" showGridlines="true" stripedRows="true">
-                <Column v-for="column of scoreColumns.slice(0,3)" :field="column" :header="column" :key="column" 
+                <Column v-for="column of scoreColumns.slice(0,3)" :field="column" :header="column" :key="column"
                 style="overflow:hidden" headerStyle="background-color:#A1D8C8; font-weight: bold" ><!--:frozen="columnIsAllNa(scoresTable, column)"-->
                 <template #body="scoresTable" >{{scoresTable.data[column]}}</template>
               </Column>
-              <Column v-for="column of scoreColumns.slice(3,scoreColumns.length)" :field="column" :header="column" :key="column" 
+              <Column v-for="column of scoreColumns.slice(3,scoreColumns.length)" :field="column" :header="column" :key="column"
                 style="overflow:hidden" headerStyle="background-color:#A1D8C8; font-weight: bold">
                 <template #body="scoresTable">{{convertToThreeDecimal(scoresTable.data[column])}}</template>
               </Column>
@@ -150,13 +150,13 @@
               <DataTable :value="countsTable" showGridlines="true" stripedRows="true">
                 <template v-if="countColumns.length==0">No count data available.</template>
                 <template v-else>
-                  <Column v-for="column of countColumns.slice(0,3)" :field="column" :header="column" :key="column" 
+                  <Column v-for="column of countColumns.slice(0,3)" :field="column" :header="column" :key="column"
                   style="overflow:hidden" headerStyle="background-color:#A1D8C8; font-weight: bold"> <!--:frozen="columnIsAllNa(countsTable, column)" bodyStyle="text-align:left"-->
                     <template #body="countsTable">{{countsTable.data[column]}}</template> <!--:style="{overflow: 'hidden'}"-->
                   </Column>
-                  <Column v-for="column of countColumns.slice(3,countColumns.length)" :field="column" :header="column" :key="column" 
+                  <Column v-for="column of countColumns.slice(3,countColumns.length)" :field="column" :header="column" :key="column"
                   style="overflow:hidden" headerStyle="background-color:#A1D8C8; font-weight: bold">
-                    <template #body="countsTable">{{convertToThreeDecimal(countsTable.data[column])}}</template> 
+                    <template #body="countsTable">{{convertToThreeDecimal(countsTable.data[column])}}</template>
                   </Column>
                 </template>
               </DataTable>
@@ -226,19 +226,19 @@ export default {
     sortedMetaAnalysis: function(){
       return _.orderBy(this.item.metaAnalysisSourceScoresets, 'urn')
     },
-    uniquePubmedIdentifiers: function(){
-      let pubmedIdentifiers = []
-      if(this.item.experiment.pubmedIdentifiers){
-        for(let i of this.item.experiment.pubmedIdentifiers){
-          pubmedIdentifiers.push(i)
+    uniquePublicationIdentifiers: function(){
+      let publicationIdentifiers = []
+      if(this.item.experiment.publicationIdentifiers){
+        for(let i of this.item.experiment.publicationIdentifiers){
+          publicationIdentifiers.push(i)
         }
       }
-      if(this.item.pubmedIdentifiers){
-        for(let i of this.item.pubmedIdentifiers){
-          pubmedIdentifiers.push(i)
+      if(this.item.publicationIdentifiers){
+        for(let i of this.item.publicationIdentifiers){
+          publicationIdentifiers.push(i)
         }
       }
-      let uniqueObjects = [...new Map(pubmedIdentifiers.map(item => [item.identifier, item])).values()]
+      let uniqueObjects = [...new Map(publicationIdentifiers.map(item => [item.identifier, item])).values()]
       return uniqueObjects
     }
   },
@@ -334,7 +334,7 @@ export default {
                 formValidationErrors[path] = error.msg
               }
             }
-          } 
+          }
         },
         reject: () => {
             //callback to execute when user rejects the action
@@ -349,7 +349,7 @@ export default {
       return _.get(...args)
     },
     publishItem: async function() {
-      let response = null 
+      let response = null
       try {
         if (this.item) {
           response = await axios.post(`${config.apiBaseUrl}/scoresets/${this.item.urn}/publish`, this.item)

--- a/src/components/screens/ScoreSetView.vue
+++ b/src/components/screens/ScoreSetView.vue
@@ -60,15 +60,24 @@
           <div class="mave-scoreset-section-title">Method</div>
           <div v-html="markdownToHtml(item.methodText)" class="mave-scoreset-abstract"></div>
         </div>
-        <div class="mave-scoreset-section-title">References</div>
-          <div v-if="item.experiment.publicationIdentifiers.length!=0 || item.publicationIdentifiers.length!=0">
-            <ul style="list-style-type:square">
-              <div v-for="publication in uniquePublicationIdentifiers" :key="publication">
-                <li v-html="markdownToHtml(publication.referenceHtml)"></li>PMID: <a :href="`${publication.url}`" target="_blank">{{publication.identifier}}</a>
-              </div>
-            </ul>
-        </div>
-        <div v-else>No associated publication.</div>
+        <div class="mave-scoreset-section-title">Primary References</div>
+          <div v-if="item.primaryPublicationIdentifiers.length > 0">
+            <div v-for="publication in item.primaryPublicationIdentifiers" :key="publication">
+                <ul style="list-style-type:square;">
+                  <li v-html="markdownToHtml(publication.referenceHtml)" ></li>Publication: <a :href="`${publication.url}`" target="_blank">{{publication.identifier}}</a>
+                </ul>
+            </div>
+          </div>
+          <div v-else>No associated primary publications.</div>
+          <div class="mave-scoreset-section-title">Secondary References</div>
+          <div v-if="item.publicationIdentifiers.length > 0">
+            <div v-for="publication in item.publicationIdentifiers" :key="publication">
+                <ul style="list-style-type:square;">
+                  <li v-html="markdownToHtml(publication.referenceHtml)" ></li>Publication: <a :href="`${publication.url}`" target="_blank">{{publication.identifier}}</a>
+                </ul>
+            </div>
+          </div>
+          <div v-else>No associated secondary publications.</div>
         <div class="mave-scoreset-section-title">Data Usage Policy</div>
           <div v-if="item.dataUsagePolicy">
             <div v-html="markdownToHtml(item.dataUsagePolicy)" class="mave-scoreset-abstract"></div>
@@ -226,21 +235,6 @@ export default {
     sortedMetaAnalysis: function(){
       return _.orderBy(this.item.metaAnalysisSourceScoresets, 'urn')
     },
-    uniquePublicationIdentifiers: function(){
-      let publicationIdentifiers = []
-      if(this.item.experiment.publicationIdentifiers){
-        for(let i of this.item.experiment.publicationIdentifiers){
-          publicationIdentifiers.push(i)
-        }
-      }
-      if(this.item.publicationIdentifiers){
-        for(let i of this.item.publicationIdentifiers){
-          publicationIdentifiers.push(i)
-        }
-      }
-      let uniqueObjects = [...new Map(publicationIdentifiers.map(item => [item.identifier, item])).values()]
-      return uniqueObjects
-    }
   },
   setup: () => {
     const scoresRemoteData = useRemoteData()

--- a/src/components/screens/ScoreSetView.vue
+++ b/src/components/screens/ScoreSetView.vue
@@ -70,8 +70,8 @@
           </div>
           <div v-else>No associated primary publications.</div>
           <div class="mave-scoreset-section-title">Secondary References</div>
-          <div v-if="item.publicationIdentifiers.length > 0">
-            <div v-for="publication in item.publicationIdentifiers" :key="publication">
+          <div v-if="item.secondaryPublicationIdentifiers.length > 0">
+            <div v-for="publication in item.secondaryPublicationIdentifiers" :key="publication">
                 <ul style="list-style-type:square;">
                   <li v-html="markdownToHtml(publication.referenceHtml)" ></li>Publication: <a :href="`${publication.url}`" target="_blank">{{publication.identifier}}</a>
                 </ul>

--- a/src/components/screens/ScoresetEditor.vue
+++ b/src/components/screens/ScoresetEditor.vue
@@ -460,7 +460,7 @@ export default {
       }
     })
     const doiIdentifierSuggestions = useItems({itemTypeName: 'doi-identifier-search'})
-    const publicationIdentifierSuggestions = useItems({itemTypeName: 'pubmed-identifier-search'})
+    const publicationIdentifierSuggestions = useItems({itemTypeName: 'publication-identifier-search'})
     const targetGeneIdentifierSuggestions = {}
     for (const dbName of externalGeneDatabases) {
       targetGeneIdentifierSuggestions[dbName] = useItems({itemTypeName: `${dbName.toLowerCase()}-identifier-search`})
@@ -727,6 +727,7 @@ export default {
       }
     },
 
+    // TODO accept other publication identifiers besides pubmed
     acceptNewPublicationIdentifier: function() {
       const input = this.$refs.publicationIdentifiersInput
       const searchText = (input.inputTextValue || '').trim()

--- a/src/components/screens/ScoresetEditor.vue
+++ b/src/components/screens/ScoresetEditor.vue
@@ -183,19 +183,19 @@
                 <div class="field">
                   <span class="p-float-label">
                     <AutoComplete
-                        ref="pubmedIdentifiersInput"
-                        v-model="pubmedIdentifiers"
-                        :id="$scopedId('input-pubmedIdentifiers')"
+                        ref="publicationIdentifiersInput"
+                        v-model="publicationIdentifiers"
+                        :id="$scopedId('input-publicationIdentifiers')"
                         field="identifier"
                         :multiple="true"
-                        :suggestions="pubmedIdentifierSuggestionsList"
-                        @complete="searchPubmedIdentifiers"
-                        @keyup.enter="acceptNewPubmedIdentifier"
-                        @keyup.escape="clearPubmedIdentifierSearch"
+                        :suggestions="publicationIdentifierSuggestionsList"
+                        @complete="searchPublicationIdentifiers"
+                        @keyup.enter="acceptNewPublicationIdentifier"
+                        @keyup.escape="clearPublicationIdentifierSearch"
                     />
-                    <label :for="$scopedId('input-pubmedIdentifiers')">PubMed IDs</label>
+                    <label :for="$scopedId('input-publicationIdentifiers')">PubMed IDs</label>
                   </span>
-                  <span v-if="validationErrors.pubmedIdentifiers" class="mave-field-error">{{validationErrors.pubmedIdentifiers}}</span>
+                  <span v-if="validationErrors.publicationIdentifiers" class="mave-field-error">{{validationErrors.publicationIdentifiers}}</span>
                 </div>
                 <div class="field">
                   <span class="p-float-label">
@@ -286,7 +286,7 @@
                   <div class="field-column">
                     <span class="p-float-label">
                       <InputNumber
-                          v-model="targetGene.externalIdentifiers[dbName].offset" 
+                          v-model="targetGene.externalIdentifiers[dbName].offset"
                           :id="$scopedId(`input-${dbName.toLowerCase()}Offset`)"
                           buttonLayout="stacked"
                           min="0"
@@ -460,7 +460,7 @@ export default {
       }
     })
     const doiIdentifierSuggestions = useItems({itemTypeName: 'doi-identifier-search'})
-    const pubmedIdentifierSuggestions = useItems({itemTypeName: 'pubmed-identifier-search'})
+    const publicationIdentifierSuggestions = useItems({itemTypeName: 'pubmed-identifier-search'})
     const targetGeneIdentifierSuggestions = {}
     for (const dbName of externalGeneDatabases) {
       targetGeneIdentifierSuggestions[dbName] = useItems({itemTypeName: `${dbName.toLowerCase()}-identifier-search`})
@@ -476,8 +476,8 @@ export default {
       licenses: licenses.items,
       doiIdentifierSuggestions: doiIdentifierSuggestions.items,
       setDoiIdentifierSearch: (text) => doiIdentifierSuggestions.setRequestBody({text}),
-      pubmedIdentifierSuggestions: pubmedIdentifierSuggestions.items,
-      setPubmedIdentifierSearch: (text) => pubmedIdentifierSuggestions.setRequestBody({text}),
+      publicationIdentifierSuggestions: publicationIdentifierSuggestions.items,
+      setPublicationIdentifierSearch: (text) => publicationIdentifierSuggestions.setRequestBody({text}),
       targetGeneSuggestions: targetGeneSuggestions.items,
       setTargetGeneSearch: (text) => targetGeneSuggestions.setRequestBody({text}),
       targetGeneIdentifierSuggestions: ref({
@@ -515,7 +515,7 @@ export default {
     methodText: null,
     keywords: [],
     doiIdentifiers: [],
-    pubmedIdentifiers: [],
+    publicationIdentifiers: [],
     dataUsagePolicy: null,
     targetGene: {
       name: null,
@@ -573,8 +573,8 @@ export default {
     metaAnalysisSourceScoresetSuggestionsList: function() {
       return this.suggestionsForAutocomplete(this.metaAnalysisSourceScoresetSuggestions)
     },
-    pubmedIdentifierSuggestionsList: function() {
-      return this.suggestionsForAutocomplete(this.pubmedIdentifierSuggestions)
+    publicationIdentifierSuggestionsList: function() {
+      return this.suggestionsForAutocomplete(this.publicationIdentifierSuggestions)
     },
     supersededScoresetSuggestionsList: function() {
       return this.suggestionsForAutocomplete(this.supersededScoresetSuggestions)
@@ -727,12 +727,12 @@ export default {
       }
     },
 
-    acceptNewPubmedIdentifier: function() {
-      const input = this.$refs.pubmedIdentifiersInput
+    acceptNewPublicationIdentifier: function() {
+      const input = this.$refs.publicationIdentifiersInput
       const searchText = (input.inputTextValue || '').trim()
       if (validatePubmedId(searchText)) {
         const pubmedId = normalizePubmedId(searchText)
-        this.pubmedIdentifiers = _.uniqBy([...this.pubmedIdentifiers, {identifier: pubmedId}])
+        this.publicationIdentifiers = _.uniqBy([...this.publicationIdentifiers, {identifier: pubmedId}])
         input.inputTextValue = null
 
         // Clear the text input.
@@ -741,8 +741,8 @@ export default {
       }
     },
 
-    clearPubmedIdentifierSearch: function() {
-      const input = this.$refs.pubmedIdentifiersInput
+    clearPublicationIdentifierSearch: function() {
+      const input = this.$refs.publicationIdentifiersInput
       input.inputTextValue = null
 
       // Clear the text input.
@@ -750,17 +750,17 @@ export default {
       input.$refs.input.value = ''
     },
 
-    searchPubmedIdentifiers: function(event) {
+    searchPublicationIdentifiers: function(event) {
       const searchText = (event.query || '').trim()
       if (searchText.length > 0) {
-        this.setPubmedIdentifierSearch(event.query)
+        this.setPublicationIdentifierSearch(event.query)
       }
     },
 
     acceptNewTargetGeneIdentifier: function(dbName) {
       const input = this.$refs[`${dbName.toLowerCase()}IdentifierInput`][0]
       const searchText = (input.inputTextValue || '').trim()
-  
+
       // Only accept the current search text if we haven't set an identifier. When the user starts typing, the current
       // identifier is cleared.
       const currentIdentifier = this.targetGene.externalIdentifiers[dbName]?.identifier
@@ -891,7 +891,7 @@ export default {
         this.methodText = this.item.methodText
         this.keywords = this.item.keywords
         this.doiIdentifiers = this.item.doiIdentifiers
-        this.pubmedIdentifiers = this.item.pubmedIdentifiers
+        this.publicationIdentifiers = this.item.publicationIdentifiers
         this.dataUsagePolicy = this.item.dataUsagePolicy
 
         this.targetGene = _.merge({
@@ -924,7 +924,7 @@ export default {
         this.methodText = null
         this.keywords = []
         this.doiIdentifiers = []
-        this.pubmedIdentifiers = []
+        this.publicationIdentifiers = []
         this.dataUsagePolicy = null
         this.targetGene = {
           name: null,
@@ -964,7 +964,7 @@ export default {
         methodText: this.methodText,
         keywords: this.keywords,
         doiIdentifiers: this.doiIdentifiers.map((identifier) => _.pick(identifier, 'identifier')),
-        pubmedIdentifiers: this.pubmedIdentifiers.map((identifier) => _.pick(identifier, 'identifier')),
+        publicationIdentifiers: this.publicationIdentifiers.map((identifier) => _.pick(identifier, 'identifier')),
         dataUsagePolicy: this.dataUsagePolicy,
         extraMetadata: {},
         targetGene: {
@@ -1019,7 +1019,7 @@ export default {
           if (this.$refs.scoresFileUpload?.files?.length == 1) {
             await this.uploadData(savedItem)
           } else {
-            this.$router.replace({path: `/scoresets/${this.item.urn}`}) 
+            this.$router.replace({path: `/scoresets/${this.item.urn}`})
             this.$toast.add({severity:'success', summary: 'Your changes were saved.', life: 3000})
           }
         } else {
@@ -1081,7 +1081,7 @@ export default {
           console.log('Imported scoreset data.')
           if (this.item) {
             // this.reloadItem()
-            this.$router.replace({path: `/scoresets/${scoreset.urn}`}) 
+            this.$router.replace({path: `/scoresets/${scoreset.urn}`})
             this.$toast.add({severity:'success', summary: 'Your changes were saved.', life: 3000})
           } else {
             this.$router.replace({path: `/scoresets/${scoreset.urn}`})

--- a/src/components/screens/ScoresetEditor.vue
+++ b/src/components/screens/ScoresetEditor.vue
@@ -722,8 +722,7 @@ export default {
     populateExperimentMetadata: function(event) {
       this.doiIdentifiers = event.value.doiIdentifiers
       this.keywords = event.value.keywords
-      this.publicationIdentifiers = _.concat(event.value.primaryPublicationIdentifiers, event.value.publicationIdentifiers)
-      console.log(this.publicationIdentifiers)
+      this.publicationIdentifiers = _.concat(event.value.primaryPublicationIdentifiers, event.value.secondaryPublicationIdentifiers)
       this.primaryPublicationIdentifiers = event.value.primaryPublicationIdentifiers.filter((primary) => {
           return this.publicationIdentifiers.some((publication) => {
             return primary.identifier === publication.identifier
@@ -927,9 +926,8 @@ export default {
         this.keywords = this.item.keywords
         this.doiIdentifiers = this.item.doiIdentifiers
         // So that the multiselect can populate correctly, build the primary publication identifiers
-        // indirectly by filtering publication identifiers list for those publications we know to be
-        // primary.
-        this.publicationIdentifiers = _.concat(this.item.primaryPublicationIdentifiers, this.item.publicationIdentifiers)
+        // indirectly by filtering a merged list of secondary and primary publication identifiers
+        this.publicationIdentifiers = _.concat(this.item.primaryPublicationIdentifiers, this.item.secondaryPublicationIdentifiers)
         this.primaryPublicationIdentifiers = this.item.primaryPublicationIdentifiers.filter((publication) => {
           return this.publicationIdentifiers.some((primary) => {
             return primary.identifier === publication.identifier
@@ -1046,12 +1044,13 @@ export default {
         // empty item arrays so that deleted items aren't merged back into editedItem object
         this.item.keywords = []
         this.item.doiIdentifiers = []
-        this.item.primaryPublicationIdentifiers
+        this.item.primaryPublicationIdentifiers = []
         this.item.publicationIdentifiers = []
         this.item.rawReadIdentifiers = []
       }
 
       const editedItem = _.merge({}, this.item || {}, editedFields)
+      console.log(editedItem)
 
       this.progressVisible = true
       let response = null

--- a/src/lib/item-types.js
+++ b/src/lib/item-types.js
@@ -26,7 +26,7 @@ const itemTypes = {
     primaryKey: 'urn'
   },
   'experimentSet': {
-    name: 'experimentSet', 
+    name: 'experimentSet',
     restCollectionName: 'experimentSets',
     primaryKey: 'urn'
   },
@@ -36,11 +36,11 @@ const itemTypes = {
   },
   'pubmed-identifier-search': {
     name: 'pubmed-identifier', // TODO Redundant, change this structure
-    restCollectionName: 'pubmedIdentifiers',
+    restCollectionName: 'publicationIdentifiers',
     httpOptions: {
       list: {
         method: 'post',
-        url: `${config.apiBaseUrl}/pubmedIdentifiers/search`
+        url: `${config.apiBaseUrl}/publicationIdentifiers/search`
       }
     }
   },

--- a/src/lib/item-types.js
+++ b/src/lib/item-types.js
@@ -34,8 +34,8 @@ const itemTypes = {
     name: 'license', // TODO Redundant, change this structure
     restCollectionName: 'licenses'
   },
-  'pubmed-identifier-search': {
-    name: 'pubmed-identifier', // TODO Redundant, change this structure
+  'publication-identifier-search': {
+    name: 'publication-identifier', // TODO Redundant, change this structure
     restCollectionName: 'publicationIdentifiers',
     httpOptions: {
       list: {


### PR DESCRIPTION
UI changes associated with VariantEffect/mavedb-api#56:
- Renames instances of pubmed variables to publicationIdentifier to remove the implication that all publications must be from PubMed
- Alters display logic for publications so users can visually differentiate between primary and secondary publications
- Allows users to select which publication from their linked publication identifiers is the primary publication for a given experiment/scoreset
- Adds logic to auto-populate DOIs, keywords, publications, and primary publications for scoresets when they are based on an already created experiment
- Adds a info message notifying users to ensure these auto-populated fields are still relevant to a given scoreset. Refactors an existing span message into a native Vue message to warn users about possible implications when selecting stricter licensing options than the default.