### PR TITLE
Don't Display `Page not Found` While Loading

### DIFF
--- a/src/components/common/ItemNotFound.vue
+++ b/src/components/common/ItemNotFound.vue
@@ -1,0 +1,35 @@
+<template>
+    <div style="height: 100vh;">
+        <h1>Could not find the requested {{ model }}.</h1>
+        <div v-if=itemId>
+            The {{ model }} with identifier `{{ itemId }}` does not exist, or you do not have permission to view it.
+        </div>
+        <div v-else>
+            The requested {{ model }} does not exist, or you do not have permission to view it.
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'PageNotFoundView',
+    components: { },
+
+    props: {
+        model: {
+            type: String,
+            default: null,
+            required: true
+        },
+        itemId: {
+            type: String,
+            default: null,
+            required: false
+        }
+    }
+}
+</script>
+
+<style>
+
+</style>

--- a/src/components/common/PageLoading.vue
+++ b/src/components/common/PageLoading.vue
@@ -1,0 +1,22 @@
+<template>
+    <div style="height: 100vh;">
+        <ProgressSpinner  class="mave-page-loading" />
+    </div>
+</template>
+
+<script>
+import ProgressSpinner from 'primevue/progressspinner'
+
+export default {
+    name: 'LoadingView',
+    components: { ProgressSpinner },
+}
+</script>
+
+<style>
+.mave-page-loading {
+    position: absolute;
+    top: 40%; /* leave 10% for menu bar */
+    left: 50%;
+}
+</style>

--- a/src/components/screens/ExperimentSetView.vue
+++ b/src/components/screens/ExperimentSetView.vue
@@ -1,6 +1,6 @@
 <template>
   <DefaultLayout>
-    <div v-if="item" class="mave-full-height mave-score-set mave-scroll-vertical">
+    <div v-if="itemStatus=='Loaded'" class="mave-full-height mave-score-set mave-scroll-vertical">
       <div class="mave-1000px-col">
         <div class="mave-screen-title-bar">
           <div class="mave-screen-title">{{item.urn}}</div>
@@ -28,6 +28,9 @@
           <div v-else>No associated experiment</div>
       </div>
     </div>
+    <div v-else-if="itemStatus=='Loading' || itemStatus=='NotLoaded'">
+      <ProgressSpinner class="mave-progress"/>
+    </div>
     <div v-else>
       <h1>Page Not Found</h1>
       The requested experiment set does not exist.
@@ -40,6 +43,7 @@
 import _ from 'lodash'
 import {marked} from 'marked'
 import Button from 'primevue/button'
+import ProgressSpinner from 'primevue/progressspinner'
 
 import DefaultLayout from '@/components/layout/DefaultLayout'
 import useItem from '@/composition/item'
