### PR TITLE
Staging environment

### DIFF
--- a/.env.staging
+++ b/.env.staging
@@ -1,0 +1,2 @@
+VITE_API_URL=https://api.staging.mavedb.org/api/v1
+VITE_SITE_TITLE=MaveDB

--- a/vite.config.js
+++ b/vite.config.js
@@ -17,6 +17,7 @@ export default defineConfig({
     extensions: ['.vue', '.tsx', '.ts', '.mjs', '.js', '.jsx', '.json', '.wasm'],
   },
   server: {
+    host: '0.0.0.0',
     port: 8081,
     // Our ORCID app only has a limited set of legal redirect URLs (which 
     // includes localhost:8081 but not all other ports), so fail if the desired


### PR DESCRIPTION
Two small changes support deployment to the staging environment:

- Vite build mode for use with the staging environment's API
- Vite configuration change: Listen on all network interfaces when running locally.

The latter change was needed because ORCID no longer allows callback URLs with `localhost`, but `127.0.0.1` is still allowed. This didn't become a problem until we needed to configure new callback URLs for the staging environment.

I'm suggesting we merge this directly into `main` since the ORCID change affects everybody's local development environments.