### PR TITLE
Recognize ORCID session expiration. (#210)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -9,9 +9,23 @@
 import ConfirmDialog from 'primevue/confirmdialog'
 import Toast from 'primevue/toast'
 import 'primeflex/primeflex.css'
+import {mapActions, mapState} from 'vuex'
 
 export default {
   components: {ConfirmDialog, Toast},
+  computed: mapState('toast', ['toasts']),
+  watch: {
+    toasts: {
+      deep: true,
+      handler: function(newValue) {
+        if (newValue.length > 0) {
+          this.$toast.add(newValue[0])
+          this.removeDequeuedToasts(1)
+        }
+      }
+    }
+  },
+  methods: mapActions('toast', ['removeDequeuedToasts'])
 }
 
 </script>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,7 +2,13 @@
 
 import axios from 'axios'
 
-import {idToken as orcidIdToken} from '@/lib/orcid'
+import config from '@/config'
+import {
+  idToken as orcidIdToken,
+  isAuthenticated as orcidIsAuthenticated,
+  signOut as orcidSignOut
+} from '@/lib/orcid'
+import store from '@/store/index'
 import authStore from '@/store/modules/auth'
 
 export interface AuthorizationHeader {
@@ -35,20 +41,59 @@ export function authHeader(): AuthorizationHeader {
 }
 
 /**
- * Add a bearer authorization token to all requests made using Axios.
+ * Determine whether a URL refers to a MaveDB API endpoint.
+ */
+function urlBelongsToApi(url: string) {
+  return (url.startsWith(config.apiBaseUrl))
+}
+
+/**
+ * Add a bearer authorization token to all requests to the MaveDB API made using Axios.
  *
- * If you wish to supply MaveDB credentials with all Axios requests, call this function at application startup time (or
- * page load time, in a single-page application).
+ * Call this function at application startup time (or page load time, in a single-page application) to supply MaveDB
+ * credentials with all Axios requests to MaveDB API endpoints.
  */
 export function installAxiosAuthHeaderInterceptor() {
   axios.interceptors.request.use((config) => {
-    const token = orcidIdToken.value
-    const activeRoles = authStore.state.activeRoles
+    // If the request URL belongs to the MaveDB API, add authorization headers.
+    if (config.url && urlBelongsToApi(config.url)) {
+      const token = orcidIdToken.value
+      const activeRoles = authStore.state.activeRoles
 
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`
-      config.headers['X-Active-Roles'] = activeRoles
+      if (token) {
+        config.headers.Authorization = `Bearer ${token}`
+        config.headers['X-Active-Roles'] = activeRoles
+      }
     }
+
     return config
   })
+}
+
+export function installAxiosUnauthorizedResponseInterceptor() {
+  axios.interceptors.response.use(
+    (response) => response,
+    async (error) => {
+      if (error && !error.config?.isSessionCheck && error.response?.status && error.response?.status == 401) {
+        try {
+          // @ts-ignore: We need to pass a custom property in the request configuration.
+          await axios.get(`${config.apiBaseUrl}/users/me`, {isSessionCheck: true})
+        } catch (error: any) {
+          if (error.response?.status == 401) {
+            // The user's session has expired. This may happen after several requests issued around the same time, so
+            // only take action if the user has not yet been signed out.
+            if (orcidIsAuthenticated.value) {
+              orcidSignOut()
+              store.dispatch('toast/enqueueToast', {
+                severity: 'info',
+                summary: 'Your ORCID session ended. Please log in again.',
+                life: 5000
+              })
+            }
+          }
+        }
+      }
+      return Promise.reject(error)
+    }
+  )
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -86,7 +86,7 @@ export function installAxiosUnauthorizedResponseInterceptor() {
               orcidSignOut()
               store.dispatch('toast/enqueueToast', {
                 severity: 'info',
-                summary: 'Your ORCID session ended. Please log in again.',
+                summary: 'Your ORCID session has ended. Please log in again.',
                 life: 5000
               })
             }

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,7 @@ import Tooltip from 'primevue/tooltip';
 import {createApp} from 'vue'
 
 import App from '@/App.vue'
-import {installAxiosAuthHeaderInterceptor} from '@/lib/auth'
+import {installAxiosAuthHeaderInterceptor, installAxiosUnauthorizedResponseInterceptor} from '@/lib/auth'
 import {initializeAuthentication as initializeOrcidAuthentication} from '@/lib/orcid'
 import router from '@/router'
 import store from '@/store'
@@ -46,3 +46,4 @@ createApp(App)
 
 // Monkey-patch Axios so that all requests will have the user's credentials.
 installAxiosAuthHeaderInterceptor()
+installAxiosUnauthorizedResponseInterceptor()

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -3,6 +3,7 @@ import {createStore} from 'vuex'
 
 import authModule from '@/store/modules/auth'
 import layoutModule from '@/store/modules/layout'
+import toastModule from '@/store/modules/toast'
 
 // Unfortunately, typed Vuex stores are painful to use, especially with multiple modules. We'll continue using any for
 // now. Now that we do not use a Vuex module for authentication, we can migrate to Pinia.
@@ -20,7 +21,8 @@ const store = createStore({
   },
   modules: {
     auth: authModule,
-    layout: layoutModule
+    layout: layoutModule,
+    toast: toastModule
   }
 })
 

--- a/src/store/modules/toast.js
+++ b/src/store/modules/toast.js
@@ -1,0 +1,30 @@
+const module = {
+  namespaced: true,
+
+  state: {
+    toasts: []
+  },
+
+  mutations: {
+    enqueueToast(state, toast) {
+      state.toasts.push(toast)
+      console.log(state.toasts)
+    },
+    removeDequeuedToasts(state, numToasts) {
+      state.toasts.splice(0, Math.min(numToasts, state.toasts.length))
+    }
+  },
+
+  actions: {
+    enqueueToast({commit}, toast) {
+      console.log('here!!!')
+      commit('enqueueToast', toast)
+    },
+    removeDequeuedToasts({commit}, numToasts) {
+      console.log('dequeue')
+      commit('removeDequeuedToasts', numToasts)
+    }
+  }
+}
+
+export default module

--- a/src/store/modules/toast.js
+++ b/src/store/modules/toast.js
@@ -17,11 +17,9 @@ const module = {
 
   actions: {
     enqueueToast({commit}, toast) {
-      console.log('here!!!')
       commit('enqueueToast', toast)
     },
     removeDequeuedToasts({commit}, numToasts) {
-      console.log('dequeue')
       commit('removeDequeuedToasts', numToasts)
     }
   }


### PR DESCRIPTION
ORCID tokens have a lifetime of 24 hours and are not renewable. After 24 hours, a logged-in MaveDB user will begin to get error responses to any API requests that check authentication status, even if they do not require authentication.

When this occurs, the UI should detect the change and clear the client-side login status. This will cause the UI to revert to logged-out status.

To capture this occurrence, we install an Axios response interceptor that looks for unauthorized (HTTP 401) responses. When one occurs, it makes a request to /users/me; if the response is again 401, it logs the user out. To notify the user, it publishes a toast message to a new Vuex store module.

Since sessions endure for 24 hours, one way to test the new behavior in a local MaveDB instance is to insert `return None` into the API's get_current_user function (in src/mavedb/lib/authentication.py):

```
async def get_current_user(
    api_key_user_data: Optional[UserData] = Depends(get_current_user_data_from_api_key),
    token_payload: dict = Depends(JWTBearer()),
    db: Session = Depends(deps.get_db),
    # Custom header for the role the authenticated user would like to assume.
    # Namespaced with x_ to indicate this is a custom application header.
    x_active_roles: Optional[str] = Header(default=None),
) -> Optional[UserData]:
    if api_key_user_data is not None:
        return api_key_user_data

    if token_payload is None:
        return None

    username: Optional[str] = token_payload.get("sub")
    if username is None:
        return None

    return None # Added this for testing
    
    # ...
```

Add this after starting the application and logging in. The next time the user attempts an action that involves checking the current login session, the UI should recognize that the user has been logged out.