### PR TITLE
Show error details if uploading wrong files.

### DIFF
--- a/src/components/screens/ScoreSetEditor.vue
+++ b/src/components/screens/ScoreSetEditor.vue
@@ -1142,7 +1142,7 @@ export default {
           }
         } else {
           this.$toast.add({severity:'error', summary: 'The score and count files could not be imported.', life: 3000})
-
+          this.$toast.add({severity:'error', summary: response.data.detail})
           // Delete the score set if just created.
           // Warn if the score set already exists.
         }


### PR DESCRIPTION
Solve https://github.com/VariantEffect/mavedb-ui/issues/54. 
Users can see the error details. Some errors details may not show because it doesn't have any detail such as uncaught error. Hence original error information is still there.  