### PR TITLE
add SendToGalaxy option

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "vue-oidc-client": "^1.0.0-alpha.4",
     "vue-router": "^4.0.14",
     "vuex": "^4.0.0-0",
-    "yup": "^0.32.9"
+    "yup": "^0.32.9",
+    "cors": "^2.8.5"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^4.5.17",

--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
     "vue-oidc-client": "^1.0.0-alpha.4",
     "vue-router": "^4.0.14",
     "vuex": "^4.0.0-0",
-    "yup": "^0.32.9",
-    "cors": "^2.8.5"
+    "yup": "^0.32.9"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^4.5.17",

--- a/src/components/screens/ScoreSetView.vue
+++ b/src/components/screens/ScoreSetView.vue
@@ -272,6 +272,7 @@ import useRemoteData from '@/composition/remote-data'
 import config from '@/config'
 import { oidc } from '@/lib/auth'
 import { parseScores } from '@/lib/scores'
+import { mapState } from 'vuex'
 
 export default {
   name: 'ScoreSetView',
@@ -295,7 +296,12 @@ export default {
     },
     sortedMetaAnalyzesScoreSetUrns: function () {
       return _.sortBy(this.item?.metaAnalyzesScoreSetUrns || [])
-    }
+    },
+    ...mapState({
+      galaxyUrl: state => state.routeProps.galaxyUrl,
+      toolId: state => state.routeProps.toolId,
+      requestFromGalaxy: state => state.routeProps.requestFromGalaxy
+    })
   },
   setup: () => {
     const scoresRemoteData = useRemoteData()
@@ -312,10 +318,7 @@ export default {
     itemId: {
       type: String,
       required: true
-    },
-    galaxyUrl: String,
-    toolId: String,
-    requestFromGalaxy: String
+    }
   },
   data: () => ({
     scores: null,

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -13,11 +13,17 @@ import SearchView from '@/components/screens/SearchView'
 import SettingsScreen from '@/components/screens/SettingsScreen'
 import UsersView from '@/components/screens/UsersView'
 import {oidc} from '@/lib/auth'
+import store from '@/store';
 
 const routes = [{
   path: '/',
   name: 'home',
-  component: HomeScreen
+  component: HomeScreen,
+  props: (route) => {
+    const props = { ...route.query };
+    store.commit('setRouteProps', props);
+    return props;
+  },
 }, {
   path: '/search',
   name: 'search',
@@ -95,7 +101,11 @@ const routes = [{
   path: '/score-sets/:urn',
   name: 'scoreSet',
   component: ScoreSetView,
-  props: (route) => ({itemId: route.params.urn})
+  props: (route) => ({
+    ...store.state.routeProps,
+    itemId: route.params.urn,
+  }),
+
 }, {
   name: 'pubmedPublicationIdentifier',
   path: '/publication-identifiers/pubmed/:identifier',

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -20,7 +20,12 @@ const routes = [{
   name: 'home',
   component: HomeScreen,
   props: (route) => {
-    const props = { ...route.query };
+    const { galaxyUrl, toolId, requestFromGalaxy } = route.query;
+    const props = {
+      galaxyUrl,
+      toolId,
+      requestFromGalaxy,
+    };
     store.commit('setRouteProps', props);
     return props;
   },
@@ -102,7 +107,6 @@ const routes = [{
   name: 'scoreSet',
   component: ScoreSetView,
   props: (route) => ({
-    ...store.state.routeProps,
     itemId: route.params.urn,
   }),
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -8,8 +8,12 @@ import layoutModule from '@/store/modules/layout'
 
 let store = createStore({
   state: {
+    routeProps: {},
   },
   mutations: {
+    setRouteProps(state, props) {
+      state.routeProps = props;
+    },
   },
   actions: {
   },


### PR DESCRIPTION
Hi, I created this pull request to add an option Send to Galaxy. If MaveDB is opened from Galaxy UI, this option becomes available.

Here is a description of the process of importing data from MaveDB into Galaxy:

1. Galaxy performs a HTTP GET request to the MaveDB url and passes the parameter GALAXY_URL in this request. The value of this parameter contains the url where Galaxy will expect the response to be sent at some later time. MaveDB keeps track of this URL as long as the user navigates MaveDB website.
2. As the user navigates MaveDB, it behaves exactly as if it would if the request would have not originated from Galaxy.
3. At the point where the parameter submission would return data, MaveDB instead posts these parameters to the url that was sent in the GALAXY_URL parameter. 
4. When Galaxy receives the parameters it will run a URL fetching process in the background that will resubmit the parameters to MaveDB, and it will deposit the returned data in the Galaxy user's account.
