### PR TITLE
Allow Ter in the heatmap.

### DIFF
--- a/src/components/ScoreSetHeatmap.vue
+++ b/src/components/ScoreSetHeatmap.vue
@@ -165,6 +165,10 @@ export default {
 
     prepareSimpleVariantInstances: function(scores) {
       let numComplexVariantInstances = 0
+
+      // Count of variants that do not appear to be complex but are don't have a valid substitution
+      let numIgnoredVariantInstances = 0
+
       const simpleVariantInstances = _.filter(
         scores.map((score) => {
           const variant = parseSimpleProVariant(score.hgvs_pro)
@@ -172,16 +176,18 @@ export default {
             numComplexVariantInstances++
             return null
           }
-          if (variant.substitution == 'Ter') {
+          const row = heatmapRowForVariant(variant.substitution)
+          if (row == null) {
+            numIgnoredVariantInstances++
             return null
           }
           const x = variant.position
-          const y = HEATMAP_ROWS.length - 1 - heatmapRowForVariant(variant.substitution)
+          const y = HEATMAP_ROWS.length - 1 - row
           return {x, y, score: score.score, details: _.omit(score, 'score')}
         }),
         (x) => x != null
       )
-      return {simpleVariantInstances, numComplexVariantInstances}
+      return {simpleVariantInstances, numComplexVariantInstances, numIgnoredVariantInstances}
     },
 
     prepareSimpleVariants: function(scores) {

--- a/src/lib/heatmap.ts
+++ b/src/lib/heatmap.ts
@@ -3,7 +3,7 @@ import {AMINO_ACIDS, AMINO_ACIDS_BY_HYDROPHILIA} from './amino-acids.js'
 /** Codes used in the right part of a MaveHGVS-pro string representing a single variation in a protein sequence. */
 const MAVE_HGVS_PRO_CHANGE_CODES = [
   {codes: {single: '='}}, // Synonymous AA variant
-  {codes: {single: '*'}}, // Stop codon
+  {codes: {single: '*', triple: 'TER'}}, // Stop codon
   {codes: {single: '-', triple: 'DEL'}} // Deletion
 ]
 

--- a/src/lib/mave-hgvs.ts
+++ b/src/lib/mave-hgvs.ts
@@ -15,8 +15,13 @@ interface SimpleProteinVariation {
   substitution: string
 }
 
-/** Regular expression for parsing simple MaveHGVS-pro expressions. */
-const proVariantRegex = /^p\.([A-Za-z]{3})([0-9]+)([A-Za-z]{3}|=)$/
+/**
+ * Regular expression for parsing simple MaveHGVS-pro expressions.
+ *
+ * MaveHGVS doesn't allow single-character codes in substitutions, but for flexibility we allow * and - here. These are
+ * properly represented as Ter and del in MaveHGVS.
+ */
+const proVariantRegex = /^p\.([A-Za-z]{3})([0-9]+)([A-Za-z]{3}|=|\*|-)$/
 
 /**
  * Parse a MaveHGVS protein variant representing a variation at one locus.


### PR DESCRIPTION
To date, the heatmap has only accepted the single-character code "*" for stop codons. This usage was present in some old score sets, but it is not valid MAVE-HGVS notation.

We will continue to support single-character notation for both amino acids and stop codons in the heatmap, but here we allow Ter as well. On the server side, single-character notation is not accepted, and the old score sets with invalid strings will be updated.