### PR TITLE
Use Vite's config functionality to choose API among localhost and production instead of manually editing config.js.

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,0 +1,2 @@
+VITE_API_URL=http://localhost:8002/api/v1
+VITE_SITE_TITLE=MaveDB (local API)

--- a/.env.live
+++ b/.env.live
@@ -1,0 +1,2 @@
+VITE_API_URL=https://api.mavedb.org/api/v1
+VITE_SITE_TITLE=MaveDB

--- a/.gitignore
+++ b/.gitignore
@@ -122,8 +122,6 @@ yarn-error.log
 .java-version
 
 # Python virtualenv
-.env.*
-!.env.template
 .venv
 env/
 venv/

--- a/README.md
+++ b/README.md
@@ -47,11 +47,18 @@ To start the application for local development, run this command from the projec
 npm run dev
 ```
 
+In development mode, the application will look for a local server running the MaveDB API at `http://localhost:8002`.
+To instead use the live MaveDB API server at `https://mavedb.org`, run:
+
+```
+MODE=production npm run dev
+```
+
 ### Building for production
 
 In production, the application is a static web application bundled using Rollup.
 
-To build for production, run
+To build for production, run:
 
 ```
 npm run build
@@ -59,12 +66,19 @@ npm run build
 
 in the project root directory. The result is generated in the `dist` subdirectory, and the contents of `dist` can be deployed as static files on any web server.
 
-If you want to preview the production build, run
+If you want to preview the production build, run:
 
 ```
-npm run serve
+npm run preview
 ```
 
+This will automatically rebuild the files in `dist` on any changes.
+
+This command will by default use the live MaveDB API server at `https://mavedb.org`. To use a local API instance instead, run:
+
+```
+MODE=development npm run preview
+```
 
 ### Deploying in production
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ In development mode, the application will look for a local server running the Ma
 To instead use the live MaveDB API server at `https://mavedb.org`, run:
 
 ```
-MODE=production npm run dev
+MODE=live npm run dev
 ```
 
 ### Building for production
@@ -77,7 +77,7 @@ This will automatically rebuild the files in `dist` on any changes.
 This command will by default use the live MaveDB API server at `https://mavedb.org`. To use a local API instance instead, run:
 
 ```
-MODE=development npm run preview
+MODE=dev npm run preview
 ```
 
 ### Deploying in production

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="/favicon.ico">
     <link rel="alternate icon" href="/favicon.png">
-    <title>MaveDB</title>
+    <title>%VITE_SITE_TITLE%</title>
   </head>
   <body>
     <noscript>

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "2023.5.0",
   "private": true,
   "scripts": {
-    "build": "vite build",
-    "dev": "vite",
-    "serve": "vite build --watch & vite preview"
+    "build": "vite build --mode=${MODE=production}",
+    "dev": "vite --mode=${MODE=development}",
+    "preview": "vite build --mode=${MODE=production} --watch & vite preview --mode=${MODE=production}"
   },
   "dependencies": {
     "@fontsource/raleway": "^4.5.5",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "2023.5.0",
   "private": true,
   "scripts": {
-    "build": "vite build --mode=${MODE=production}",
-    "dev": "vite --mode=${MODE=development}",
-    "preview": "vite build --mode=${MODE=production} --watch & vite preview --mode=${MODE=production}"
+    "build": "vite build --mode=${MODE=live}",
+    "dev": "vite --mode=${MODE=dev}",
+    "preview": "vite build --mode=${MODE=live} --watch & vite preview --mode=${MODE=live}"
   },
   "dependencies": {
     "@fontsource/raleway": "^4.5.5",

--- a/src/config.js
+++ b/src/config.js
@@ -1,10 +1,3 @@
 export default {
-  // Production
-  apiBaseUrl: 'https://api.mavedb.org/api/v1'
-
-  // Local development
-  // apiBaseUrl:  'http://localhost:8002/api/v1'
-
-  // AWS test environment
-  // apiBaseUrl: 'https://dev.api.mavedb.lims.bbi.gs.washington.edu/api/v1'
+  apiBaseUrl: import.meta.env.VITE_API_URL,
 }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -23,13 +23,13 @@ const routes = [{
   name: 'search',
   component: SearchView,
   meta: {
-    title: 'MaveDB | Search'
+    title: import.meta.env.VITE_SITE_TITLE + ' | Search'
   }
 }, {
   path: '/docs',
   component: DocumentationView,
   meta: {
-    title: 'MaveDB | Documentation'
+    title: import.meta.env.VITE_SITE_TITLE + ' | Documentation'
   }
 }, {
   path: '/settings',


### PR DESCRIPTION
Largely following the change here https://github.com/bbi-lab/bbi-lims-ui/commit/23acd644b171e9a15fe35e1cf5b1d593de3a8c05 by @jstone-uw 

This should help new contributors get started faster by eliminating one of the currently existing gotchas (another is tackled in https://github.com/VariantEffect/mavedb-api/pull/117).