### PR TITLE
Use `assemblies` rather than `grouped-assemblies`

### DIFF
--- a/src/components/screens/ScoreSetEditor.vue
+++ b/src/components/screens/ScoreSetEditor.vue
@@ -354,15 +354,7 @@
                         <div class="field-column">
                           <span class="p-float-label">
                             <!-- Assembly is the reference genome property in coordinate cases -->
-                            <Dropdown v-model="assembly" :id="$scopedId('input-targetGeneAssembly')" :options="assemblies"
-                              optionGroupLabel="type" optionGroupChildren="assemblies" style="width: 100%">
-                              <template #optiongroup="slotProps">
-                                <div class="flex align-items-center dropdown-option-group">
-                                  <div>{{ slotProps.option.type }}</div>
-                                </div>
-                              </template>
-                            </Dropdown>
-
+                            <Dropdown v-model="assembly" :id="$scopedId('input-targetGeneAssembly')" :options="assemblies" style="width: 100%"/>
                             <label :for="$scopedId('input-targetGeneAssembly')">Assembly</label>
                           </span>
                         </div>
@@ -644,7 +636,7 @@ export default {
     const licenses = useItems({ itemTypeName: 'license' })
     const referenceGenomes = useItems({ itemTypeName: 'reference-genome' })
     const geneNames = useItems({ itemTypeName: 'gene-names' })
-    const assemblies = useItems({ itemTypeName: 'grouped-assemblies' })
+    const assemblies = useItems({ itemTypeName: 'assemblies' })
     const targetGeneSuggestions = useItems({ itemTypeName: 'target-gene-search' })
 
     const expandedTargetGeneRows = ref([])

--- a/src/lib/item-types.js
+++ b/src/lib/item-types.js
@@ -109,10 +109,6 @@ const itemTypes = {
     name: 'gene-names', // TODO Redundant, change this structure
     restCollectionName: 'hgvs/genes'
   },
-  'grouped-assemblies': {
-    name: 'grouped-assemblies', // TODO Redundant, change this structure
-    restCollectionName: 'hgvs/grouped-assemblies'
-  },
   'scoreSet': {
     name: 'scoreSet', // TODO Redundant, change this structure
     restCollectionName: 'score-sets',


### PR DESCRIPTION
UI changes associated with https://github.com/VariantEffect/mavedb-api/pull/158

Reopens https://github.com/VariantEffect/mavedb-ui/pull/127 with a new base branch.