### PR TITLE
Data set contributors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,10 +38,12 @@
         "moment": "^2.29.4",
         "papaparse": "^5.4.1",
         "pdfmake": "^0.2.8",
+        "pinia": "^2.2.1",
         "pluralize": "^8.0.0",
         "primeflex": "^3.3.1",
         "primeicons": "^6.0.1",
         "primevue": "3.52.0",
+        "rest-client-vue": "^1.2.0-b2",
         "universal-base64url": "~1.1.0",
         "uuid": "^9.0.1",
         "vee-validate": "^4.12.2",
@@ -920,9 +922,9 @@
       }
     },
     "node_modules/@vue/devtools-api": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.5.1.tgz",
-      "integrity": "sha512-+KpckaAQyfbvshdDW5xQylLni1asvNSGme1JFs8I1+/H5pHEhqUKMEQD/qn3Nx5+/nycBq11qAEi8lk+LXI2dA=="
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.3.tgz",
+      "integrity": "sha512-0MiMsFma/HqA6g3KLKn+AGpL1kgKhFWszC9U29NfpWK5LE7bjeXxySWJrOJ77hBz+TBrBQ7o4QJqbPbqbs8rJw=="
     },
     "node_modules/@vue/reactivity": {
       "version": "3.3.12",
@@ -2065,6 +2067,12 @@
         "event-emitter": "~0.3.5"
       }
     },
+    "node_modules/es6-object-assign": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+      "integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==",
+      "optional": true
+    },
     "node_modules/es6-set": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.6.tgz",
@@ -2958,6 +2966,14 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "node_modules/json-stringify-deterministic": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/json-stringify-deterministic/-/json-stringify-deterministic-1.0.12.tgz",
+      "integrity": "sha512-q3PN0lbUdv0pmurkBNdJH3pfFvOTL/Zp0lquqpvcjfKzt6Y0j49EPHAmVHCAS4Ceq/Y+PejWTzyiVpoY71+D6g==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/jsonpath-plus": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz",
@@ -3472,6 +3488,56 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pinia": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.2.1.tgz",
+      "integrity": "sha512-ltEU3xwiz5ojVMizdP93AHi84Rtfz0+yKd8ud75hr9LVyWX2alxp7vLbY1kFm7MXFmHHr/9B08Xf8Jj6IHTEiQ==",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.3",
+        "vue-demi": "^0.14.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.4.0",
+        "typescript": ">=4.4.4",
+        "vue": "^2.6.14 || ^3.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pinia/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/pluralize": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
@@ -3667,6 +3733,25 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/rest-client-vue": {
+      "version": "1.2.0-b2",
+      "resolved": "https://registry.npmjs.org/rest-client-vue/-/rest-client-vue-1.2.0-b2.tgz",
+      "integrity": "sha512-a8yicsiryaR+vBnSuze9XaHHkyY/MTIVRDLSbC0E8xVmaQj6j3YbmvlWh/kRWit0k3G1kvU82Mb4gbU8quaGdw==",
+      "dependencies": {
+        "axios": "^1.6.2",
+        "jsog": "^1.0.7",
+        "json-stringify-deterministic": "^1.0.12",
+        "lodash": "^4.17.21",
+        "uuid": "^9.0.1"
+      },
+      "optionalDependencies": {
+        "vuejs-logger": "^1.5.5"
+      },
+      "peerDependencies": {
+        "pinia": "^2.1.7",
+        "vue": "^3.3.11"
       }
     },
     "node_modules/reusify": {
@@ -4492,6 +4577,23 @@
       "peerDependencies": {
         "vue": "^3.2.0"
       }
+    },
+    "node_modules/vuejs-logger": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/vuejs-logger/-/vuejs-logger-1.5.5.tgz",
+      "integrity": "sha512-wESz1F4KWk98YANEDg2yeS+fpwk2WrR41ZslLfZgTD+EYFm/7VMMUjRThhHT8CCOLOCQdsS4Ge2C9bIs68v8Ww==",
+      "optional": true,
+      "dependencies": {
+        "es6-object-assign": "1.1.0",
+        "vue": "2.6.11"
+      }
+    },
+    "node_modules/vuejs-logger/node_modules/vue": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.11.tgz",
+      "integrity": "sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ==",
+      "deprecated": "Vue 2 has reached EOL and is no longer actively maintained. See https://v2.vuejs.org/eol/ for more details.",
+      "optional": true
     },
     "node_modules/vuex": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -38,10 +38,12 @@
     "moment": "^2.29.4",
     "papaparse": "^5.4.1",
     "pdfmake": "^0.2.8",
