### PR TITLE
Update Release 2024.2.1 to fix ORCID expiration flow.

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -74,12 +74,15 @@ export function installAxiosUnauthorizedResponseInterceptor() {
   axios.interceptors.response.use(
     (response) => response,
     async (error) => {
-      if (error && !error.config?.isSessionCheck && error.response?.status && error.response?.status == 401) {
+      if (error && !error.config?.isSessionCheck && error.response?.status && (
+        error.response?.status == 401 ||
+        error.response?.status == 403
+      )) {
         try {
           // @ts-ignore: We need to pass a custom property in the request configuration.
           await axios.get(`${config.apiBaseUrl}/users/me`, {isSessionCheck: true})
         } catch (error: any) {
-          if (error.response?.status == 401) {
+          if (error.response?.status == 401 || error.response?.status == 403) {
             // The user's session has expired. This may happen after several requests issued around the same time, so
             // only take action if the user has not yet been signed out.
             if (orcidIsAuthenticated.value) {


### PR DESCRIPTION
403 is required in both places as of now. Dropping it in either seems to fail to initiate logout flow.