### PR TITLE
Add force selection to Taxonomy

### DIFF
--- a/src/components/screens/ScoreSetCreator.vue
+++ b/src/components/screens/ScoreSetCreator.vue
@@ -509,6 +509,7 @@
                           :id="$scopedId('input-targetSequenceTaxonomy')"
                           :suggestions="taxonomySuggestionsList"
                           field="organismName"
+                          forceSelection
                           :multiple="false"
                           :options="taxonomies"
                           @complete="searchTaxonomies"


### PR DESCRIPTION
If no force selection, invalid taxonomy can be added in target gene and raise an error in saving a new score set. 
https://github.com/VariantEffect/mavedb-api/issues/266