### PR TITLE
Update README.md with accurate Node version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MaveDB user interface
 
 Your development environment will need to have the following software installed.
 
-- Node.js, version 16 or later
+- Node.js, version 14
 
   https://nodejs.org/en/download/
 


### PR DESCRIPTION
When run on Node 16, as the documentation suggests should work, `npm install` misses a key dependency and `npm run serve` errors out. Node 14 works. I have not tested any later versions.