### PR TITLE
Fixed: Documentation link is broken in AWS deployment.

### DIFF
--- a/src/components/screens/DocumentationView.vue
+++ b/src/components/screens/DocumentationView.vue
@@ -3,17 +3,17 @@
     <h1>Documentation</h1>
     <p>Welcome to the documentation page for MaveDB and its associated packages.</p>
     <ul>
-        <li><a href="/docs/mavedb/">MaveDB documentation homepage</a></li>
+        <li><a href="/docs/mavedb/index.html">MaveDB documentation homepage</a></li>
         <ul>
             <li>View project on <a href="https://github.com/VariantEffect/mavedb-api">GitHub</a></li>
             <li><a :href="apiDocumentationUrl">API documentation</a></li>
         </ul>
-        <li><a href="/docs/mavehgvs/">MAVE-HGVS documentation homepage</a></li>
+        <li><a href="/docs/mavehgvs/index.html">MAVE-HGVS documentation homepage</a></li>
         <ul>
             <li>View project on <a href="https://github.com/VariantEffect/mavehgvs">GitHub</a></li>
             <li>View project on <a href="https://pypi.org/project/mavehgvs/">PyPI</a></li>
         </ul>
-        <li><a href="/docs/mavetools/">MaveTools documentation homepage</a></li>
+        <li><a href="/docs/mavetools/index.html">MaveTools documentation homepage</a></li>
         <ul>
             <li>View project on <a href="https://github.com/VariantEffect/MaveTools">GitHub</a></li>
             <li>View project on <a href="https://pypi.org/project/mavetools/">PyPI</a></li>
@@ -32,7 +32,7 @@ export default {
   components: {DefaultLayout},
   computed: {
     apiDocumentationUrl: function() {
-      return new URL('/docs/index.html', config.apiBaseUrl)
+      return new URL('/docs', config.apiBaseUrl)
     }
   }
 }


### PR DESCRIPTION
CloudFront doesn't allow us easily to specify a default document except at the website root. (This can be accomplished using a Lambda function.) Instead, we'll just include index.html in the link.

(I checked the wrong fix in earlier, sorry.)