+    "pinia": "^2.2.1",
     "pluralize": "^8.0.0",
     "primeflex": "^3.3.1",
     "primeicons": "^6.0.1",
     "primevue": "3.52.0",
+    "rest-client-vue": "^1.2.0-b2",
     "universal-base64url": "~1.1.0",
     "uuid": "^9.0.1",
     "vee-validate": "^4.12.2",
@@ -52,8 +54,8 @@
     "yup": "^1.3.3"
   },
   "devDependencies": {
-    "@types/papaparse": "^5.3.14",
     "@types/lodash": "^4.17.0",
+    "@types/papaparse": "^5.3.14",
     "@types/uuid": "^9.0.8",
     "@vitejs/plugin-basic-ssl": "^1.0.2",
     "@vitejs/plugin-vue": "^4.5.2",

--- a/src/components/screens/ExperimentEditor.vue
+++ b/src/components/screens/ExperimentEditor.vue
@@ -334,6 +334,7 @@ import useItem from '@/composition/item'
 import useItems from '@/composition/items'
 import config from '@/config'
 import {normalizeDoi, normalizePubmedId, normalizeRawRead, validateDoi, validatePubmedId, validateRawRead} from '@/lib/identifiers'
+import {ORCID_ID_REGEX} from '@/lib/orcid'
 import useFormatters from '@/composition/formatters'
 
 const KEYWORDS = [
@@ -509,7 +510,6 @@ export default {
 
   computed: {
     contributorSuggestions: function() {
-      console.log(this.contributorLookupResult)
       return this.suggestionsForAutocomplete(this.contributorLookupResult ? [this.contributorLookupResult] : [])
     },
     publicationIdentifierSuggestionsList: function() {
@@ -599,8 +599,7 @@ export default {
 
     lookupContributor: function(event) {
       const searchText = (event.query || '').trim()
-      console.log(searchText)
-      if (searchText.length > 0) {
+      if (searchText.length > 0 && ORCID_ID_REGEX.test(searchText)) {
         this.setContributorLookupId(searchText)
         this.setContributorLookupEnabled(true)
       } else {

--- a/src/components/screens/ExperimentEditor.vue
+++ b/src/components/screens/ExperimentEditor.vue
@@ -322,6 +322,7 @@ import {useRestResource} from 'rest-client-vue'
 
 import DefaultLayout from '@/components/layout/DefaultLayout'
 import EmailPrompt from '@/components/common/EmailPrompt'
+import useAuth from '@/composition/auth'
 import useItem from '@/composition/item'
 import useItems from '@/composition/items'
 import config from '@/config'
@@ -407,6 +408,8 @@ export default {
   components: { AutoComplete, Button, Card, Chips, Dialog, Dropdown, Multiselect, DefaultLayout, EmailPrompt, FileUpload, InputText, ProgressSpinner, TabPanel, TabView, Textarea },
 
   setup: () => {
+    const {userProfile} = useAuth()
+
     const variantLibraryKeywordOptions = useItems({itemTypeName: `controlled-keywords-variant-search`})
     const endogenousSystemKeywordOptions = useItems({itemTypeName: `controlled-keywords-endo-system-search`})
     const endogenousMechanismKeywordOptions = useItems({itemTypeName: `controlled-keywords-endo-mechanism-search`})
@@ -422,6 +425,7 @@ export default {
     const publicationIdentifierSuggestions = useItems({itemTypeName: 'publication-identifier-search'})
     const externalPublicationIdentifierSuggestions = useItems({itemTypeName: 'external-publication-identifier-search'})
     return {
+      userProfile,
       ...useFormatters(),
       ...useItem({itemTypeName: 'experiment'}),
       variantLibraryKeywordOptions: variantLibraryKeywordOptions.items,
@@ -536,6 +540,10 @@ export default {
         this.keywordKeys['In Vitro Construct Library Method Mechanism'] = null
       }
     }
+  },
+
+  mounted: function() {
+    this.resetForm()
   },
 
   methods: {
@@ -787,7 +795,7 @@ export default {
         this.shortDescription = null
         this.abstractText = null
         this.methodText = null
-        this.contributors = []
+        this.contributors = [{orcidId: this.userProfile?.sub, givenName: this.userProfile?.given_name, familyName: this.userProfile?.family_name}]
         this.doiIdentifiers = []
         this.primaryPublicationIdentifiers = []
         this.secondaryPublicationIdentifiers = []

--- a/src/components/screens/ExperimentView.vue
+++ b/src/components/screens/ExperimentView.vue
@@ -24,6 +24,19 @@
             v-if="item.modifiedBy">
             <a :href="`https://orcid.org/${item.modifiedBy.orcidId}`" target="blank"><img src="@/assets/ORCIDiD_icon.png"
                 alt="ORCIDiD">{{ item.modifiedBy.firstName }} {{ item.modifiedBy.lastName }}</a></span></div>
+        <div v-if="contributors.length > 0">
+          Contributors
+          <a
+            v-for="contributor in contributors"
+            class="mave-contributor"
+            :href="`https://orcid.org/${contributor.orcidId}`"
+            :key="contributor.orcidId"
+            target="blank"
+          >
+            <img src="@/assets/ORCIDiD_icon.png" alt="ORCIDiD">
+            {{ contributor.givenName }} {{ contributor.familyName }}
+          </a>
+        </div>
         <div v-if="item.publishedDate">Published {{ formatDate(item.publishedDate) }}</div>
         <div v-if="item.experimentSetUrn">Member of <router-link
             :to="{ name: 'experimentSet', params: { urn: item.experimentSetUrn } }">{{ item.experimentSetUrn
@@ -244,6 +257,15 @@ export default {
     fullDescription: [],
   }),
 
+  computed: {
+    contributors: function() {
+      return _.sortBy(
+        (this.item?.contributors || []).filter((c) => c.orcidId != this.item?.createdBy?.orcidId),
+        ['familyName', 'givenName', 'orcidId']
+      )
+    }
+  },
+
   created() {
     this.getAssociatedScoreSets();
   },
@@ -390,6 +412,10 @@ export default {
 .mave-score-set-keywords .p-chip {
   /*font-family: Helvetica, Verdana, Arial, sans-serif;*/
   margin: 0 5px;
+}
+
+.mave-contributor {
+  margin: 0 0.5em;
 }
 
 /* Formatting in Markdown blocks */

--- a/src/components/screens/ScoreSetCreator.vue
+++ b/src/components/screens/ScoreSetCreator.vue
@@ -834,6 +834,7 @@ import useItem from '@/composition/item'
 import useItems from '@/composition/items'
 import config from '@/config'
 import {normalizeDoi, normalizeIdentifier, normalizePubmedId, validateDoi, validateIdentifier, validatePubmedId} from '@/lib/identifiers'
+import {ORCID_ID_REGEX} from '@/lib/orcid'
 import useFormatters from '@/composition/formatters'
 
 const externalGeneDatabases = ['UniProt', 'Ensembl', 'RefSeq']
@@ -1254,7 +1255,7 @@ export default {
 
     lookupContributor: function(event) {
       const searchText = (event.query || '').trim()
-      if (searchText.length > 0) {
+      if (searchText.length > 0 && ORCID_ID_REGEX.test(searchText)) {
         this.setContributorLookupId(searchText)
         this.setContributorLookupEnabled(true)
       } else {

--- a/src/components/screens/ScoreSetCreator.vue
+++ b/src/components/screens/ScoreSetCreator.vue
@@ -77,8 +77,14 @@
                     </div>
                     <div v-else style="position: relative;">
                       <span class="p-float-label">
-                        <Dropdown v-model="experiment" :id="$scopedId('input-experiment')" :options="editableExperiments"
-                          optionLabel="title" v-on:change="populateExperimentMetadata" style="width: 50%"/>
+                        <Dropdown
+                          v-model="experiment"
+                          :id="$scopedId('input-experiment')"
+                          :options="editableExperiments"
+                          optionLabel="title"
+                          style="width: 50%"
+                          @change="populateExperimentMetadata"
+                        />
                         <label :for="$scopedId('input-experiment')">Experiment</label>
                       </span>
                       <span v-if="validationErrors.experiment" class="mave-field-error">{{ validationErrors.experiment }}</span>
@@ -97,9 +103,16 @@
                     </div>
                     <div v-if="itemStatus == 'NotLoaded'" class="field">
                       <span class="p-float-label">
-                        <AutoComplete ref="supersededScoreSetInput" v-model="supersededScoreSet"
-                          :id="$scopedId('input-supersededScoreSet')" field="title" :forceSelection="true"
-                          :suggestions="supersededScoreSetSuggestionsList" @complete="searchSupersededScoreSets">
+                        <AutoComplete
+                          ref="supersededScoreSetInput"
+                          v-model="supersededScoreSet"
+                          :id="$scopedId('input-supersededScoreSet')"
+                          field="title"
+                          :forceSelection="true"
+                          :suggestions="supersededScoreSetSuggestionsList"
+                          @change="populateSupersededScoreSetMetadata"
+                          @complete="searchSupersededScoreSets"
+                        >
                           <template #item="slotProps">
                             {{ slotProps.item.urn }}: {{ slotProps.item.title }}
                           </template>
@@ -1203,20 +1216,6 @@ export default {
           this.assemblySuggestions = await this.fetchTargetAccessionsByAssembly(this.assemblyDropdownValue)
         }
       }
-    },
-    experiment: {
-      handler: async function(newValue, oldValue) {
-        if (!_.isEqual(newValue, oldValue) && this.contributors.length == 0) {
-          this.contributors = newValue.contributors || []
-        }
-      }
-    },
-    supersededScoreSet: {
-      handler: async function(newValue, oldValue) {
-        if (!_.isEqual(newValue, oldValue) && this.contributors.length == 0) {
-          this.contributors = newValue.contributors || []
-        }
-      }
     }
   },
 
@@ -1466,6 +1465,7 @@ export default {
 
     populateExperimentMetadata: function (event) {
       this.abstractText = event.value.abstractText
+      this.contributors = event.value.contributors || []
       this.doiIdentifiers = event.value.doiIdentifiers
       this.publicationIdentifiers = _.concat(event.value.primaryPublicationIdentifiers, event.value.secondaryPublicationIdentifiers)
       this.primaryPublicationIdentifiers = event.value.primaryPublicationIdentifiers.filter((primary) => {
@@ -1474,7 +1474,9 @@ export default {
         })
       })
     },
-
+    populateSupersededScoreSetMetadata: function(event) {
+      this.contributors = event.value.contributors || []
+    },
     acceptNewDoiIdentifier: function(event) {
       // Remove new string item from the model and add new structured item in its place if it validates and is not a duplicate.
       const idx = this.doiIdentifiers.findIndex((item) => typeof item === 'string' || item instanceof String)

--- a/src/components/screens/ScoreSetCreator.vue
+++ b/src/components/screens/ScoreSetCreator.vue
@@ -1044,7 +1044,6 @@ export default {
 
   computed: {
     contributorSuggestions: function() {
-        console.log(this.contributorLookupResult)
         return this.suggestionsForAutocomplete(this.contributorLookupResult ? [this.contributorLookupResult] : [])
       },
     maxWizardStepValidated: function() {
@@ -1204,6 +1203,20 @@ export default {
         }
       }
     },
+    experiment: {
+      handler: async function(newValue, oldValue) {
+        if (!_.isEqual(newValue, oldValue) && this.contributors.length == 0) {
+          this.contributors = newValue.contributors || []
+        }
+      }
+    },
+    supersededScoreSet: {
+      handler: async function(newValue, oldValue) {
+        if (!_.isEqual(newValue, oldValue) && this.contributors.length == 0) {
+          this.contributors = newValue.contributors || []
+        }
+      }
+    }
   },
 
   methods: {
@@ -1234,7 +1247,6 @@ export default {
     },
 
     clearContributorSearch: function() {
-      console.log('clear')
       // This could change with a new PrimeVue version.
       const input = this.$refs.contributorsInput
       input.$refs.focusInput.value = ''

--- a/src/components/screens/ScoreSetCreator.vue
+++ b/src/components/screens/ScoreSetCreator.vue
@@ -333,17 +333,15 @@
                     </div>
                     <div class="mavedb-wizard-content field">
                       <span class="p-float-label">
-                        <AutoComplete
-                            ref="contributorsInput"
-                            v-model="contributors"
-                            :id="$scopedId('input-contributors')"
-                            :multiple="true"
-                            placeholder="Type an ORCID ID"
-                            :suggestions="contributorSuggestions"
-                            @complete="lookupContributor"
-                            @item-select="acceptNewContributor"
-                            @keyup.escape="clearContributorSearch"
-                            option-label="orcidId"
+                        <Chips
+                          ref="contributorsInput"
+                          v-model="contributors"
+                          :id="$scopedId('input-contributors')"
+                          :addOnBlur="true"
+                          :allowDuplicate="false"
+                          placeholder="Type or paste ORCID IDs here."
+                          @add="newContributorsAdded"
+                          @keyup.escape="clearContributorSearch"
                         >
                           <template #chip="slotProps">
                             <div>
@@ -351,13 +349,7 @@
                               <div v-else>{{ slotProps.value.orcidId }}</div>
                             </div>
                           </template>
-                          <template #item="slotProps">
-                            <div>
-                                <div>Name: {{ slotProps.item.givenName }} {{ slotProps.item.familyName }}</div>
-                                <div>ORCID ID: {{ slotProps.item.orcidId }}</div>
-                            </div>
-                          </template>
-                        </AutoComplete>
+                        </Chips>
                         <label :for="$scopedId('input-contributors')">Contributors</label>
                       </span>
                       <span v-if="validationErrors.contributors" class="mave-field-error">{{validationErrors.contributors}}</span>
@@ -924,19 +916,6 @@ export default {
     const geneNames = useItems({ itemTypeName: 'gene-names' })
     const assemblies = useItems({ itemTypeName: 'assemblies' })
     const targetGeneSuggestions = useItems({ itemTypeName: 'target-gene-search' })
-
-    const {
-      resource: contributorLookupResult,
-      setEnabled: setContributorLookupEnabled,
-      setResourceId: setContributorLookupId
-    } = useRestResource({
-      enabled: false,
-      resourceType: {
-        collectionName: 'orcid/users',
-        idProperty: 'orcidId'
-      }
-    })
-
     const expandedTargetGeneRows = ref([])
 
     return {
@@ -964,11 +943,7 @@ export default {
       setTaxonomySearch: (text) => taxonomySuggestions.setRequestBody({text}),
       assemblies: assemblies.items,
       geneNames: geneNames.items,
-      expandedTargetGeneRows,
-
-      contributorLookupResult,
-      setContributorLookupEnabled,
-      setContributorLookupId
+      expandedTargetGeneRows
     }
   },
 
@@ -1057,9 +1032,6 @@ export default {
   }),
 
   computed: {
-    contributorSuggestions: function() {
-        return this.suggestionsForAutocomplete(this.contributorLookupResult ? [this.contributorLookupResult] : [])
-      },
     maxWizardStepValidated: function() {
       const numSteps = 4
       // This yields the index of the maximum step validated, -1 if step 0 is not valid, and -2 if all steps are valid.
@@ -1224,41 +1196,64 @@ export default {
     // Contributors
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    acceptNewContributor: function() {
-      // Assume the newest value is the right-most one. That seems to always be true in this version of PrimeVue, but it
-      // might change in the future.
-      const newIdx = this.contributors.length - 1
-
-      const newIdentifier = this.contributors[newIdx].orcidId
-
-      if (!newIdentifier) {
-        // Remove the new value if it contains no ORCID ID, which may happen if the user clicks an option before the
-        // ORCID ID has been looked up.
-        this.contributors.splice(newIdx, 1)
-      } else if (this.contributors.findIndex((c) => c.orcidId == newIdentifier) < newIdx) {
-        // Remove new value if it is a duplicate.
-        this.contributors.splice(newIdx, 1)
-        let description = `${this.contributors[newIdx].firstName} ${this.contributors[newIdx].lastName}`
-        if (description.length == 1) {
-          description = this.contributors[newIdx].orcidId
-        }
-        this.$toast.add({severity:'warning', summary: `The ORCID user "${description}" is already associated with this experiment`, life: 3000})
-      }
-    },
-
     clearContributorSearch: function() {
       // This could change with a new PrimeVue version.
       const input = this.$refs.contributorsInput
-      input.$refs.focusInput.value = ''
+      input.$refs.input.value = ''
     },
 
-    lookupContributor: function(event) {
-      const searchText = (event.query || '').trim()
-      if (searchText.length > 0 && ORCID_ID_REGEX.test(searchText)) {
-        this.setContributorLookupId(searchText)
-        this.setContributorLookupEnabled(true)
-      } else {
-        this.setContributorLookupEnabled(false)
+    lookupOrcidUser: async function(orcidId) {
+      let orcidUser = null
+      try {
+        orcidUser = (await axios.get(`${config.apiBaseUrl}/orcid/users/${orcidId}`)).data
+      } catch (err) {
+        // Assume that the error was 404 Not Found.
+      }
+      return orcidUser
+    },
+
+    newContributorsAdded: async function(event) {
+      const newContributors = event.value
+
+      // Convert any strings to ORCID users without names.
+      this.contributors = this.contributors.map((c) => _.isString(c) ? {orcidId: c} : c)
+
+      // Validate and look up each new contributor.
+      for (const newContributor of newContributors) {
+        if (_.isString(newContributor)) {
+          const orcidId = newContributor.trim()
+          if (orcidId && this.contributors.filter((c) => c.orcidId == orcidId).length > 1) {
+            const firstIndex = _.findIndex(this.contributors, (c) => c.orcidId == orcidId)
+            _.remove(this.contributors, (c, i) => i > firstIndex && c.orcidId == orcidId)
+          } else if (orcidId && ORCID_ID_REGEX.test(orcidId)) {
+            // Look up the ORCID ID.
+            const orcidUser = await this.lookupOrcidUser(orcidId)
+
+            if (orcidUser) {
+              // If found, update matching contributors. (There should only be one.)
+              for (const contributor of this.contributors) {
+                if (contributor.orcidId == orcidUser.orcidId) {
+                  _.merge(contributor, orcidUser)
+                }
+              }
+            } else {
+              // Otherwise remove the contributor.
+              _.remove(this.contributors, (c) => c.orcidId == orcidId)
+              this.$toast.add({
+                life: 3000,
+                severity: 'warning',
+                summary: `No ORCID user was found with ORCID ID ${orcidId}.`
+              })
+            }
+          } else {
+            _.remove(this.contributors, (c) => c.orcidId == orcidId)
+            this.$toast.add({
+              life: 3000,
+              severity: 'warning',
+              summary: `${orcidId} is not a valid ORCID ID`
+            })
+          }
+        }
       }
     },
 

--- a/src/components/screens/ScoreSetEditor.vue
+++ b/src/components/screens/ScoreSetEditor.vue
@@ -134,17 +134,15 @@
                 </div>
                 <div class="field">
                   <span class="p-float-label">
-                    <AutoComplete
-                        ref="contributorsInput"
-                        v-model="contributors"
-                        :id="$scopedId('input-contributors')"
-                        :multiple="true"
-                        placeholder="Type an ORCID ID"
-                        :suggestions="contributorSuggestions"
-                        @complete="lookupContributor"
-                        @item-select="acceptNewContributor"
-                        @keyup.escape="clearContributorSearch"
-                        option-label="orcidId"
+                    <Chips
+                      ref="contributorsInput"
+                      v-model="contributors"
+                      :id="$scopedId('input-contributors')"
+                      :addOnBlur="true"
+                      :allowDuplicate="false"
+                      placeholder="Type or paste ORCID IDs here."
+                      @add="newContributorsAdded"
+                      @keyup.escape="clearContributorSearch"
                     >
                       <template #chip="slotProps">
                         <div>
@@ -152,13 +150,7 @@
                           <div v-else>{{ slotProps.value.orcidId }}</div>
                         </div>
                       </template>
-                      <template #item="slotProps">
-                        <div>
-                            <div>Name: {{ slotProps.item.givenName }} {{ slotProps.item.familyName }}</div>
-                            <div>ORCID ID: {{ slotProps.item.orcidId }}</div>
-                        </div>
-                      </template>
-                    </AutoComplete>
+                    </Chips>
                     <label :for="$scopedId('input-contributors')">Contributors</label>
                   </span>
                   <span v-if="validationErrors.contributors" class="mave-field-error">{{validationErrors.contributors}}</span>
@@ -695,19 +687,6 @@
       const geneNames = useItems({ itemTypeName: 'gene-names' })
       const assemblies = useItems({ itemTypeName: 'assemblies' })
       const targetGeneSuggestions = useItems({ itemTypeName: 'target-gene-search' })
-
-      const {
-        resource: contributorLookupResult,
-        setEnabled: setContributorLookupEnabled,
-        setResourceId: setContributorLookupId
-      } = useRestResource({
-        enabled: false,
-        resourceType: {
-          collectionName: 'orcid/users',
-          idProperty: 'orcidId'
-        }
-      })
-
       const expandedTargetGeneRows = ref([])
 
       return {
@@ -735,11 +714,7 @@
         setTaxonomySearch: (text) => taxonomySuggestions.setRequestBody({text}),
         assemblies: assemblies.items,
         geneNames: geneNames.items,
-        expandedTargetGeneRows,
-
-        contributorLookupResult,
-        setContributorLookupEnabled,
-        setContributorLookupId
+        expandedTargetGeneRows
       }
     },
 
@@ -809,10 +784,6 @@
     }),
 
     computed: {
-      contributorSuggestions: function() {
-        console.log(this.contributorLookupResult)
-        return this.suggestionsForAutocomplete(this.contributorLookupResult ? [this.contributorLookupResult] : [])
-      },
       targetGeneIdentifierSuggestionsList: function () {
         return _.fromPairs(
           externalGeneDatabases.map((dbName) => {
@@ -960,41 +931,64 @@
       // Contributors
       //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-      acceptNewContributor: function() {
-        // Assume the newest value is the right-most one. That seems to always be true in this version of PrimeVue, but it
-        // might change in the future.
-        const newIdx = this.contributors.length - 1
-
-        const newIdentifier = this.contributors[newIdx].orcidId
-
-        if (!newIdentifier) {
-          // Remove the new value if it contains no ORCID ID, which may happen if the user clicks an option before the
-          // ORCID ID has been looked up.
-          this.contributors.splice(newIdx, 1)
-        } else if (this.contributors.findIndex((c) => c.orcidId == newIdentifier) < newIdx) {
-          // Remove new value if it is a duplicate.
-          this.contributors.splice(newIdx, 1)
-          let description = `${this.contributors[newIdx].firstName} ${this.contributors[newIdx].lastName}`
-          if (description.length == 1) {
-            description = this.contributors[newIdx].orcidId
-          }
-          this.$toast.add({severity:'warning', summary: `The ORCID user "${description}" is already associated with this experiment`, life: 3000})
-        }
-      },
-
       clearContributorSearch: function() {
         // This could change with a new PrimeVue version.
         const input = this.$refs.contributorsInput
-        input.$refs.focusInput.value = ''
+        input.$refs.input.value = ''
       },
 
-      lookupContributor: function(event) {
-        const searchText = (event.query || '').trim()
-        if (searchText.length > 0 && ORCID_ID_REGEX.test(searchText)) {
-          this.setContributorLookupId(searchText)
-          this.setContributorLookupEnabled(true)
-        } else {
-          this.setContributorLookupEnabled(false)
+      lookupOrcidUser: async function(orcidId) {
+        let orcidUser = null
+        try {
+          orcidUser = (await axios.get(`${config.apiBaseUrl}/orcid/users/${orcidId}`)).data
+        } catch (err) {
+          // Assume that the error was 404 Not Found.
+        }
+        return orcidUser
+      },
+
+      newContributorsAdded: async function(event) {
+        const newContributors = event.value
+
+        // Convert any strings to ORCID users without names.
+        this.contributors = this.contributors.map((c) => _.isString(c) ? {orcidId: c} : c)
+
+        // Validate and look up each new contributor.
+        for (const newContributor of newContributors) {
+          if (_.isString(newContributor)) {
+            const orcidId = newContributor.trim()
+            if (orcidId && this.contributors.filter((c) => c.orcidId == orcidId).length > 1) {
+              const firstIndex = _.findIndex(this.contributors, (c) => c.orcidId == orcidId)
+              _.remove(this.contributors, (c, i) => i > firstIndex && c.orcidId == orcidId)
+            } else if (orcidId && ORCID_ID_REGEX.test(orcidId)) {
+              // Look up the ORCID ID.
+              const orcidUser = await this.lookupOrcidUser(orcidId)
+
+              if (orcidUser) {
+                // If found, update matching contributors. (There should only be one.)
+                for (const contributor of this.contributors) {
+                  if (contributor.orcidId == orcidUser.orcidId) {
+                    _.merge(contributor, orcidUser)
+                  }
+                }
+              } else {
+                // Otherwise remove the contributor.
+                _.remove(this.contributors, (c) => c.orcidId == orcidId)
+                this.$toast.add({
+                  life: 3000,
+                  severity: 'warning',
+                  summary: `No ORCID user was found with ORCID ID ${orcidId}.`
+                })
+              }
+            } else {
+              _.remove(this.contributors, (c) => c.orcidId == orcidId)
+              this.$toast.add({
+                life: 3000,
+                severity: 'warning',
+                summary: `${orcidId} is not a valid ORCID ID`
+              })
+            }
+          }
         }
       },
 

--- a/src/components/screens/ScoreSetEditor.vue
+++ b/src/components/screens/ScoreSetEditor.vue
@@ -642,6 +642,7 @@
   import useItems from '@/composition/items'
   import config from '@/config'
   import {normalizeDoi, normalizeIdentifier, normalizePubmedId, validateDoi, validateIdentifier, validatePubmedId} from '@/lib/identifiers'
+  import {ORCID_ID_REGEX} from '@/lib/orcid'
   import useFormatters from '@/composition/formatters'
 
   const externalGeneDatabases = ['UniProt', 'Ensembl', 'RefSeq']
@@ -989,7 +990,7 @@
 
       lookupContributor: function(event) {
         const searchText = (event.query || '').trim()
-        if (searchText.length > 0) {
+        if (searchText.length > 0 && ORCID_ID_REGEX.test(searchText)) {
           this.setContributorLookupId(searchText)
           this.setContributorLookupEnabled(true)
         } else {

--- a/src/components/screens/ScoreSetView.vue
+++ b/src/components/screens/ScoreSetView.vue
@@ -91,6 +91,19 @@
             <a :href="`https://orcid.org/${item.modifiedBy.orcidId}`" target="blank"><img src="@/assets/ORCIDiD_icon.png"
                 alt="ORCIDiD">{{ item.modifiedBy.firstName }} {{ item.modifiedBy.lastName }}</a></span>
         </div>
+        <div v-if="contributors.length > 0">
+          Contributors
+          <a
+            v-for="contributor in contributors"
+            class="mave-contributor"
+            :href="`https://orcid.org/${contributor.orcidId}`"
+            :key="contributor.orcidId"
+            target="blank"
+          >
+            <img src="@/assets/ORCIDiD_icon.png" alt="ORCIDiD">
+            {{ contributor.givenName }} {{ contributor.familyName }}
+          </a>
+        </div>
         <div v-if="item.publishedDate">Published {{ formatDate(item.publishedDate) }}</div>
         <div v-if="item.license">
           License:
@@ -364,6 +377,12 @@ export default {
   name: 'ScoreSetView',
   components: { Accordion, AccordionTab, AutoComplete, Button, Chip, DefaultLayout, EntityLink, ScoreSetHeatmap, ScoreSetHistogram, TabView, TabPanel, Message, DataTable, Column, ProgressSpinner, ScrollPanel, PageLoading, ItemNotFound },
   computed: {
+    contributors: function() {
+      return _.sortBy(
+        (this.item?.contributors || []).filter((c) => c.orcidId != this.item?.createdBy?.orcidId),
+        ['familyName', 'givenName', 'orcidId']
+      )
+    },
     isMetaDataEmpty: function() {
       //If extraMetadata is empty, return value will be true.
       return Object.keys(this.item.extraMetadata).length === 0
@@ -804,6 +823,10 @@ export default {
 
 .mave-score-set-urn {
   /*font-family: Helvetica, Verdana, Arial, sans-serif;*/
+}
+
+.mave-contributor {
+  margin: 0 0.5em;
 }
 
 /* Formatting in Markdown blocks */

--- a/src/lib/orcid.ts
+++ b/src/lib/orcid.ts
@@ -43,6 +43,8 @@ export interface OidcUserProfileBase {
   sub: string
 }
 
+export const ORCID_ID_REGEX = /^\d{4}-\d{4}-\d{4}-\d{4}$/
+
 // Notice the final '/'.
 const appUrl = `${window.location.origin}/`
 

--- a/src/lib/orcid.ts
+++ b/src/lib/orcid.ts
@@ -43,7 +43,7 @@ export interface OidcUserProfileBase {
   sub: string
 }
 
-export const ORCID_ID_REGEX = /^\d{4}-\d{4}-\d{4}-\d{4}$/
+export const ORCID_ID_REGEX = /^\d{4}-\d{4}-\d{4}-(\d{4}|\d{3}X)$/
 
 // Notice the final '/'.
 const appUrl = `${window.location.origin}/`

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,13 @@
+import {createPinia} from 'pinia'
 import PrimeVue from 'primevue/config';
 import ConfirmationService from 'primevue/confirmationservice'
 import ToastService from 'primevue/toastservice'
 import Tooltip from 'primevue/tooltip';
+import {initRestClient} from 'rest-client-vue'
 import {createApp} from 'vue'
 
 import App from '@/App.vue'
+import config from '@/config'
 import {installAxiosAuthHeaderInterceptor, installAxiosUnauthorizedResponseInterceptor} from '@/lib/auth'
 import {initializeAuthentication as initializeOrcidAuthentication} from '@/lib/orcid'
 import router from '@/router'
@@ -37,12 +40,15 @@ router.beforeEach((to) => {
 createApp(App)
     .use(router)
     .use(store)
+    .use(createPinia())
     .use(PrimeVue)
     .use(ConfirmationService)
     .use(ToastService)
     .use(vueComponentId)
     .directive('tooltip', Tooltip)
     .mount('#app')
+
+initRestClient({apiBaseUrl: config.apiBaseUrl})
 
 // Monkey-patch Axios so that all requests will have the user's credentials.
 installAxiosAuthHeaderInterceptor()


### PR DESCRIPTION
Creators of experiments and score sets may now assign them lists of contributors. Contributors must be looked up by ORCID ID, and the API returns the ORCID user's name. If a contributor has a MaveDB user account, that user is granted the same permissions on the experiment or score set as its creator.

- User interfaces for assigning contributors to an experiment or score set
- Experiment and score set views now display lists of contributors.
- Pinia and rest-client-vue are used here to manage ORCID ID lookups. We'll likely want to replace other uses of Vuex and useItems with these libraries.

This PR depends on the corresponding contributors PR on mavedb-api (https://github.com/VariantEffect/mavedb-api/pull/259).