### PR TITLE
Home Page Highlights View for Score Set and Target Aggregate Statistics

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,2 +1,3 @@
 VITE_API_URL=http://localhost:8002/api/v1
+VITE_APP_URL=https://localhost:8081
 VITE_SITE_TITLE=MaveDB (local API)

--- a/.env.live
+++ b/.env.live
@@ -1,2 +1,3 @@
 VITE_API_URL=https://api.mavedb.org/api/v1
+VITE_APP_URL=https://mavedb.org
 VITE_SITE_TITLE=MaveDB

--- a/.env.prodapi
+++ b/.env.prodapi
@@ -1,0 +1,3 @@
+VITE_API_URL=https://api.mavedb.org/api/v1
+VITE_APP_URL=https://localhost:8081
+VITE_SITE_TITLE=MaveDB (prod API)

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,7 @@
   "root": true,
   "env": {
     "node": true,
-    "es2022": true,
+    "es2022": true
   },
   "extends": [
     "plugin:vue/vue3-essential",

--- a/README.md
+++ b/README.md
@@ -48,7 +48,13 @@ npm run dev
 ```
 
 In development mode, the application will look for a local server running the MaveDB API at `http://localhost:8002`.
-To instead use the live MaveDB API server at `https://mavedb.org`, run:
+If you would like to use the live MaveDB API server at `https://mavedb.org` while still having internal links resolve
+to the development environment, run:
+```
+MODE=prodapi npm run dev
+```
+
+If you would like internal links to resolve to the live MaveDB site at `https://mavedb.org`, run:
 
 ```
 MODE=live npm run dev
@@ -78,6 +84,12 @@ This command will by default use the live MaveDB API server at `https://mavedb.o
 
 ```
 MODE=dev npm run preview
+```
+
+To use the live MaveDB API server at `https://mavedb.org` while still using local internal site links, run:
+
+```
+MODE=prodapi npm run preview
 ```
 
 ### Deploying in production
@@ -127,4 +139,3 @@ To update these types from a locally running `mavedb-api` server for development
 ```
 npx openapi-typescript http://localhost:8002/openapi.json -o src/schema/openapi.d.ts
 ```
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@fontsource/raleway": "^5.0.16",
         "axios": "^1.6.2",
+        "chart.js": "^4.4.1",
         "d3": "^7.8.5",
         "datatables.net": "1.11.5",
         "datatables.net-buttons": "1.7.0",
@@ -600,6 +601,11 @@
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
+      "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1233,6 +1239,17 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.1.tgz",
+      "integrity": "sha512-C74QN1bxwV1v2PEujhmKjOZ7iUM4w6BWs23Md/6aOZZSlwMzeCIDGuZay++rBgChYru7/+QFeoQW0fQoP534Dg==",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=7"
       }
     },
     "node_modules/clone": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@fontsource/raleway": "^5.0.16",
     "axios": "^1.6.2",
+    "chart.js": "^4.4.1",
     "d3": "^7.8.5",
     "datatables.net": "1.11.5",
     "datatables.net-buttons": "1.7.0",

--- a/src/components/common/HighlightsView.vue
+++ b/src/components/common/HighlightsView.vue
@@ -357,9 +357,6 @@ export default defineComponent({
           window.open(`${config.appBaseUrl}/#/search?${model}=${Object.keys(data)[element[0].index]}`)
         },
         plugins: {
-          colorschemes: {
-            scheme: 'brewer.Paired12'
-          },
           legend: {
             display: false
           },
@@ -378,7 +375,7 @@ export default defineComponent({
         datasets: [
           {
             data: entries.map((e) => { return e[1] }),
-            // Color pallete for pie charts.
+            // Colors for pie charts; Colors palette from https://sashamaps.net/docs/resources/20-colors/.
             backgroundColor: ['#3f51b5', '#e6194b', '#3cb44b', '#ffe119', '#f032e6', '#bcf60c', '#fabebe', '#008080', '#e6beff', '#f58231', '#911eb4', '#4363d8', '#46f0f0', '#9a6324', '#fffac8', '#800000', '#aaffc3', '#808000', '#ffd8b1', '#808080', '#ffffff', '#000000']
           }
         ]

--- a/src/components/common/HighlightsView.vue
+++ b/src/components/common/HighlightsView.vue
@@ -466,7 +466,7 @@ export default defineComponent({
             }
           }
         )
-        // TODO mavedb-ui#130 catch errors in response
+        // TODO(#130) catch errors in response
         return response.data || {}
       } catch (err) {
         console.log(`Error while loading search results for Model: ${model}, Name: ${name}, Field: ${field}")`, err)
@@ -485,7 +485,7 @@ export default defineComponent({
             }
           }
         )
-        // TODO mavedb-ui#130 catch errors in response
+        // TODO (#130) catch errors in response
         return response.data || []
       } catch (err) {
         console.log(`Error while loading ${identifier} search results")`, err)
@@ -503,7 +503,7 @@ export default defineComponent({
             }
           }
         )
-        // TODO mavedb-ui#130 catch errors in response
+        // TODO (#130) catch errors in response
         return response.data || []
       } catch (err) {
         console.log(`Error while loading publication identifier search results")`, err)
@@ -522,7 +522,7 @@ export default defineComponent({
             }
           }
         )
