### PR TITLE
fix broken Galaxy plugin

### DIFF
--- a/src/components/screens/ScoreSetView.vue
+++ b/src/components/screens/ScoreSetView.vue
@@ -505,6 +505,9 @@ export default {
           .urn}&outputType=${params
           .outputType}&URL=${encodeURIComponent(params.URL)}`;
           window.location.href = submitGalaxyUrl;
+          localStorage.removeItem('galaxyUrl'); 
+          localStorage.removeItem('toolId'); 
+          localStorage.removeItem('requestFromGalaxy');
         }
       } catch (error) {
         console.error('Error sending data:', error);

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -9,11 +9,18 @@ import layoutModule from '@/store/modules/layout'
 
 const store = createStore({
   state: {
-    routeProps: {},
+    routeProps: {
+      galaxyUrl: localStorage.getItem('galaxyUrl'),
+      toolId: localStorage.getItem('toolId'), 
+      requestFromGalaxy: localStorage.getItem('requestFromGalaxy'), 
+    },
   },
   mutations: {
     setRouteProps(state: any, props: any) {
       state.routeProps = props;
+      localStorage.setItem('galaxyUrl', props.galaxyUrl);
+      localStorage.setItem('toolId', props.toolId);
+      localStorage.setItem('requestFromGalaxy', props.requestFromGalaxy);
     },
   },
   actions: {


### PR DESCRIPTION
This PR addresses [issue #207](https://github.com/VariantEffect/mavedb-ui/issues/207). Additionally, the Galaxy-related parameters (requestFromGalaxy, toolId, galaxyUrl) will persist throughout the user's session and will be passed to new browser tabs or windows that the user opens. These parameters will remain in localStorage until the user sends data to Galaxy, at which point the parameters will be removed.