### PR TITLE
Fixed: Documentation link is broken in AWS deployment.

### DIFF
--- a/src/components/screens/DocumentationView.vue
+++ b/src/components/screens/DocumentationView.vue
@@ -32,7 +32,7 @@ export default {
   components: {DefaultLayout},
   computed: {
     apiDocumentationUrl: function() {
-      return new URL('/docs', config.apiBaseUrl)
+      return new URL('/docs/index.html', config.apiBaseUrl)
     }
   }
 }


### PR DESCRIPTION
CloudFront doesn't allow us easily to specify a default document except at the website root. (This can be accomplished using a Lambda function.) Instead, we'll just include index.html in the link.