-        // TODO mavedb-ui#130 catch errors in response
+        // TODO (#130) catch errors in response
         return response.data || []
       } catch (err) {
         console.log(`Error while loading search results")`, err)

--- a/src/components/common/HighlightsView.vue
+++ b/src/components/common/HighlightsView.vue
@@ -1,0 +1,615 @@
+<template>
+  <div v-if="$props.model == 'Target'">
+    <Card>
+      <template #title>Target Gene Highlights</template>
+      <template #content>
+        <TabView @update:active-index="(idx) => { this.field = targetLeaderboardFields[idx] }"
+          v-model:activeIndex="activeTabIndex">
+          <TabPanel v-for="tab in targetLeaderboardFields" :key="tab"
+            :header="tab.charAt(0).toUpperCase() + tab.slice(1)">
+            <div v-if="loading" class="highlights-spinner-container" ref="spinner">
+              <ProgressSpinner class="highlights-progress" />
+            </div>
+            <div v-else>
+              <DataTable :value="leaderboardData" sortField="count" :sortOrder="-1" paginator :rows="5"
+                :rowsPerPageOptions="[5, 10, 20]" size="small">
+                <Column v-for="col of targetLeaderboardColumns[this.field]" :field="col.field" :header="col.header"
+                  :sortable="col.field == 'count'" :key="col.field">
+                  <!-- Link any identifier columns or `column` (in this compoenent representative of some db key) to a MaveDB search page -->
+                  <template v-if="this.field == 'accession' && col.field == 'column'" #body="slotProps">
+                    <a :href="`${config.appBaseUrl}/#/search?target-accession=${slotProps.data[col.field]}`">{{
+                      slotProps.data[col.field] }}</a>
+                  </template>
+                  <template v-else-if="this.field == 'gene' && col.field == 'column'" #body="slotProps">
+                    <a :href="`${config.appBaseUrl}/#/search?search=${slotProps.data[col.field]}`">{{
+                      slotProps.data[col.field] }}</a>
+                  </template>
+                  <template v-else-if="col.field == 'identifier'" #body="slotProps">
+                    <a :href="`${config.appBaseUrl}/#/search?search=${slotProps.data[col.field]}`">{{
+                      slotProps.data[col.field] }}</a>
+                  </template>
+                  <!-- Handle url columns separately, so that we can fill in any missing DB data -->
+                  <template v-else-if="this.field == 'uniprot-identifier' && col.field == 'url'" #body="slotProps">
+                    <a
+                      :href="slotProps.data[col.field] ? `${slotProps.data[col.field]}` : `http://purl.uniprot.org/uniprot/${slotProps.data.identifier}`" target="_blank">{{
+                      slotProps.data.url ? slotProps.data.url :
+                      `http://purl.uniprot.org/uniprot/${slotProps.data.identifier}` }}</a>
+                  </template>
+                  <template v-else-if="this.field == 'refseq-identifier' && col.field == 'url'" #body="slotProps">
+                    <a
+                      :href="slotProps.data[col.field] ? `${slotProps.data[col.field]}` : `http://www.ncbi.nlm.nih.gov/entrez/viewer.fcgi?val=${slotProps.data.identifier}`" target="_blank">{{
+                      slotProps.data.url ? slotProps.data.url :
+                      `http://www.ncbi.nlm.nih.gov/entrez/viewer.fcgi?val=${slotProps.data.identifier}` }}</a>
+                  </template>
+                  <template v-else-if="this.field == 'ensembl-identifier' && col.field == 'url'" #body="slotProps">
+                    <a
+                      :href="slotProps.data[col.field] ? `${slotProps.data[col.field]}` : `http://www.ensembl.org/id/${slotProps.data.identifier}`" target="_blank">{{
+                      slotProps.data.url ? slotProps.data.url : `http://www.ensembl.org/id/${slotProps.data.identifier}`
+                      }}</a>
+                  </template>
+                  <!-- Handle generic url columns  -->
+                  <template v-else-if="col.field == 'url'" #body="slotProps">
+                    <a :href="`${slotProps.data.url}`" target="_blank">{{
+                      slotProps.data.url }}</a>
+                  </template>
+                </Column>
+              </DataTable>
+            </div>
+          </TabPanel>
+        </TabView>
+        <!-- TODO: I think these v-ifs are causing persistent re-rendering of charts when tabs are switched, but a workaround is unclear. -->
+        <div class="chart-container">
+          <div v-if="this.targetAccessionAssemblyFieldCounts" class="chart">
+            <Chart v-show="Object.keys(this.targetAccessionAssemblyFieldCounts).length > 0" type="pie"
+              :data="chartDataForTarget(this.targetAccessionAssemblyFieldCounts)"
+              :options="setChartOptions('Target Gene Assemblies', this.targetAccessionAssemblyFieldCounts, null)" />
+          </div>
+          <div v-if="this.targetGeneCategoryFieldCounts" class="chart">
+            <Chart v-show="Object.keys(this.targetGeneCategoryFieldCounts).length > 0" type="pie"
+              :data="chartDataForTarget(this.targetGeneCategoryFieldCounts)"
+              :options="setChartOptions('Target Gene Category', this.targetGeneCategoryFieldCounts, 'target-type')" />
+          </div>
+          <div v-if="this.targetGeneReferenceFieldCounts" class="chart">
+            <Chart v-show="Object.keys(this.targetGeneReferenceFieldCounts).length > 0" type="pie"
+              :data="chartDataForTarget(this.targetGeneReferenceFieldCounts)"
+              :options="setChartOptions('Target Reference Genome', this.targetGeneReferenceFieldCounts, null)" />
+          </div>
+          <div v-if="this.targetGeneOrganismFieldCounts" class="chart">
+            <Chart v-show="Object.keys(this.targetGeneOrganismFieldCounts).length > 0" type="pie"
+              :data="chartDataForTarget(this.targetGeneOrganismFieldCounts)"
+              :options="setChartOptions('Target Organism', this.targetGeneOrganismFieldCounts, 'target-organism-name')" />
+          </div>
+        </div>
+      </template>
+    </Card>
+  </div>
+  <div v-else-if="$props.model == 'ScoreSet'">
+    <Card>
+      <template #title>Score Set Highlights</template>
+      <template #content>
+        <TabView @tab-change="(event) => { this.field = scoreSetLeaderboardFields[event.index] }"
+          v-model:activeIndex="activeTabIndex">
+          <TabPanel v-for="tab in scoreSetLeaderboardFields" :key="tab"
+            :header="tab.charAt(0).toUpperCase() + tab.slice(1)">
+            <div v-if="loading" class="highlights-spinner-container" ref="spinner">
+              <ProgressSpinner class="highlights-progress" />
+            </div>
+            <div v-else>
+              <DataTable :value="leaderboardData" sortField="count" :sortOrder="-1" paginator :rows="5"
+                :rowsPerPageOptions="[5, 10, 20]" size="small">
+                <Column v-for="col of scoreSetLeaderboardColumns[this.field]" :field="col.field" :header="col.header"
+                  :sortable="col.field == 'count'" :key="col.field">
+                  <!-- Link publication identifiers to their MaveDB page -->
+                  <template v-if="this.field == 'publication-identifiers' && col.field == 'identifier'" #body="slotProps">
+                    <a
+                      :href="`${config.appBaseUrl}/#/publication-identifiers/${slotProps.data.dbName}/${slotProps.data[col.field]}`">{{
+                        slotProps.data[col.field] }}</a>
+                  </template>
+                  <!-- Link keywords and Doi Identifiers to an internal MaveDB search page -->
+                  <template v-else-if="this.field == 'keywords' && col.field == 'column'" #body="slotProps">
+                    <a :href="`${config.appBaseUrl}/#/search?search=${slotProps.data[col.field]}`">{{
+                      slotProps.data[col.field] }}</a>
+                  </template>
+                  <template v-else-if="this.field == 'doi-identifiers' && col.field == 'identifier'" #body="slotProps">
+                    <a :href="`${config.appBaseUrl}/#/search?search=${slotProps.data[col.field]}`">{{
+                      slotProps.data[col.field] }}</a>
+                  </template>
+                  <!-- Link out any remaining URLs to the appropriate location -->
+                  <template v-else-if="col.field == 'url'" #body="slotProps">
+                    <a :href="`${slotProps.data.url}`" target="_blank">{{
+                      slotProps.data.url }}</a>
+                  </template>
+                </Column>
+              </DataTable>
+            </div>
+          </TabPanel>
+        </TabView>
+      </template>
+    </Card>
+  </div>
+  <div v-else-if="$props.model == 'Experiment'">
+    <Card>
+      <template #title>Experiment Highlights</template>
+      <template #content>
+        <TabView @tab-change="(event) => { this.field = experimentLeaderboardFields[event.index] }"
+          v-model:activeIndex="activeTabIndex">
+          <TabPanel v-for="tab in experimentLeaderboardFields" :key="tab"
+            :header="tab.charAt(0).toUpperCase() + tab.slice(1)">
+            <div v-if="loading" class="highlights-spinner-container" ref="spinner">
+              <ProgressSpinner class="highlights-progress" />
+            </div>
+            <div v-else>
+              <DataTable :value="leaderboardData" sortField="count" :sortOrder="-1" paginator :rows="5"
+                :rowsPerPageOptions="[5, 10, 20]" size="small">
+                <Column v-for="col of experimentLeaderboardColumns[this.field]" :field="col.field" :header="col.header"
+                  :sortable="col.field == 'count'" :key="col.field">
+                  <!-- Link publication identifiers to their MaveDB page -->
+                  <template v-if="this.field == 'publication-identifiers' && col.field == 'identifier'" #body="slotProps">
+                    <a
+                      :href="`${config.appBaseUrl}/#/publication-identifiers/${slotProps.data.dbName}/${slotProps.data[col.field]}`">{{
+                        slotProps.data[col.field] }}</a>
+                  </template>
+                  <!-- Link keywords to an internal MaveDB search page -->
+                  <template v-else-if="this.field == 'keywords' && col.field == 'column'" #body="slotProps">
+                    <a :href="`${config.appBaseUrl}/#/search?search=${slotProps.data[col.field]}`">{{
+                      slotProps.data[col.field] }}</a>
+                  </template>
+                  <!-- Link out any URLs to the appropriate location -->
+                  <template v-else-if="col.field == 'url'" #body="slotProps">
+                    <a :href="`${slotProps.data.url}`" target="_blank">{{
+                      slotProps.data.url }}</a>
+                  </template>
+                </Column>
+              </DataTable>
+            </div>
+          </TabPanel>
+        </TabView>
+      </template>
+    </Card>
+  </div>
+</template>
+
+<script>
+import axios from 'axios'
+import config from '@/config'
+import { defineComponent, ref } from 'vue';
+import useItem from '@/composition/item'
+import DataTable from 'primevue/datatable';
+import Column from 'primevue/column';
+import Card from 'primevue/card'
+import TabView from 'primevue/tabview'
+import TabPanel from 'primevue/tabpanel'
+import ProgressSpinner from 'primevue/progressspinner';
+import Chart from 'primevue/chart'
+
+export default defineComponent({
+  name: 'HighlightsView',
+  components: { Card, Chart, Column, DataTable, TabView, TabPanel, ProgressSpinner },
+
+  setup: (props) => {
+    const targetAccessionAssemblyStatistic = useItem({ itemTypeName: "target-accession-statistics" })
+    targetAccessionAssemblyStatistic.setItemId("assembly")
+    const targetGeneCategoryStatistic = useItem({ itemTypeName: "target-gene-statistics" })
+    targetGeneCategoryStatistic.setItemId("category")
+    const targetGeneReferenceStatistic = useItem({ itemTypeName: "target-gene-statistics" })
+    targetGeneReferenceStatistic.setItemId("reference")
+    const targetGeneOrganismStatistic = useItem({ itemTypeName: "target-gene-statistics" })
+    targetGeneOrganismStatistic.setItemId("organism")
+
+    const statisticFields = {
+      "Target": {
+        "accession": { "model": "target", "name": "accession", "field": "accession" },
+        "assembly": { "model": "target", "name": "accession", "field": "assembly" },
+        "gene": { "model": "target", "name": "accession", "field": "gene" },
+
+        "sequence": { "model": "target", "name": "sequence", "field": "sequence" },
+        "sequence-type": { "model": "target", "name": "sequence", "field": "sequence-type" },
+
+        "category": { "model": "target", "name": "gene", "field": "category" },
+        "reference": { "model": "target", "name": "gene", "field": "reference" },
+        "organism": { "model": "target", "name": "gene", "field": "organism" },
+        "uniprot-identifier": { "model": "target", "name": "gene", "field": "uniprot-identifier" },
+        "refseq-identifier": { "model": "target", "name": "gene", "field": "refseq-identifier" },
+        "ensembl-identifier": { "model": "target", "name": "gene", "field": "ensembl-identifier" },
+      },
+
+      "ScoreSet": {
+        "keywords": { "model": "record", "name": "score-set", "field": "keywords" },
+        "publication-identifiers": { "model": "record", "name": "score-set", "field": "publication-identifiers" },
+        "doi-identifiers": { "model": "record", "name": "score-set", "field": "doi-identifiers" },
+      },
+
+      "Experiment": {
+        "keywords": { "model": "record", "name": "experiment", "field": "keywords" },
+        "raw-read-identifiers": { "model": "record", "name": "experiment", "field": "raw-read-identifiers" },
+        "publication-identifiers": { "model": "record", "name": "experiment", "field": "publication-identifiers" },
+        "doi-identifiers": { "model": "record", "name": "experiment", "field": "doi-identifiers" },
+      }
+    }
+
+    const targetLeaderboardFields = ['accession', 'gene', 'uniprot-identifier', 'refseq-identifier', 'ensembl-identifier']
+    const scoreSetLeaderboardFields = ['keywords', 'publication-identifiers', 'doi-identifiers']
+    const experimentLeaderboardFields = ['keywords', 'raw-read-identifiers', 'publication-identifiers', 'doi-identifiers']
+    const activeTabIndex = ref(0)
+
+    const setDefaultField = function () {
+      if (props.model == "Target") {
+        activeTabIndex.value = 0
+        return targetLeaderboardFields[activeTabIndex.value]
+      } else if (props.model == "ScoreSet") {
+        activeTabIndex.value = 0
+        return scoreSetLeaderboardFields[activeTabIndex.value]
+      } else if (props.model == "Experiment") {
+        activeTabIndex.value = 0
+        return experimentLeaderboardFields[activeTabIndex.value]
+      } else {
+        return null
+      }
+    }
+
+    const field = ref(setDefaultField())
+    const loading = ref(true)
+
+    return {
+      config: config,
+
+      statisticFields: statisticFields,
+
+      targetLeaderboardFields: targetLeaderboardFields,
+      scoreSetLeaderboardFields: scoreSetLeaderboardFields,
+      experimentLeaderboardFields: experimentLeaderboardFields,
+
+      targetLeaderboardColumns: {
+        "accession": [{ field: "column", header: "Accession" }, { field: "count", "header": "Associated Score Sets" }],
+        "gene": [{ field: "column", header: "Gene Name" }, { field: "count", "header": "Associated Score Sets" }],
+        "uniprot-identifier": [{ field: "identifier", header: "Uniprot Id" }, { field: "count", "header": "Associated Score Sets" }, { field: "url", header: "URL" }],
+        "refseq-identifier": [{ field: "identifier", header: "RefSeq Id" }, { field: "count", "header": "Associated Score Sets" }, { field: "url", header: "URL" }],
+        "ensembl-identifier": [{ field: "identifier", header: "Ensembl Id" }, { field: "count", "header": "Associated Score Sets" }, { field: "url", header: "URL" }]
+      },
+      scoreSetLeaderboardColumns: {
+        "keywords": [{ field: "column", "header": "Keyword" }, { field: "count", header: "Associated Score Sets" }],
+        "publication-identifiers": [{ field: "identifier", "header": "Identifier" }, { field: "count", header: "Associated Score Sets" }, { field: "title", header: "Title" }, { field: "url", header: "URL" }],
+        "doi-identifiers": [{ field: "identifier", "header": "Identifier" }, { field: "count", header: "Associated Score Sets" }, { field: "url", header: "URL" }]
+      },
+      experimentLeaderboardColumns: {
+        "keywords": [{ field: "column", "header": "Keyword" }, { field: "count", header: "Associated Score Sets" }],
+        "raw-read-identifiers": [{ field: "identifier", "header": "Raw Read Identifier" }, { field: "count", header: "Associated Score Sets" }, { field: "url", header: "URL" }],
+        "publication-identifiers": [{ field: "identifier", "header": "Identifier" }, { field: "count", header: "Associated Score Sets" }, { field: "title", header: "Title" }, { field: "url", header: "URL" }],
+        "doi-identifiers": [{ field: "identifier", "header": "Identifier" }, { field: "count", header: "Associated Score Sets" }, { field: "url", header: "URL" }]
+      },
+
+      // These are for the pie charts
+      targetAccessionAssemblyFieldCounts: targetAccessionAssemblyStatistic.item,
+      targetGeneCategoryFieldCounts: targetGeneCategoryStatistic.item,
+      targetGeneReferenceFieldCounts: targetGeneReferenceStatistic.item,
+      targetGeneOrganismFieldCounts: targetGeneOrganismStatistic.item,
+
+      field: field,
+      activeTabIndex: activeTabIndex,
+      loading: loading
+    }
+  },
+
+  computed: {
+
+  },
+
+  props: {
+    model: {
+      type: String,
+      required: true,
+      validator: (val) => ['Target', 'ScoreSet', 'Experiment'].includes(val),
+    }
+  },
+
+  data: () => ({
+    dataForField: null,
+    leaderboardData: null,
+
+    fetchedLeaderboardData: {}
+  }),
+
+  watch: {
+    field: {
+      handler: async function (newValue, oldValue) {
+        if (newValue == oldValue) {
+          return
+        } else {
+          this.field = newValue
+          this.loading = true
+        }
+
+        this.leaderboardData = null
+        await this.inferAndSetStatisticField(newValue)
+        this.loading = false
+      },
+      immediate: true
+    }
+  },
+
+  methods: {
+    chartDataForTarget: function (targetData) {
+      if (!targetData) {
+        return {}
+      }
+
+      return this.statisticsDictToChartData(targetData)
+    },
+
+    // This gets problematic if there are any duplicated statistics field names. If any do arise, we could add
+    // add nesting levels to the `fetchedLeaderboardData` object and utilize the `statisticForProp` object to
+    // resolve fields dynamically.
+    inferAndSetStatisticField: async function (field) {
+      const statisticForProp = this.statisticFields[this.model]
+      const dataAlreadyFetched = this.fetchedLeaderboardData?.[field]
+
+      if (!dataAlreadyFetched) {
+        this.dataForField = await this.fetchStatistic(statisticForProp[field].model, statisticForProp[field].name, statisticForProp[field].field)
+        this.fetchedLeaderboardData[field] = await this.calculateLeaderboardData()
+      }
+
+      this.leaderboardData = this.fetchedLeaderboardData[field]
+    },
+
+    setChartOptions: function (title, data, model) {
+      return {
+        onClick: (event, element) => {
+          if (!model) {
+            model = 'search'
+          }
+
+          window.open(`${config.appBaseUrl}/#/search?${model}=${Object.keys(data)[element[0].index]}`)
+        },
+        plugins: {
+          colorschemes: {
+            scheme: 'brewer.Paired12'
+          },
+          legend: {
+            display: false
+          },
+          title: {
+            display: true,
+            text: title
+          },
+        }
+      }
+    },
+
+    statisticsDictToChartData: function (stats) {
+      let entries = Object.entries(stats)
+      return {
+        labels: entries.map(e => { return e[0] }),
+        datasets: [
+          {
+            data: entries.map(e => { return e[1] }),
+            backgroundColor: ['#3f51b5', '#e6194b', '#3cb44b', '#ffe119', '#f032e6', '#bcf60c', '#fabebe', '#008080', '#e6beff', '#f58231', '#911eb4', '#4363d8', '#46f0f0', '#9a6324', '#fffac8', '#800000', '#aaffc3', '#808000', '#ffd8b1', '#808080', '#ffffff', '#000000']
+          }
+        ]
+      }
+    },
+
+    calculateLeaderboardData: async function () {
+      if (!this.dataForField) {
+        return []
+      }
+
+      // Target loaders
+      const loadUniprotIdentifiers = async () => {
+        const identifiers = []
+        for (const identifier of Object.keys(this.dataForField)) {
+          let result = await this.searchTargetIdentifiers("UniProt", identifier)
+          identifiers.push({ ...result[0], ...{ count: this.dataForField[identifier] } })
+        }
+
+        return identifiers
+      }
+
+      const loadRefseqIdentifiers = async () => {
+        const identifiers = []
+        for (const identifier of Object.keys(this.dataForField)) {
+          let result = await this.searchTargetIdentifiers("RefSeq", identifier)
+          identifiers.push({ ...result[0], ...{ count: this.dataForField[identifier] } })
+        }
+
+        return identifiers
+      }
+
+      const loadEnsemblIdentifiers = async () => {
+        const identifiers = []
+        for (const identifier of Object.keys(this.dataForField)) {
+          let result = await this.searchTargetIdentifiers("Ensembl", identifier)
+          identifiers.push({ ...result[0], ...{ count: this.dataForField[identifier] } })
+        }
+
+        return identifiers
+      }
+
+      // ScoreSet loaders
+      const loadDoiIdentifiers = async () => {
+        const identifiers = []
+        for (const identifier of Object.keys(this.dataForField)) {
+          let result = await this.searchDoiIdentifiers(identifier)
+          identifiers.push({ ...result[0], ...{ count: this.dataForField[identifier] } })
+        }
+
+        return identifiers
+      }
+
+      const loadPublicationIdentifiers = async () => {
+        const identifiers = []
+        for (const dbName of Object.keys(this.dataForField)) {
+          for (const identifier of Object.keys(this.dataForField[dbName])) {
+            let result = await this.searchPublicationIdentifiers(dbName, identifier)
+            identifiers.push({ ...result, ...{ count: this.dataForField[dbName][identifier] } })
+          }
+        }
+
+        return identifiers
+      }
+
+      const loadRawReadSetIdentifiers = async () => {
+        const identifiers = []
+        for (const identifier of Object.keys(this.dataForField)) {
+          let result = await this.searchRawReadSetIdentifiers(identifier)
+          identifiers.push({ ...result[0], ...{ count: this.dataForField[identifier] } })
+        }
+
+        return identifiers
+      }
+
+      // Target fields
+      if (this.field == 'accession' || this.field == 'gene') {
+        return this.countsToLeaderboard(this.dataForField)
+      }
+      if (this.field == 'uniprot-identifier') {
+        return (await loadUniprotIdentifiers()).sort((a, b) => { a.count - b.count })
+      }
+      else if (this.field == 'refseq-identifier') {
+        return (await loadRefseqIdentifiers()).sort((a, b) => { a.count - b.count })
+      }
+      else if (this.field == 'ensembl-identifier') {
+        return (await loadEnsemblIdentifiers()).sort((a, b) => { a.count - b.count })
+      }
+
+      // ScoreSet fields
+      else if (this.field == 'doi-identifiers') {
+        return (await loadDoiIdentifiers()).sort((a, b) => { a.count - b.count })
+      }
+      else if (this.field == 'publication-identifiers') {
+        return (await loadPublicationIdentifiers()).sort((a, b) => { a.count - b.count })
+      }
+      else if (this.field == 'raw-read-identifiers') {
+        return (await loadRawReadSetIdentifiers()).sort((a, b) => { a.count - b.count })
+      }
+      else if (this.field == 'keywords') {
+        return this.countsToLeaderboard(this.dataForField)
+      }
+      else {
+        return []
+      }
+    },
+
+    countsToLeaderboard: function (counts) {
+      return Object.keys(counts).map(k => { return { column: k, count: counts[k] } })
+    },
+
+    fetchStatistic: async function (model, name, field) {
+      try {
+        const response = await axios.get(
+          `${config.apiBaseUrl}/statistics/${model}/${name}/${field}`,
+          {
+            headers: {
+              accept: 'application/json'
+            }
+          }
+        )
+        // TODO catch errors in response
+        return response.data || {}
+      } catch (err) {
+        console.log(`Error while loading search results")`, err)
+        return []
+      }
+    },
+
+    searchDoiIdentifiers: async function (identifier) {
+      try {
+        const response = await axios.post(
+          `${config.apiBaseUrl}/doi-identifiers/search`,
+          { text: identifier },
+          {
+            headers: {
+              accept: 'application/json'
+            }
+          }
+        )
+        // TODO catch errors in response
+        return response.data || []
+      } catch (err) {
+        console.log(`Error while loading search results")`, err)
+        return []
+      }
+    },
+
+    searchPublicationIdentifiers: async function (dbName, identifier) {
+      try {
+        const response = await axios.get(
+          `${config.apiBaseUrl}/publication-identifiers/${dbName}/${identifier}`,
+          {
+            headers: {
+              accept: 'application/json'
+            }
+          }
+        )
+        // TODO catch errors in response
+        return response.data || []
+      } catch (err) {
+        console.log(`Error while loading search results")`, err)
+        return []
+      }
+    },
+
+    searchRawReadSetIdentifiers: async function (identifier) {
+      try {
+        const response = await axios.post(
+          `${config.apiBaseUrl}/raw-read-identifiers/search`,
+          { text: identifier },
+          {
+            headers: {
+              accept: 'application/json'
+            }
+          }
+        )
+        // TODO catch errors in response
+        return response.data || []
+      } catch (err) {
+        console.log(`Error while loading search results")`, err)
+        return []
+      }
+    },
+
+    searchTargetIdentifiers: async function (db, identifier) {
+      try {
+        const response = await axios.post(
+          `${config.apiBaseUrl}/target-gene-identifiers/search?db_name=${db}`,
+          { text: identifier },
+          {
+            headers: {
+              accept: 'application/json'
+            }
+          }
+        )
+        // TODO catch errors in response
+        return response.data || []
+      } catch (err) {
+        console.log(`Error while loading search results")`, err)
+        return []
+      }
+    },
+  }
+})
+</script>
+
+<style>
+.p-tabview-panel .highlights-spinner-container {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  padding-top: 18px;
+  width: 100%;
+}
+
+.p-tabview-panel .highlights-progress {
+  height: 50px;
+  width: 50px;
+}
+
+.chart-container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-evenly;
+}
+
+.chart {
+  flex: 0 1 auto;
+}
+</style>