@@ -48,13 +52,13 @@ import {oidc} from '@/lib/auth'
 
 export default {
   name: 'ExperimentSetView',
-  components: {Button, DefaultLayout},
+  components: {Button, DefaultLayout, ProgressSpinner},
 
   computed: {
     oidc: function() {
       return oidc
       },
-    
+
   },
   setup: () => {
     return {
@@ -89,7 +93,7 @@ export default {
   },
 
   methods: {
-    
+
     addExperiment: function() {
       this.$router.push({name: 'createExperimentInExperimentSet', params: {urn: this.item.urn}})
     },
@@ -100,7 +104,7 @@ export default {
       return _.get(...args)
     }
   }
-  
+
 }
 
 </script>
@@ -172,4 +176,10 @@ export default {
   word-wrap: break-word;
 }
 
+.mave-progress {
+  position: absolute;
+  bottom: 5px;
+  right: 5px;
+  z-index: 1001;
+}
 </style>

--- a/src/components/screens/ExperimentSetView.vue
+++ b/src/components/screens/ExperimentSetView.vue
@@ -29,11 +29,10 @@
       </div>
     </div>
     <div v-else-if="itemStatus=='Loading' || itemStatus=='NotLoaded'">
-      <ProgressSpinner class="mave-progress"/>
+      <PageLoading/>
     </div>
     <div v-else>
-      <h1>Page Not Found</h1>
-      The requested experiment set does not exist.
+      <ItemNotFound model="experiment set" :itemId="itemId"/>
     </div>
   </DefaultLayout>
 </template>
@@ -43,16 +42,17 @@
 import _ from 'lodash'
 import {marked} from 'marked'
 import Button from 'primevue/button'
-import ProgressSpinner from 'primevue/progressspinner'
 
 import DefaultLayout from '@/components/layout/DefaultLayout'
+import PageLoading from '@/components/common/PageLoading'
+import ItemNotFound from '@/components/common/ItemNotFound'
 import useItem from '@/composition/item'
 import useFormatters from '@/composition/formatters'
 import {oidc} from '@/lib/auth'
 
 export default {
   name: 'ExperimentSetView',
-  components: {Button, DefaultLayout, ProgressSpinner},
+  components: {Button, DefaultLayout, PageLoading, ItemNotFound},
 
   computed: {
     oidc: function() {
@@ -174,12 +174,5 @@ export default {
   color: #987cb8;
   font-size: 87.5%;
   word-wrap: break-word;
-}
-
-.mave-progress {
-  position: absolute;
-  bottom: 5px;
-  right: 5px;
-  z-index: 1001;
 }
 </style>

--- a/src/components/screens/ExperimentView.vue
+++ b/src/components/screens/ExperimentView.vue
@@ -1,6 +1,6 @@
 <template>
   <DefaultLayout>
-    <div v-if="item" class="mave-score-set">
+    <div v-if="itemStatus=='Loaded'" class="mave-score-set">
       <div class="mave-1000px-col">
         <div class="mave-screen-title-bar">
           <div class="mave-screen-title">{{ item.title || 'Untitled experiment' }}</div>
@@ -167,6 +167,9 @@
         </div><template v-else>No associated raw reads<br /></template>
       </div>
     </div>
+    <div v-else-if="itemStatus=='Loading' || itemStatus=='NotLoaded'">
+      <ProgressSpinner class="mave-progress"/>
+    </div>
     <div v-else>
       <h1>Page Not Found</h1>
       The requested experiment does not exist.
@@ -181,6 +184,7 @@ import {marked} from 'marked'
 import Button from 'primevue/button'
 import Chip from 'primevue/chip'
 import DefaultLayout from '@/components/layout/DefaultLayout'
+import ProgressSpinner from 'primevue/progressspinner'
 import useItem from '@/composition/item'
 import useFormatters from '@/composition/formatters'
 import config from '@/config'
@@ -189,7 +193,7 @@ import { oidc } from '@/lib/auth'
 
 export default {
   name: 'ExperimentView',
-  components: { Button, Chip, DefaultLayout },
+  components: { Button, Chip, DefaultLayout, ProgressSpinner },
 
   setup: () => {
     return {
@@ -369,5 +373,12 @@ export default {
   color: #987cb8;
   font-size: 87.5%;
   word-wrap: break-word;
+}
+
+.mave-progress {
+  position: absolute;
+  bottom: 5px;
+  right: 5px;
+  z-index: 1001;
 }
 </style>

--- a/src/components/screens/ExperimentView.vue
+++ b/src/components/screens/ExperimentView.vue
@@ -168,11 +168,10 @@
       </div>
     </div>
     <div v-else-if="itemStatus=='Loading' || itemStatus=='NotLoaded'">
-      <ProgressSpinner class="mave-progress"/>
+      <PageLoading/>
     </div>
     <div v-else>
-      <h1>Page Not Found</h1>
-      The requested experiment does not exist.
+      <ItemNotFound model="experiment" :itemId="itemId"/>
     </div>
   </DefaultLayout>
 </template>
@@ -184,6 +183,8 @@ import {marked} from 'marked'
 import Button from 'primevue/button'
 import Chip from 'primevue/chip'
 import DefaultLayout from '@/components/layout/DefaultLayout'
+import PageLoading from '@/components/common/PageLoading'
+import ItemNotFound from '@/components/common/ItemNotFound'
 import ProgressSpinner from 'primevue/progressspinner'
 import useItem from '@/composition/item'
 import useFormatters from '@/composition/formatters'
@@ -193,7 +194,7 @@ import { oidc } from '@/lib/auth'
 
 export default {
   name: 'ExperimentView',
-  components: { Button, Chip, DefaultLayout, ProgressSpinner },
+  components: { Button, Chip, DefaultLayout, PageLoading, ItemNotFound },
 
   setup: () => {
     return {
@@ -373,12 +374,5 @@ export default {
   color: #987cb8;
   font-size: 87.5%;
   word-wrap: break-word;
-}
-
-.mave-progress {
-  position: absolute;
-  bottom: 5px;
-  right: 5px;
-  z-index: 1001;
 }
 </style>

--- a/src/components/screens/PublicationIdentifierView.vue
+++ b/src/components/screens/PublicationIdentifierView.vue
@@ -38,11 +38,10 @@
         </div>
       </div>
       <div v-else-if="itemStatus=='Loading' || itemStatus=='NotLoaded'">
-          <ProgressSpinner class="mave-progress"/>
+          <PageLoading/>
       </div>
       <div v-else>
-        <h1>Page Not Found</h1>
-        The requested publication does not exist.
+        <ItemNotFound model="publication" :itemId="itemId"/>
       </div>
     </DefaultLayout>
   </template>
@@ -51,10 +50,11 @@
 
   import _ from 'lodash'
   import {marked} from 'marked'
-  import ProgressSpinner from 'primevue/progressspinner'
 
   import DefaultLayout from '@/components/layout/DefaultLayout'
   import ScoreSetTable from '@/components/ScoreSetTable'
+  import PageLoading from '@/components/common/PageLoading'
+  import ItemNotFound from '@/components/common/ItemNotFound'
   import useItem from '@/composition/item'
   import config from '@/config'
   import useFormatters from '@/composition/formatters'
@@ -63,7 +63,7 @@
 
   export default {
     name: 'PublicationIdentifierView',
-    components: {DefaultLayout, ScoreSetTable, ProgressSpinner},
+    components: {DefaultLayout, ScoreSetTable, PageLoading, ItemNotFound},
 
     computed: {
       oidc: function() {
@@ -225,11 +225,4 @@
     font-size: 87.5%;
     word-wrap: break-word;
   }
-
-  .mave-progress {
-  position: absolute;
-  bottom: 5px;
-  right: 5px;
-  z-index: 1001;
-}
 </style>

--- a/src/components/screens/PublicationIdentifierView.vue
+++ b/src/components/screens/PublicationIdentifierView.vue
@@ -1,6 +1,6 @@
 <template>
     <DefaultLayout>
-      <div v-if="item" class="mave-publication mave-scroll-vertical">
+      <div v-if="itemStatus=='Loaded'" class="mave-publication mave-scroll-vertical">
         <div class="mave-1000px-col">
           <div class="mave-screen-title-bar">
             <div class="mave-screen-title">{{ item.dbName }} {{ item.identifier }}: {{item.title}}</div>
@@ -37,6 +37,9 @@
 
         </div>
       </div>
+      <div v-else-if="itemStatus=='Loading' || itemStatus=='NotLoaded'">
+          <ProgressSpinner class="mave-progress"/>
+      </div>
       <div v-else>
         <h1>Page Not Found</h1>
         The requested publication does not exist.
@@ -48,6 +51,7 @@
 
   import _ from 'lodash'
   import {marked} from 'marked'
+  import ProgressSpinner from 'primevue/progressspinner'
 
   import DefaultLayout from '@/components/layout/DefaultLayout'
   import ScoreSetTable from '@/components/ScoreSetTable'
@@ -59,7 +63,7 @@
 
   export default {
     name: 'PublicationIdentifierView',
-    components: {DefaultLayout, ScoreSetTable},
+    components: {DefaultLayout, ScoreSetTable, ProgressSpinner},
 
     computed: {
       oidc: function() {
@@ -222,4 +226,10 @@
     word-wrap: break-word;
   }
 
+  .mave-progress {
+  position: absolute;
+  bottom: 5px;
+  right: 5px;
+  z-index: 1001;
+}
 </style>

--- a/src/components/screens/ScoreSetView.vue
+++ b/src/components/screens/ScoreSetView.vue
@@ -245,11 +245,10 @@
       </div>
     </div>
     <div v-else-if="itemStatus=='Loading' || itemStatus=='NotLoaded'">
-      <ProgressSpinner class="mave-progress"/>
+      <PageLoading/>
     </div>
     <div v-else>
-      <h1>Page Not Found</h1>
-      The requested score set does not exist.
+      <ItemNotFound model="score set" :itemId="itemId"/>
     </div>
   </DefaultLayout>
 </template>
@@ -269,6 +268,8 @@ import ProgressSpinner from 'primevue/progressspinner'
 
 import ScoreSetHeatmap from '@/components/ScoreSetHeatmap'
 import EntityLink from '@/components/common/EntityLink'
+import PageLoading from '@/components/common/PageLoading'
+import ItemNotFound from '@/components/common/ItemNotFound'
 import DefaultLayout from '@/components/layout/DefaultLayout'
 import useFormatters from '@/composition/formatters'
 import useItem from '@/composition/item'
@@ -281,7 +282,7 @@ import items from '@/composition/items'
 
 export default {
   name: 'ScoreSetView',
-  components: { Button, Chip, DefaultLayout, EntityLink, ScoreSetHeatmap, TabView, TabPanel, DataTable, Column, ProgressSpinner },
+  components: { Button, Chip, DefaultLayout, EntityLink, ScoreSetHeatmap, TabView, TabPanel, DataTable, Column, PageLoading, ItemNotFound },
   computed: {
     isMetaDataEmpty: function () {
       //If extraMetadata is empty, return value will be true.
@@ -683,12 +684,5 @@ export default {
   color: #987cb8;
   font-size: 87.5%;
   word-wrap: break-word;
-}
-
-.mave-progress {
-  position: absolute;
-  bottom: 5px;
-  right: 5px;
-  z-index: 1001;
 }
 </style>

--- a/src/components/screens/ScoreSetView.vue
+++ b/src/components/screens/ScoreSetView.vue
@@ -1,6 +1,6 @@
 <template>
   <DefaultLayout>
-    <div v-if="item" class="mave-score-set">
+    <div v-if="itemStatus=='Loaded'" class="mave-score-set">
       <div class="mave-1000px-col">
         <div class="mave-screen-title-bar">
           <div class="mave-screen-title">{{ item.title || 'Untitled score set' }}</div>
@@ -244,6 +244,9 @@
         </TabView>
       </div>
     </div>
+    <div v-else-if="itemStatus=='Loading' || itemStatus=='NotLoaded'">
+      <ProgressSpinner class="mave-progress"/>
+    </div>
     <div v-else>
       <h1>Page Not Found</h1>
       The requested score set does not exist.
@@ -262,6 +265,7 @@ import Column from 'primevue/column'
 import DataTable from 'primevue/datatable'
 import TabPanel from 'primevue/tabpanel'
 import TabView from 'primevue/tabview'
+import ProgressSpinner from 'primevue/progressspinner'
 
 import ScoreSetHeatmap from '@/components/ScoreSetHeatmap'
 import EntityLink from '@/components/common/EntityLink'
@@ -273,10 +277,11 @@ import config from '@/config'
 import { oidc } from '@/lib/auth'
 import { parseScores } from '@/lib/scores'
 import { mapState } from 'vuex'
+import items from '@/composition/items'
 
 export default {
   name: 'ScoreSetView',
-  components: { Button, Chip, DefaultLayout, EntityLink, ScoreSetHeatmap, TabView, TabPanel, DataTable, Column },
+  components: { Button, Chip, DefaultLayout, EntityLink, ScoreSetHeatmap, TabView, TabPanel, DataTable, Column, ProgressSpinner },
   computed: {
     isMetaDataEmpty: function () {
       //If extraMetadata is empty, return value will be true.
@@ -678,5 +683,12 @@ export default {
   color: #987cb8;
   font-size: 87.5%;
   word-wrap: break-word;
+}
+
+.mave-progress {
+  position: absolute;
+  bottom: 5px;
+  right: 5px;
+  z-index: 1001;
 }
 </style>

--- a/src/store/modules/item.js
+++ b/src/store/modules/item.js
@@ -93,6 +93,7 @@ export default (collectionUrl, {primaryKey = '_id'} = {}) => {
             commit('loadedItem', {item: response.data || null})
           } catch (err) {
             console.log(`Error while loading item (URL="${url}")`, err)
+            commit('loadingFailed')
           }
         }
       },


### PR DESCRIPTION
Makes use of the `itemStatus` property of items to only display `Page not Found` when loading an item fails. While an item is loading, a progress spinner will display in the bottom right corner of the screen.