### PR TITLE
Additional Properties for Target Picker

### DIFF
--- a/src/components/screens/ScoreSetEditor.vue
+++ b/src/components/screens/ScoreSetEditor.vue
@@ -265,7 +265,17 @@
                         <span class="p-float-label">
                           <AutoComplete ref="existingTargetGeneInput" v-model="existingTargetGene"
                             :id="$scopedId('input-existingTargetGene')" field="name" :forceSelection="true"
-                            :suggestions="targetGeneSuggestionsList" @complete="searchTargetGenes" />
+                            :suggestions="targetGeneSuggestionsList" @complete="searchTargetGenes">
+                            <template #item="slotProps">
+                              <div>
+                                  <div>Name: {{ slotProps.item.name }}</div>
+                                  <div>Category: {{ slotProps.item.category }}</div>
+                                  <div v-for="externalIdentifier of slotProps.item.externalIdentifiers" :key=externalIdentifier.identifier>
+                                    {{ externalIdentifier.identifier.dbName }}: {{ externalIdentifier.identifier.identifier }}, Offset: {{ externalIdentifier.offset }}
+                                  </div>
+                              </div>
+                            </template>
+                          </AutoComplete>
                           <label :for="$scopedId('input-existingTargetGene')">Copy from an existing target gene</label>
                         </span>
                       </div>


### PR DESCRIPTION
Adds the category and external identifier properties to the existing target picker, see below.
 
<img width="598" alt="Screenshot 2024-04-04 at 2 13 33 PM" src="https://github.com/VariantEffect/mavedb-ui/assets/31941502/16e986fb-f197-4cd4-aa26-8bf7d3808892">

I think the changes are worth incorporating as is for now, but we also floated a couple of ideas we might want to pull into other issues:
1. Restricting target autocomplete to only targets attached to a users' score set.
2. Adding a way for users to view the sequence information for a particular autocompleted target

For (1): If we wanted to restrict these to just the targets created by the user we could, but it would require some extra changes (either fetch score sets created by the user and then search targets attached to those score sets, or add a new API endpoint for fetching a users' targets).

For (2): This is also doable, but as I was working on it I became less and less convinced of throwing a string of T, A, G, and Cs at the user. If others feel strongly about it though, I can work on adding it. As it stands, the `TargetSequence` properties of a `TargetGene` aren't actually populated anyway. This seems like it could be a bug from when I implemented the Sequence/Accession split, but I'm not sure.