### PR TITLE
Add ProgressSpinner to search page and hide table contents while xhr is loading.

### DIFF
--- a/src/components/ScoreSetTable.vue
+++ b/src/components/ScoreSetTable.vue
@@ -5,6 +5,7 @@
       :options="tableOptions"
       :scrollX="scrollX"
       :scrollY="scrollY"
+      :loading="loading"
       rowIdPath="urn"
     />
   </div>
@@ -52,6 +53,11 @@ export default {
       required: false,
       default: false,
     },
+    loading: {
+      type: Boolean,
+      required: false,
+      default: false,
+    }
   },
 
   data() {

--- a/src/components/common/FlexDataTable.vue
+++ b/src/components/common/FlexDataTable.vue
@@ -1,7 +1,12 @@
 <template>
 
-<div :class="{'samplify-data-table': true, 'lims-flex-data-table-scroll-x': scrollX}" :style="containerStyle" ref="dataTableElement">
+<div :class="{'samplify-data-table': true, 'lims-flex-data-table-scroll-x': scrollX, 'samplify-data-table-loading': loading}"
+     :style="containerStyle"
+     ref="dataTableElement">
   <div class="samplify-data-table-liner" ref="tableLiner"></div>
+  <div v-if="loading" class="samplify-data-table-spinner-container" ref="spinner">
+    <ProgressSpinner class="samplify-data-table-progress" />
+  </div>
 </div>
 
 </template>
@@ -25,12 +30,15 @@ import 'datatables.net-rowgroup-dt'
 import 'datatables.net-scroller-dt'
 import 'datatables.net-select-dt'
 import jszip from 'jszip'
+import ProgressSpinner from 'primevue/progressspinner'
 import 'pdfmake'
 
 window.JSZip = jszip
 
 export default {
   name: 'FlexDataTable',
+
+  components: { ProgressSpinner },
 
   emits: [
     'did-click-checkbox',
@@ -94,6 +102,10 @@ export default {
     virtualRows: {
       type: Boolean,
       default: true
+    },
+    loading: {
+      type: Boolean,
+      default: false 
     }
   },
 
@@ -771,6 +783,23 @@ export default {
 
 .samplify-data-table .dataTables_scrollBody .dts_label {
   display: none;
+}
+
+.samplify-data-table.samplify-data-table-loading .dataTables_scrollBody {
+  display: none;
+}
+
+.samplify-data-table .samplify-data-table-spinner-container {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  padding-top: 18px;
+  width: 100%;
+}
+
+.samplify-data-table .samplify-data-table-progress {
+  height: 50px;
+  width: 50px;
 }
 
 </style>

--- a/src/components/screens/SearchView.vue
+++ b/src/components/screens/SearchView.vue
@@ -31,6 +31,7 @@
       <ScoreSetTable
           :data="publishedScoreSets"
           :language="language"
+          :loading="loading"
           :scrollX="true"
           :scrollY="true"
       />
@@ -65,6 +66,7 @@ export default {
       filterPublicationAuthors: this.$route.query['publication-authors'] ? this.$route.query['publication-authors'] : [],
       filterPublicationDatabases: this.$route.query['publication-databases'] ? this.$route.query['publication-databases'].split(',') : [],
       filterPublicationJournals: this.$route.query['publication-journals'] ? this.$route.query['publication-journals'].split(',') : [],
+      loading: false,
       searchText: this.$route.query.search,
       scoreSets: [],
       publishedScoreSets: [],
@@ -317,6 +319,7 @@ export default {
         ...(this.filterPublicationDatabases.length > 0) ? {'publication-databases': this.filterPublicationDatabases.join(',')} : {},
         ...(this.filterPublicationJournals.length > 0) ? {'publication-journals': this.filterPublicationJournals.join(',')} : {}
       }})
+      this.loading = true;
       await this.fetchSearchResults()
       /*URL
       if (this.searchText && this.searchText.length > 0) {
@@ -325,6 +328,7 @@ export default {
         this.scoreSets = []
       }
       */
+     this.loading = false;
     },
     fetchSearchResults: async function() {
       try {


### PR DESCRIPTION
Before this PR, the previous results are shown while a new search is loading. This also has the (intended) effect of hiding those results when a new search is initiated.

Demo: https://recordit.co/9vjBQGUAAu