### PR TITLE
Wizard-ify new score set screen.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mavedb-ui",
-  "version": "2023.5.1",
+  "version": "2024.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mavedb-ui",
-      "version": "2023.5.1",
+      "version": "2024.1.0",
       "dependencies": {
         "@fontsource/raleway": "^5.0.16",
         "axios": "^1.6.2",
@@ -41,7 +41,7 @@
         "pluralize": "^8.0.0",
         "primeflex": "^3.3.1",
         "primeicons": "^6.0.1",
-        "primevue": "3.32.2",
+        "primevue": "3.52.0",
         "universal-base64url": "~1.1.0",
         "uuid": "^9.0.1",
         "vee-validate": "^4.12.2",
@@ -3545,9 +3545,9 @@
       "integrity": "sha512-KDeO94CbWI4pKsPnYpA1FPjo79EsY9I+M8ywoPBSf9XMXoe/0crjbUK7jcQEDHuc0ZMRIZsxH3TYLv4TUtHmAA=="
     },
     "node_modules/primevue": {
-      "version": "3.32.2",
-      "resolved": "https://registry.npmjs.org/primevue/-/primevue-3.32.2.tgz",
-      "integrity": "sha512-BEDhIb+VqfjjIF9+G+dCRsE542afz5Xl01XHbViYR13T7ZreBMWsPcJCCTyKzouwJHr6HTskJXJnrkTmOI1vKg==",
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/primevue/-/primevue-3.52.0.tgz",
+      "integrity": "sha512-HLOVP5YI0ArFKUhIyfZsWmTNMaBYNCBWC/3DYvdd/Po4LY5/WXf7yIYvArE2q/3OuwSXJXvjlR8UNQeJYRSQog==",
       "peerDependencies": {
         "vue": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "pluralize": "^8.0.0",
     "primeflex": "^3.3.1",
     "primeicons": "^6.0.1",
-    "primevue": "3.32.2",
+    "primevue": "3.52.0",
     "universal-base64url": "~1.1.0",
     "uuid": "^9.0.1",
     "vee-validate": "^4.12.2",

--- a/src/assets/app.css
+++ b/src/assets/app.css
@@ -23,3 +23,7 @@ body .p-inputtext {
 body .p-button {
   min-width: 10px;
 }
+
+.p-badge {
+  text-align: center;
+}

--- a/src/components/layout/Toolbar.vue
+++ b/src/components/layout/Toolbar.vue
@@ -76,35 +76,35 @@ export default {
     menuItems: function() {
       return [{
         label: 'Dashboard',
-        to: '/dashboard',
+        command: () => this.navigate('/dashboard'),
         available: ({authenticated}) => authenticated
       }, {
         label: 'Home',
-        to: '/'
+        command: () => this.navigate('/'),
       }, {
         label: 'Search',
-        to: '/search'
+        command: () => this.navigate('/search'),
       }, {
         label: 'Documentation',
-        to: '/docs'
+        command: () => this.navigate('/docs'),
       }, {
         label: 'New experiment',
-        to: '/create-experiment',
+        command: () => this.navigate('/create-experiment'),
         available: ({authenticated}) => authenticated
       }, {
         label: 'New score set',
-        to: '/create-score-set',
+        command: () => this.navigate('/create-score-set'),
         available: ({authenticated}) => authenticated
       }, {
         label: 'Users',
-        to: '/users',
+        command: () => this.navigate('/users'),
         available: ({roles}) => roles.includes('admin')
       }, {
         label: this.userName,
         icon:'pi pi-fw pi-user',
         items:[{
           label: 'Settings',
-          to: '/settings',
+          command: () => this.navigate('/settings'),
           available: ({authenticated}) => authenticated
         }, {
           label: 'Sign out',
@@ -124,6 +124,10 @@ export default {
       if (this.searchText && this.searchText.length > 0) {
         this.$router.push({name: 'search', query: {search: this.searchText}})
       }
+    },
+
+    navigate(routerPath) {
+      this.$router.push(routerPath)
     },
 
     filterAvailableMenuItems(menuItems) {

--- a/src/components/screens/ScoreSetEditor.vue
+++ b/src/components/screens/ScoreSetEditor.vue
@@ -24,9 +24,8 @@
             </div>
           </div>
         </div>
-        <div class="col-12 md:col-6">
-          <Card>
-            <template #title>Parent experiment and context</template>
+        <Stepper v-model:activeStep="activeWizardStep">
+          <StepperPanel header="Parent experiment and context">
             <template #content>
               <div v-if="itemStatus != 'NotLoaded' && item.experiment">
                 Experiment:
@@ -84,9 +83,8 @@
                   validationErrors.metaAnalyzesScoreSetUrns }}</span>
               </div>
             </template>
-          </Card>
-          <Card>
-            <template #title>Score set information</template>
+          </StepperPanel>
+          <StepperPanel header="Score set information">
             <template #content>
               <div class="field">
                 <span class="p-float-label">
@@ -254,12 +252,9 @@
                 </div>
               </div>
             </template>
-          </Card>
-        </div>
-        <div class="col-12 md:col-6">
+          </StepperPanel>
           <div v-if="itemStatus == 'NotLoaded' || this.item.private">
-            <Card>
-              <template #title>Targets</template>
+            <StepperPanel header="Targets">
               <template #content>
                 <div>
                   <TabView class="field">
@@ -426,8 +421,6 @@
                     </TabPanel>
                   </TabView>
                 </div>
-              </template>
-              <template #footer>
                 <div class="field">
                   <span v-if="targetGenes.length > 0">
                     <DataTable v-model:expandedRows="expandedTargetGeneRows" :value="targetGenes" dataKey="name">
@@ -539,8 +532,8 @@
                   </Message>
                 </div>
               </template>
-            </Card>
-            <Card>
+            </StepperPanel>
+            <StepperPanel header="Variant scores">
               <template #title>Variant scores</template>
               <template #content>
                 <div v-if="item">
@@ -577,9 +570,9 @@
                   }}</span>
                 </div>
               </template>
-            </Card>
-          </div>
-        </div>
+            </StepperPanel>
+            </div>
+        </Stepper>
       </div>
     </div>
     <ProgressSpinner v-if="progressVisible" class="mave-progress" />
@@ -605,6 +598,8 @@ import Message from 'primevue/message'
 import Multiselect from 'primevue/multiselect'
 import ProgressSpinner from 'primevue/progressspinner'
 import SelectButton from 'primevue/selectbutton'
+import Stepper from 'primevue/stepper'
+import StepperPanel from 'primevue/stepperpanel'
 import TabPanel from 'primevue/tabpanel'
 import TabView from 'primevue/tabview'
 import Textarea from 'primevue/textarea'
@@ -647,7 +642,7 @@ function emptyTargetGene() {
 
 export default {
   name: 'ScoreSetEditor',
-  components: { AutoComplete, Button, Card, Chips, Column, DataTable, DefaultLayout, Dropdown, EmailPrompt, EntityLink, FileUpload, InputNumber, InputText, Message, Multiselect, ProgressSpinner, SelectButton, TabPanel, TabView, Textarea },
+  components: { AutoComplete, Button, Card, Chips, Column, DataTable, DefaultLayout, Dropdown, EmailPrompt, EntityLink, FileUpload, InputNumber, InputText, Message, Multiselect, ProgressSpinner, SelectButton, Stepper, StepperPanel, TabPanel, TabView, Textarea },
 
   setup: () => {
     const editableExperiments = useItems({
@@ -752,6 +747,7 @@ export default {
       'Other noncoding'
     ],
 
+    activeWizardStep: 0,
     progressVisible: false,
     serverSideValidationErrors: {},
     clientSideValidationErrors: {},

--- a/src/components/screens/SearchView.vue
+++ b/src/components/screens/SearchView.vue
@@ -5,11 +5,13 @@
         <h1>Search MaveDB Experiments and Score Sets</h1>
       </div>
       <div class="mavedb-search-form">
-        <span class="p-input-icon-left">
-          <i class="pi pi-search" />
-          <InputText v-model="searchText" ref="searchTextInput" type="search" class="p-inputtext-sm" placeholder="Search" />&nbsp;
+        <div class="flex flex-wrap justify-content-center gap-3">
+          <IconField iconPosition="left">
+            <InputIcon class="pi pi-search"></InputIcon>
+            <InputText v-model="searchText" ref="searchTextInput" type="search" class="p-inputtext-sm" placeholder="Search" />
+          </IconField>
           <Button class="p-button-plain" @click="clear">Clear All</Button>
-        </span>
+        </div>
         <TabView class="mavedb-search-tabs">
           <TabPanel header="Target filters">
             <div class="mavedb-search-filters">
@@ -42,6 +44,8 @@
 <script lang="ts">
 
 import axios from 'axios'
+import IconField from 'primevue/iconfield'
+import InputIcon from 'primevue/inputicon'
 import InputText from 'primevue/inputtext'
 import config from '@/config'
 import ScoreSetTable from '@/components/ScoreSetTable.vue'
@@ -108,7 +112,7 @@ function extractQueryParam(content: LocationQueryValue | LocationQueryValue[]): 
 
 export default defineComponent({
   name: 'SearchView',
-  components: {DefaultLayout, ScoreSetTable, InputText, SelectList, TabView, TabPanel, Button},
+  components: {DefaultLayout, ScoreSetTable, IconField, InputIcon, InputText, SelectList, TabView, TabPanel, Button},
 
   data: function() {
     return {


### PR DESCRIPTION
For our initial base here, we'll use primevue's stepper/stepperpanel components. These only came out in Feb '24, so we have to do a long-delayed primevue version upgrade. This was delayed as it required fixing at least 3 resulting bugs, which I've done: header buttons not working as the MenuItem `to` property had been deprecated, badge numbers were not centered, and the main search page search field icon was not displaying correctly. I've fixed those bugs.