### PR TITLE
Add Validation Error Component for targetGenes

### DIFF
--- a/src/components/screens/ScoreSetEditor.vue
+++ b/src/components/screens/ScoreSetEditor.vue
@@ -325,11 +325,11 @@
                       <div class="field">
                         <span class="p-float-label">
                           <AutoComplete
-                            ref="taxonomyInput" 
-                            v-model="taxonomy" 
+                            ref="taxonomyInput"
+                            v-model="taxonomy"
                             dropdown
                             :id="$scopedId('input-targetSequenceTaxonomy')"
-                            :suggestions="taxonomySuggestionsList" 
+                            :suggestions="taxonomySuggestionsList"
                             field="organismName"
                             :multiple="false"
                             :options="taxonomies"
@@ -527,6 +527,7 @@
                     </DataTable>
                   </span>
                 </div>
+                <span v-if="validationErrors['targetGenes']" class="mave-field-error">{{validationErrors['targetGenes']}}</span>
                 <div class="field">
                   <Message v-if="targetGenes?.length > 1" severity="info">
                     When defining variants against multiple targets, uploaded variant coordinates should be fully


### PR DESCRIPTION
Makes the validation error raised by the backend as a result of https://github.com/VariantEffect/mavedb-api/pull/185 visible from the Score Set editor UI.

<img width="1451" alt="Screenshot 2024-04-19 at 5 00 20 PM" src="https://github.com/VariantEffect/mavedb-ui/assets/31941502/731782b0-a4c6-42a8-8036-3b9073174c6d">