### PR TITLE
Add /signed-in.html and /signed-out.html that were in webpack version to vite/rollup.

### DIFF
--- a/signed-in.html
+++ b/signed-in.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <link rel="icon" href="/favicon.ico">
+    <link rel="alternate icon" href="/favicon.png">
+    <title>%VITE_SITE_TITLE%</title>
+  </head>
+  <body>
+    <noscript>
+      <strong>We're sorry but MaveDB doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
+    </noscript>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/signed-out.html
+++ b/signed-out.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <link rel="icon" href="/favicon.ico">
+    <link rel="alternate icon" href="/favicon.png">
+    <title>%VITE_SITE_TITLE%</title>
+  </head>
+  <body>
+    <noscript>
+      <strong>We're sorry but MaveDB doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
+    </noscript>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,5 @@
 import {fileURLToPath, URL} from 'node:url'
+import {resolve} from 'path'
 import {defineConfig} from 'vite'
 import vue from '@vitejs/plugin-vue'
 import basicSsl from '@vitejs/plugin-basic-ssl'
@@ -26,5 +27,14 @@ export default defineConfig({
     port: 8082,
     // Same as above, but localhost:8082 is also legal per ORCID.
     strictPort: true,
+  },
+  build: {
+    rollupOptions: {
+      input: {
+        'index': resolve(__dirname, 'index.html'),
+        'signed-in': resolve(__dirname, 'signed-in.html'),
+        'signed-out': resolve(__dirname, 'signed-out.html'),
+      },
+    },
   },
 })


### PR DESCRIPTION
Unfortunately, we cannot do these without extra files, as per the Vite documentation here: https://vitejs.dev/guide/build#multi-page-app.

Relevant excerpt: Note that for HTML files, Vite ignores the name given to the entry in the rollupOptions.input object and instead respects the resolved id of the file when generating the HTML asset in the dist folder. This ensures a consistent structure with the way the dev server works.