### PR TITLE
Populate Target Properties on Autocomplete Selection

### DIFF
--- a/src/components/screens/ScoreSetEditor.vue
+++ b/src/components/screens/ScoreSetEditor.vue
@@ -830,10 +830,8 @@ export default {
     existingTargetGene: {
       immediate: true,
       handler: function () {
-        console.log(this.existingTargetGene)
         if (_.isObject(this.existingTargetGene)) {
           // _.cloneDeep is needed because the target gene has been frozen.
-          // this.targetGene = _.cloneDeep(this.existingTargetGene)
           const targetGene = _.cloneDeep(this.existingTargetGene)
           if (!targetGene.targetSequence) {
             targetGene.targetSequence = {
@@ -859,6 +857,7 @@ export default {
             this.assembly = targetGene.targetAccession.assembly
             this.accession = targetGene.targetAccession.accession
           }
+
           const autopopulatedExternalIdentifiers = {}
           for (const dbName of externalGeneDatabases) {
             autopopulatedExternalIdentifiers[dbName] = (targetGene.externalIdentifiers || [])

--- a/src/components/screens/ScoreSetEditor.vue
+++ b/src/components/screens/ScoreSetEditor.vue
@@ -842,9 +842,6 @@ export default {
             }
           }
           else {
-            this.sequenceType = targetGene.targetSequence.sequenceType
-            this.sequence = targetGene.targetSequence.sequence
-            this.label = targetGene.targetSequence.label
             this.taxonomy = targetGene.targetSequence.taxonomy
           }
           if (!targetGene.targetAccession) {
@@ -853,6 +850,7 @@ export default {
               accession: null
             }
           }
+          // Reactivity is handled by separate fields for target accession properties.
           else {
             this.assembly = targetGene.targetAccession.assembly
             this.accession = targetGene.targetAccession.accession

--- a/src/components/screens/ScoreSetEditor.vue
+++ b/src/components/screens/ScoreSetEditor.vue
@@ -827,33 +827,48 @@ export default {
         }
       }
     },
-    existingTargetGene: function () {
-      if (_.isObject(this.existingTargetGene)) {
-        // _.cloneDeep is needed because the target gene has been frozen.
-        // this.targetGene = _.cloneDeep(this.existingTargetGene)
-        const targetGene = _.cloneDeep(this.existingTargetGene)
-        this.targetGene = _.merge({
-          name: null,
-          category: null,
-          type: null,
-          targetSequence: {
-            sequenceType: null,
-            sequence: null,
-            label: null,
-            taxonomy: null
-          },
-          targetAccession: {
-            assembly: null,
-            accession: null
+    existingTargetGene: {
+      immediate: true,
+      handler: function () {
+        console.log(this.existingTargetGene)
+        if (_.isObject(this.existingTargetGene)) {
+          // _.cloneDeep is needed because the target gene has been frozen.
+          // this.targetGene = _.cloneDeep(this.existingTargetGene)
+          const targetGene = _.cloneDeep(this.existingTargetGene)
+          if (!targetGene.targetSequence) {
+            targetGene.targetSequence = {
+              sequenceType: null,
+              sequence: null,
+              label: null,
+              taxonomy: null
+            }
           }
-        }, targetGene)
-        this.targetGene.externalIdentifiers = {}
-        for (const dbName of externalGeneDatabases) {
-          this.targetGene.externalIdentifiers[dbName] = (targetGene.externalIdentifiers || [])
-            .find(({ identifier }) => identifier?.dbName == dbName) || {
-            identifier: null,
-            offset: null
+          else {
+            this.sequenceType = targetGene.targetSequence.sequenceType
+            this.sequence = targetGene.targetSequence.sequence
+            this.label = targetGene.targetSequence.label
+            this.taxonomy = targetGene.targetSequence.taxonomy
           }
+          if (!targetGene.targetAccession) {
+            targetGene.targetAccession = {
+              assembly: null,
+              accession: null
+            }
+          }
+          else {
+            this.assembly = targetGene.targetAccession.assembly
+            this.accession = targetGene.targetAccession.accession
+          }
+          const autopopulatedExternalIdentifiers = {}
+          for (const dbName of externalGeneDatabases) {
+            autopopulatedExternalIdentifiers[dbName] = (targetGene.externalIdentifiers || [])
+              .find(({ identifier }) => identifier?.dbName == dbName) || {
+              identifier: null,
+              offset: null
+            }
+          }
+          targetGene.externalIdentifiers = autopopulatedExternalIdentifiers
+          this.targetGene = targetGene
         }
       }
     },


### PR DESCRIPTION
Sets additional helper properties on the score set on autocomplete selection of targets to allow the target to be saved directly. This will likely be a short lived change given planned updates to the score set editor.

Closes #192 