--- a/src/components/common/HighlightsView.vue
+++ b/src/components/common/HighlightsView.vue
@@ -378,10 +378,11 @@ export default defineComponent({
     statisticsDictToChartData: function (stats) {
       let entries = Object.entries(stats)
       return {
-        labels: entries.map(e => { return e[0] }),
+        labels: entries.map((e) => { return e[0] }),
         datasets: [
           {
-            data: entries.map(e => { return e[1] }),
+            data: entries.map((e) => { return e[1] }),
+            // Color pallete for pie charts.
             backgroundColor: ['#3f51b5', '#e6194b', '#3cb44b', '#ffe119', '#f032e6', '#bcf60c', '#fabebe', '#008080', '#e6beff', '#f58231', '#911eb4', '#4363d8', '#46f0f0', '#9a6324', '#fffac8', '#800000', '#aaffc3', '#808000', '#ffd8b1', '#808080', '#ffffff', '#000000']
           }
         ]
@@ -428,7 +429,7 @@ export default defineComponent({
       const loadDoiIdentifiers = async () => {
         const identifiers = []
         for (const identifier of Object.keys(this.dataForField)) {
-          let result = await this.searchDoiIdentifiers(identifier)
+          let result = await this.searchIdentifiers(identifier, "doi-identifiers")
           identifiers.push({ ...result[0], ...{ count: this.dataForField[identifier] } })
         }
 
@@ -450,7 +451,7 @@ export default defineComponent({
       const loadRawReadSetIdentifiers = async () => {
         const identifiers = []
         for (const identifier of Object.keys(this.dataForField)) {
-          let result = await this.searchRawReadSetIdentifiers(identifier)
+          let result = await this.searchIdentifiers(identifier, 'raw-read-identifiers')
           identifiers.push({ ...result[0], ...{ count: this.dataForField[identifier] } })
         }
 
@@ -503,7 +504,7 @@ export default defineComponent({
             }
           }
         )
-        // TODO catch errors in response
+        // TODO mavedb-ui#130 catch errors in response
         return response.data || {}
       } catch (err) {
         console.log(`Error while loading search results")`, err)
@@ -511,10 +512,10 @@ export default defineComponent({
       }
     },
 
-    searchDoiIdentifiers: async function (identifier) {
+    searchIdentifiers: async function (identifier, field) {
       try {
         const response = await axios.post(
-          `${config.apiBaseUrl}/doi-identifiers/search`,
+          `${config.apiBaseUrl}/${field}/search`,
           { text: identifier },
           {
             headers: {
@@ -522,7 +523,7 @@ export default defineComponent({
             }
           }
         )
-        // TODO catch errors in response
+        // TODO mavedb-ui#130 catch errors in response
         return response.data || []
       } catch (err) {
         console.log(`Error while loading search results")`, err)
@@ -540,26 +541,7 @@ export default defineComponent({
             }
           }
         )
-        // TODO catch errors in response
-        return response.data || []
-      } catch (err) {
-        console.log(`Error while loading search results")`, err)
-        return []
-      }
-    },
-
-    searchRawReadSetIdentifiers: async function (identifier) {
-      try {
-        const response = await axios.post(
-          `${config.apiBaseUrl}/raw-read-identifiers/search`,
-          { text: identifier },
-          {
-            headers: {
-              accept: 'application/json'
-            }
-          }
-        )
-        // TODO catch errors in response
+        // TODO mavedb-ui#130 catch errors in response
         return response.data || []
       } catch (err) {
         console.log(`Error while loading search results")`, err)
@@ -578,7 +560,7 @@ export default defineComponent({
             }
           }
         )
-        // TODO catch errors in response
+        // TODO mavedb-ui#130 catch errors in response
         return response.data || []
       } catch (err) {
         console.log(`Error while loading search results")`, err)

--- a/src/components/screens/ExperimentView.vue
+++ b/src/components/screens/ExperimentView.vue
@@ -57,7 +57,7 @@
               <li v-html="markdownToHtml(publication.referenceHtml)"></li>
               <div>
                 Publication: <a
-                  :href="`https://www.mavedb.org/#/publication-identifiers/${publication.dbName}/${publication.identifier}`">{{
+                  :href="`${config.appBaseUrl}/#/publication-identifiers/${publication.dbName}/${publication.identifier}`">{{
                     publication.identifier }}</a>
               </div>
               <div>
@@ -74,7 +74,7 @@
               <li v-html="markdownToHtml(publication.referenceHtml)"></li>
               <div>
                 Publication: <a
-                  :href="`https://www.mavedb.org/#/publication-identifiers/${publication.dbName}/${publication.identifier}`">{{
+                  :href="`${config.appBaseUrl}/#/publication-identifiers/${publication.dbName}/${publication.identifier}`">{{
                     publication.identifier }}</a>
               </div>
               <div>
@@ -88,7 +88,7 @@
           <div class="mave-score-set-section-title">Keywords</div>
           <div class="mave-score-set-keywords">
             <Chip :label="keyword" />
-            <!--<a v-for="(keyword, i) of item.keywords" :key="i" :href="`https://www.mavedb.org/search/?keywords=${keyword}`"><Chip :label="keyword"/></a>-->
+            <a v-for="(keyword, i) of item.keywords" :key="i" :href="`${config.appBaseUrl}/search?search=${keyword}`"><Chip :label="keyword"/></a>
           </div>
         </div>
 
@@ -178,12 +178,12 @@
 
 import _ from 'lodash'
 import {marked} from 'marked'
+import config from '@/config'
 import Button from 'primevue/button'
 import Chip from 'primevue/chip'
 import DefaultLayout from '@/components/layout/DefaultLayout'
 import useItem from '@/composition/item'
 import useFormatters from '@/composition/formatters'
-import config from '@/config'
 import axios from 'axios'
 import { oidc } from '@/lib/auth'
 
@@ -193,6 +193,8 @@ export default {
 
   setup: () => {
     return {
+      config: config,
+
       ...useFormatters(),
       ...useItem({ itemTypeName: 'experiment' })
     }

--- a/src/components/screens/HomeScreen.vue
+++ b/src/components/screens/HomeScreen.vue
@@ -1,7 +1,7 @@
 <template>
   <DefaultLayout>
     <div class="grid" style="margin: 10px 0;">
-      <div class="col-6">
+      <div class="col-8">
         <Card>
           <template #title>About</template>
           <template #content>
@@ -29,9 +29,9 @@
           </template>
         </Card>
       </div>
-      <div class="col-6">
+      <div class="col-4">
         <Card>
-          <template #title>Highlights</template>
+          <template #title>Featured Searches</template>
           <template #content>
             <table>
               <thead>
@@ -70,7 +70,13 @@
           </template>
         </Card>
       </div>
-      <div class="col-6">
+      <div class="col-12">
+        <HighlightsView model="ScoreSet"></HighlightsView>
+      </div>
+      <div class="col-8">
+        <HighlightsView model="Target"></HighlightsView>
+      </div>
+      <div class="col-4">
         <Card>
           <template #title>Citation</template>
           <template #content>
@@ -97,10 +103,11 @@ import Card from 'primevue/card'
 
 //import config from '@/config'
 import DefaultLayout from '@/components/layout/DefaultLayout'
+import HighlightsView from '@/components/common/HighlightsView.vue';
 
 export default {
   name: 'HomeScreen',
-  components: {Card, DefaultLayout}
+  components: {Card, DefaultLayout, HighlightsView}
 }
 
 </script>

--- a/src/components/screens/PublicationIdentifierView.vue
+++ b/src/components/screens/PublicationIdentifierView.vue
@@ -139,7 +139,7 @@
               }
             }
           )
-          // TODO catch errors in response
+          // TODO mavedb-ui#130 catch errors in response
           this.scoreSets = response.data || []
 
           // reset published score sets search results when using search bar

--- a/src/components/screens/PublicationIdentifierView.vue
+++ b/src/components/screens/PublicationIdentifierView.vue
@@ -139,7 +139,7 @@
               }
             }
           )
-          // TODO mavedb-ui#130 catch errors in response
+          // TODO (#130) catch errors in response
           this.scoreSets = response.data || []
 
           // reset published score sets search results when using search bar

--- a/src/components/screens/ScoreSetEditor.vue
+++ b/src/components/screens/ScoreSetEditor.vue
@@ -912,7 +912,7 @@ export default {
             }
           }
         )
-        // TODO catch errors in response
+        // TODO mavedb-ui#130 catch errors in response
         return response.data || []
       } catch (err) {
         console.log(`Error while loading search results")`, err)
@@ -949,7 +949,7 @@ export default {
             }
           }
         )
-        // TODO catch errors in response
+        // TODO mavedb-ui#130 catch errors in response
         return response.data || []
       } catch (err) {
         console.log(`Error while loading search results")`, err)
@@ -968,7 +968,7 @@ export default {
             }
           }
         )
-        // TODO catch errors in response
+        // TODO mavedb-ui#130 catch errors in response
         return response.data || []
       } catch (err) {
         console.log(`Error while loading search results")`, err)
@@ -998,7 +998,7 @@ export default {
             }
           }
         )
-        // TODO catch errors in response
+        // TODO mavedb-ui#130 catch errors in response
         if (!response.data) {
           this.$toast.add({ severity: 'error', summary: `No matching protein accession found for ${this.targetGene.targetAccession.accession}`, life: 3000 })
         }

--- a/src/components/screens/ScoreSetEditor.vue
+++ b/src/components/screens/ScoreSetEditor.vue
@@ -912,7 +912,7 @@ export default {
             }
           }
         )
-        // TODO mavedb-ui#130 catch errors in response
+        // TODO (#130) catch errors in response
         return response.data || []
       } catch (err) {
         console.log(`Error while loading search results")`, err)
@@ -949,7 +949,7 @@ export default {
             }
           }
         )
-        // TODO mavedb-ui#130 catch errors in response
+        // TODO (#130) catch errors in response
         return response.data || []
       } catch (err) {
         console.log(`Error while loading search results")`, err)
@@ -968,7 +968,7 @@ export default {
             }
           }
         )
-        // TODO mavedb-ui#130 catch errors in response
+        // TODO (#130) catch errors in response
         return response.data || []
       } catch (err) {
         console.log(`Error while loading search results")`, err)
@@ -998,7 +998,7 @@ export default {
             }
           }
         )
-        // TODO mavedb-ui#130 catch errors in response
+        // TODO (#130) catch errors in response
         if (!response.data) {
           this.$toast.add({ severity: 'error', summary: `No matching protein accession found for ${this.targetGene.targetAccession.accession}`, life: 3000 })
         }

--- a/src/components/screens/ScoreSetView.vue
+++ b/src/components/screens/ScoreSetView.vue
@@ -83,7 +83,7 @@
               <li v-html="markdownToHtml(publication.referenceHtml)"></li>
               <div>
                 Publication: <a
-                  :href="`https://www.mavedb.org/#/publication-identifiers/${publication.dbName}/${publication.identifier}`">{{
+                  :href="`${config.appBaseUrl}/#/publication-identifiers/${publication.dbName}/${publication.identifier}`">{{
                     publication.identifier }}</a>
               </div>
               <div>
@@ -100,7 +100,7 @@
               <li v-html="markdownToHtml(publication.referenceHtml)"></li>
               <div>
                 Publication: <a
-                  :href="`https://www.mavedb.org/#/publication-identifiers/${publication.dbName}/${publication.identifier}`">{{
+                  :href="`${config.appBaseUrl}/#/publication-identifiers/${publication.dbName}/${publication.identifier}`">{{
                     publication.identifier }}</a>
               </div>
               <div>
@@ -120,7 +120,7 @@
           <div class="mave-score-set-section-title">Keywords</div>
           <div class="mave-score-set-keywords">
             <a v-for="(keyword, i) in item.keywords" :key="i"
-              :href="`https://www.mavedb.org/search/?keywords=${keyword}`">
+              :href="`${config.appBaseUrl}/#/search?search=${keyword}`">
               <Chip :label="keyword" />
             </a>
           </div>
@@ -306,6 +306,8 @@ export default {
   setup: () => {
     const scoresRemoteData = useRemoteData()
     return {
+      config: config,
+
       ...useFormatters(),
       ...useItem({ itemTypeName: 'scoreSet' }),
       scoresData: scoresRemoteData.data,

--- a/src/components/screens/SearchView.vue
+++ b/src/components/screens/SearchView.vue
@@ -136,7 +136,7 @@ export default defineComponent({
       return countTargetGeneMetadata(this.publishedScoreSets, (targetGene) => targetGene.name)
     },
     targetOrganismFilterOptions: function() {
-      return countTargetGeneMetadata(this.publishedScoreSets, 
+      return countTargetGeneMetadata(this.publishedScoreSets,
         (targetGene) => targetGene.targetSequence?.reference.organismName || '')
     },
     targetAccessionFilterOptions: function() {
@@ -147,15 +147,15 @@ export default defineComponent({
       return countTargetGeneMetadata(this.publishedScoreSets, (targetGene) => targetGene.category)
     },
     publicationAuthorFilterOptions: function() {
-      return countPublicationMetadata(this.publishedScoreSets, 
+      return countPublicationMetadata(this.publishedScoreSets,
         (publicationIdentifier) => publicationIdentifier.authors.map((author) => author.name))
     },
     publicationDatabaseFilterOptions: function() {
-      return countPublicationMetadata(this.publishedScoreSets, 
+      return countPublicationMetadata(this.publishedScoreSets,
         (publicationIdentifier) => publicationIdentifier.dbName ? [publicationIdentifier.dbName] : [])
     },
     publicationJournalFilterOptions: function() {
-      return countPublicationMetadata(this.publishedScoreSets, 
+      return countPublicationMetadata(this.publishedScoreSets,
         (publicationIdentifier) => publicationIdentifier.publicationJournal ? [publicationIdentifier.publicationJournal] : [])
     },
   },
@@ -329,7 +329,7 @@ export default defineComponent({
             }
           }
         )
-        // TODO catch errors in response
+        // TODO mavedb-ui#130 catch errors in response
         this.scoreSets = response.data || []
 
         // reset published score sets search results when using search bar

--- a/src/components/screens/SearchView.vue
+++ b/src/components/screens/SearchView.vue
@@ -329,7 +329,7 @@ export default defineComponent({
             }
           }
         )
-        // TODO mavedb-ui#130 catch errors in response
+        // TODO (#130) catch errors in response
         this.scoreSets = response.data || []
 
         // reset published score sets search results when using search bar

--- a/src/config.d.ts
+++ b/src/config.d.ts
@@ -1,4 +1,5 @@
 declare namespace Config {
     let apiBaseUrl: string;
+    let appBaseUrl: string;
 }
 export default Config;

--- a/src/config.js
+++ b/src/config.js
@@ -1,3 +1,4 @@
 export default {
   apiBaseUrl: import.meta.env.VITE_API_URL,
+  appBaseUrl: import.meta.env.VITE_APP_URL,
 }

--- a/src/lib/item-types.js
+++ b/src/lib/item-types.js
@@ -128,6 +128,28 @@ const itemTypes = {
       }
     }
   },
+  'target-gene-statistics': {
+    name: 'target-gene-statistics',
+    restCollectionName: 'target-gene-statistics',
+    primaryKey: 'field',
+    httpOptions: {
+      list: {
+        method: 'get',
+        url: `${config.apiBaseUrl}/statistics/target/gene`
+      }
+    }
+  },
+  'target-accession-statistics': {
+    name: 'target-accession-statistics',
+    restCollectionName: 'target-accession-statistics',
+    primaryKey: 'field',
+    httpOptions: {
+      list: {
+        method: 'get',
+        url: `${config.apiBaseUrl}/statistics/target/accession`
+      }
+    }
+  },
   'uniprot-identifier-search': {
     name: 'uniprot-identifier', // TODO Redundant, change this structure
     restCollectionName: 'target-gene-identifiers',

--- a/src/store/modules/item.js
+++ b/src/store/modules/item.js
@@ -89,7 +89,7 @@ export default (collectionUrl, {primaryKey = '_id'} = {}) => {
                 }
               }
             )
-            // TODO catch errors in response
+            // TODO mavedb-ui#130 catch errors in response
             commit('loadedItem', {item: response.data || null})
           } catch (err) {
             console.log(`Error while loading item (URL="${url}")`, err)

--- a/src/store/modules/item.js
+++ b/src/store/modules/item.js
@@ -89,7 +89,7 @@ export default (collectionUrl, {primaryKey = '_id'} = {}) => {
                 }
               }
             )
-            // TODO mavedb-ui#130 catch errors in response
+            // TODO (#130) catch errors in response
             commit('loadedItem', {item: response.data || null})
           } catch (err) {
             console.log(`Error while loading item (URL="${url}")`, err)

--- a/src/store/modules/items.js
+++ b/src/store/modules/items.js
@@ -36,7 +36,7 @@ export default (collectionUrl, options = {}) => {
     }
     return item[options.primaryKey]
   }
-  
+
   function sortItems(items, state) {
     if (items && _.get(state, 'filter.itemIds') && !state.order) {
       return _.filter(state.filter.itemIds.map((id) => items.find((item) => getPrimaryKeyValue(item) == id)), Boolean)
@@ -629,7 +629,7 @@ export default (collectionUrl, options = {}) => {
           await dispatch('beginLoadingItems')
           /*commit('loadingItems')
           let response = await axios.get(collectionUrl)
-          // TODO catch errors in response
+          // TODO mavedb-ui#130 catch errors in response
           commit('loadedItems', {items: response.data || []})*/
         }
       },

--- a/src/store/modules/items.js
+++ b/src/store/modules/items.js
@@ -629,7 +629,7 @@ export default (collectionUrl, options = {}) => {
           await dispatch('beginLoadingItems')
           /*commit('loadingItems')
           let response = await axios.get(collectionUrl)
-          // TODO mavedb-ui#130 catch errors in response
+          // TODO (#130) catch errors in response
           commit('loadedItems', {items: response.data || []})*/
         }
       },

--- a/src/store/modules/remote-data.js
+++ b/src/store/modules/remote-data.js
@@ -72,7 +72,7 @@ export default () => {
                 } */
               }
             )
-            // TODO catch errors in response
+            // TODO mavedb-ui#130 catch errors in response
             commit('loadedData', {data: response.data || null})
           } catch (err) {
             console.log(`Error while loading data (URL="${dataUrl}")`, err)

--- a/src/store/modules/remote-data.js
+++ b/src/store/modules/remote-data.js
@@ -72,7 +72,7 @@ export default () => {
                 } */
               }
             )
-            // TODO mavedb-ui#130 catch errors in response
+            // TODO (#130) catch errors in response
             commit('loadedData', {data: response.data || null})
           } catch (err) {
             console.log(`Error while loading data (URL="${dataUrl}")`, err)


### PR DESCRIPTION
Adds a Highlight View component to display simple counting statistics of key Target, Score set, and/or Experiment model properties. Counting statistics are generally displayed as leaderboard style data, where property values that are associated with more Score sets, Experiments and/or Targets are displayed first. Where appropriate, data that is more readily displayed as proportional is displayed with charts.

For Score sets and Experiments, this may include Keywords, Publication Identifiers, DOI Identifiers, and/or Raw Read Identifiers:
![Screenshot 2024-02-20 at 3 19 48 PM](https://github.com/VariantEffect/mavedb-ui/assets/31941502/e4b8cc9a-453b-47be-a66d-ea10181ee315)

For Targets, these fields include Accession and Gene names: 
![Screenshot 2024-02-20 at 3 22 45 PM](https://github.com/VariantEffect/mavedb-ui/assets/31941502/0616417f-edb2-41a1-bab1-d78211c08af7)

and Ensembl, RefSeq, and UniProt identifiers:
![Screenshot 2024-02-20 at 3 23 26 PM](https://github.com/VariantEffect/mavedb-ui/assets/31941502/4e0258ad-4fc8-4618-9dab-355aab2027a4)

Certain target properties, such as Assemblies, Organisms, References, and Gene Categories make more sense to display proportionally. However if desired we could also display them as a leaderboard, or just drop them from the homepage. Hovering over a segment will display its legend:
![Screenshot 2024-02-20 at 3 34 13 PM](https://github.com/VariantEffect/mavedb-ui/assets/31941502/6e5f2e96-86a2-4c98-938e-d3fb8fbbad1b)

Chart segments and identifiers are all selectable and link to the internal MaveDB search page, where associated Score sets can be displayed and explored. Publication identifiers link to the internal publication identifier pages. Where appropriate, external URLs are linked to the appropriate data provider.

This component is re-used on the homepage to display both Score set and Target gene summary information, which may be useful to visitors wanting to engage with the site in a more exploratory fashion:
![Screenshot 2024-02-20 at 3 28 44 PM](https://github.com/VariantEffect/mavedb-ui/assets/31941502/f7f50127-828c-45b0-b8b1-df252e2074a4)

In the future, it would be useful to provide additional context around identifier based fields (such as DOI, RefSeq, UniProt, and Ensembl Identifiers) so that users can understand more about the field value than just the identifier name. It will also be useful to add properties to these routes as they are added to Score sets and Targets, such as the new Taxonomy information that will represent an upgrade over the currently used Keywords. It should be simple to add these properties as additional configuration entries in addition to adding fetcher functions to appropriately format statistic API responses.

These changes also include a config entry for the application URL. As we add more internal links, it will be useful to ensure links clicked within a development environment also open with the development URL.