### PR TITLE
Score Range UI

### DIFF
--- a/src/components/screens/ScoreSetCreator.vue
+++ b/src/components/screens/ScoreSetCreator.vue
@@ -919,7 +919,7 @@
                   </div>
                   <div class="mavedb-wizard-content">
                     <span class="p-float-label">
-                      <InputNumber v-model="scoreRanges.wtScore" :aria-labelledby="$scopedId('input-wtScore')" showButtons :step="0.01" style="width:100%;" :minFractionDigits="1" />
+                      <InputNumber v-model="scoreRanges.wtScore" :aria-labelledby="$scopedId('input-wtScore')" style="width:100%;" :minFractionDigits="1" :maxFractionDigits="10" />
                       <label :for="$scopedId('input-wtScore')"> Wild Type Score </label>
                     </span>
                     <span v-if="validationErrors[`scoreRanges.wtScore`]" class="mave-field-error">{{ validationErrors[`scoreRanges.wtScore`] }}</span>

--- a/src/components/screens/ScoreSetCreator.vue
+++ b/src/components/screens/ScoreSetCreator.vue
@@ -979,8 +979,8 @@
                             <label for="upperBound" class="ml-2"> No upper bound </label>
                             <Checkbox :binary="true" v-model="rangeObj.infiniteUpper" inputId="upperBound" name="upper" @change="boundaryLimitUpdated(rangeIdx, 'upper')"/>
                           </span>
-                          <span v-if="validationErrors[`scoreRanges.ranges.${rangeIdx}.0`]" class="mave-field-error">{{ validationErrors[`scoreRanges.ranges.${rangeIdx}.0`] }}</span>
-                          <span v-if="validationErrors[`scoreRanges.ranges.${rangeIdx}.1`]" class="mave-field-error">{{ validationErrors[`scoreRanges.ranges.${rangeIdx}.1`] }}</span>
+                          <span v-if="validationErrors[`scoreRanges.ranges.${rangeIdx}.0.range`]" class="mave-field-error">{{ validationErrors[`scoreRanges.ranges.${rangeIdx}.0.range`] }}</span>
+                          <span v-if="validationErrors[`scoreRanges.ranges.${rangeIdx}.1.range`]" class="mave-field-error">{{ validationErrors[`scoreRanges.ranges.${rangeIdx}.1.range`] }}</span>
                       </div>
                     </div>
                   </div>

--- a/src/components/screens/ScoreSetCreator.vue
+++ b/src/components/screens/ScoreSetCreator.vue
@@ -343,36 +343,6 @@
                   </div>
                   <div class="mavedb-wizard-row">
                     <div class="mavedb-wizard-help">
-                      <label :id="$scopedId('input-doiIdentifiers')">
-                        The DOIs of any digital resources associated with the score set.
-                      </label>
-                      <div class="mavedb-help-small">
-                        Please note: If you would like to associate publications with this score set via their DOI, please do not do so here.
-                        Instead, use the publication identifiers field below.
-                      </div>
-                    </div>
-                    <div class="mavedb-wizard-content field">
-                      <span class="p-float-label">
-                        <Chips
-                            v-model="doiIdentifiers"
-                            :id="$scopedId('input-doiIdentifiers')"
-                            :addOnBlur="true"
-                            :allowDuplicate="false"
-                            @add="acceptNewDoiIdentifier"
-                        >
-                          <template #chip="slotProps">
-                            <div>
-                              <div>{{ slotProps.value.identifier }}</div>
-                            </div>
-                          </template>
-                        </Chips>
-                        <label :for="$scopedId('input-doiIdentifiers')">DOI identifiers</label>
-                      </span>
-                      <span v-if="validationErrors.doiIdentifiers" class="mave-field-error">{{validationErrors.doiIdentifiers}}</span>
-                    </div>
-                  </div>
-                  <div class="mavedb-wizard-row">
-                    <div class="mavedb-wizard-help">
                       <label>
                         Contributors who may edit this score set. Enter each contributor's
                         <a href="https://orcid.org" target="_blank">ORCID</a> ID and confirm their name.

--- a/src/components/screens/ScoreSetCreator.vue
+++ b/src/components/screens/ScoreSetCreator.vue
@@ -1670,12 +1670,12 @@ export default {
               && (currentTargetGene.targetAccession.accession || (currentTargetGene.targetSequence.sequence && currentTargetGene.targetSequence.sequenceType))
         }
         case (step == 3 + this.numTargets): {
-          let allRangesCompleted = false
+          let allRangesCompleted = true
           for (const scoreRange of this.scoreRanges.ranges) {
             if (!scoreRange.value.label || !scoreRange.value.classification || (!scoreRange.value.range[0] && !scoreRange.infiniteLower) || (!scoreRange.value.range[1] && !scoreRange.infiniteUpper)) {
+              allRangesCompleted = false
               break
             }
-            allRangesCompleted = true
           }
           return !(this.isProvidingScoreRanges) || (allRangesCompleted && this.scoreRanges.wtScore)
         }

--- a/src/components/screens/ScoreSetCreator.vue
+++ b/src/components/screens/ScoreSetCreator.vue
@@ -343,6 +343,36 @@
                   </div>
                   <div class="mavedb-wizard-row">
                     <div class="mavedb-wizard-help">
+                      <label :id="$scopedId('input-doiIdentifiers')">
+                        The DOIs of any digital resources associated with the score set.
+                      </label>
+                      <div class="mavedb-help-small">
+                        Please note: If you would like to associate publications with this score set via their DOI, please do not do so here.
+                        Instead, use the publication identifiers field below.
+                      </div>
+                    </div>
+                    <div class="mavedb-wizard-content field">
+                      <span class="p-float-label">
+                        <Chips
+                            v-model="doiIdentifiers"
+                            :id="$scopedId('input-doiIdentifiers')"
+                            :addOnBlur="true"
+                            :allowDuplicate="false"
+                            @add="acceptNewDoiIdentifier"
+                        >
+                          <template #chip="slotProps">
+                            <div>
+                              <div>{{ slotProps.value.identifier }}</div>
+                            </div>
+                          </template>
+                        </Chips>
+                        <label :for="$scopedId('input-doiIdentifiers')">DOI identifiers</label>
+                      </span>
+                      <span v-if="validationErrors.doiIdentifiers" class="mave-field-error">{{validationErrors.doiIdentifiers}}</span>
+                    </div>
+                  </div>
+                  <div class="mavedb-wizard-row">
+                    <div class="mavedb-wizard-help">
                       <label>
                         Contributors who may edit this score set. Enter each contributor's
                         <a href="https://orcid.org" target="_blank">ORCID</a> ID and confirm their name.
@@ -1347,17 +1377,6 @@ export default {
           this.numTargets = 2
         } else {
           this.numTargets = 1
-        }
-      }
-    },
-    assembly: {
-      handler: async function(newValue, oldValue) {
-        if (newValue == oldValue) {
-          return;
-        }
-        this.assemblyDropdownValue = this.assembly?.trim() || null
-        if (this.assemblyDropdownValue) {
-          this.assemblySuggestions = await this.fetchTargetAccessionsByAssembly(this.assemblyDropdownValue)
         }
       }
     },

--- a/src/components/screens/ScoreSetCreator.vue
+++ b/src/components/screens/ScoreSetCreator.vue
@@ -919,7 +919,7 @@
                   </div>
                   <div class="mavedb-wizard-content">
                     <span class="p-float-label">
-                      <InputNumber v-model="scoreRanges.wtScore" :aria-labelledby="$scopedId('input-wtScore')" showButtons :step="0.01" style="width:100%;" />
+                      <InputNumber v-model="scoreRanges.wtScore" :aria-labelledby="$scopedId('input-wtScore')" showButtons :step="0.01" style="width:100%;" :minFractionDigits="1" />
                       <label :for="$scopedId('input-wtScore')"> Wild Type Score </label>
                     </span>
                     <span v-if="validationErrors[`scoreRanges.wtScore`]" class="mave-field-error">{{ validationErrors[`scoreRanges.wtScore`] }}</span>

--- a/src/components/screens/ScoreSetEditor.vue
+++ b/src/components/screens/ScoreSetEditor.vue
@@ -1218,24 +1218,24 @@
       },
 
       boundaryLimitUpdated: function(rangeIdx, boundary) {
-      const updatedRange = this.scoreRanges.ranges[rangeIdx]
-      if (boundary === "upper") {
-        updatedRange.range[1] = null
-      }
-      else if (boundary == "lower") {
-        updatedRange.range[0] = null
-      }
-    },
+        const updatedRange = this.scoreRanges.ranges[rangeIdx]
+        if (boundary === "upper") {
+          updatedRange.range[1] = null
+        }
+        else if (boundary == "lower") {
+          updatedRange.range[0] = null
+        }
+      },
 
-    addScoreRange: function() {
-      this.scoreRanges.ranges.push(emptyScoreRange())
-      this.scoreRangeBoundaryHelper.push(emptyScoreRangeBoundaryHelper())
-    },
+      addScoreRange: function() {
+        this.scoreRanges.ranges.push(emptyScoreRange())
+        this.scoreRangeBoundaryHelper.push(emptyScoreRangeBoundaryHelper())
+      },
 
-    removeScoreRange: function(rangeIdx) {
-      this.scoreRanges.ranges.splice(rangeIdx, 1)
-      this.scoreRangeBoundaryHelper.splice(rangeIdx, 1)
-    },
+      removeScoreRange: function(rangeIdx) {
+        this.scoreRanges.ranges.splice(rangeIdx, 1)
+        this.scoreRangeBoundaryHelper.splice(rangeIdx, 1)
+      },
 
       ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
       // Form fields
@@ -1479,7 +1479,11 @@
           this.targetGenes = this.item.targetGenes
           this.scoreRanges = this.item.scoreRanges
           this.scoreRangeBoundaryHelper = []
-          this.scoreRanges.ranges.forEach(() => this.scoreRangeBoundaryHelper.push(emptyScoreRangeBoundaryHelper()))
+          this.scoreRanges.ranges.forEach((range, idx) => {
+            this.scoreRangeBoundaryHelper.push(emptyScoreRangeBoundaryHelper())
+            this.scoreRangeBoundaryHelper[idx].lowerBoundIsInfinity = this.scoreRanges.ranges[idx].range[0] === null
+            this.scoreRangeBoundaryHelper[idx].upperBoundIsInfinity = this.scoreRanges.ranges[idx].range[1] === null
+          })
           this.extraMetadata = this.item.extraMetadata
         } else {
           this.experiment = null

--- a/src/components/screens/ScoreSetEditor.vue
+++ b/src/components/screens/ScoreSetEditor.vue
@@ -270,6 +270,68 @@
                 </div>
               </template>
             </Card>
+            <Card>
+              <template #title>Score ranges</template>
+              <template #content>
+                <div v-for="(scoreRange, scoreIdx) of scoreRanges.ranges" :key="scoreIdx" class="mavedb-score-range-container">
+                  <Card>
+                    <template #title>Range {{ scoreIdx+1 }}:
+                      <Button icon="pi pi-times" severity="danger" aria-label="Delete range" rounded text style="float:right;" @click="removeScoreRange(scoreIdx)"/>
+                    </template>
+                    <template #content>
+                      <div style="padding-top: 1%;">
+                          <InputGroup>
+                            <span class="p-float-label" style="width:75%;">
+                              <InputText v-model="scoreRange.label" style="width:75%;" :aria-labelledby="$scopedId(`input-scoreRangeLabel-${scoreIdx}`)"></InputText>
+                              <label :for="$scopedId(`input-scoreRangeLabel-${scoreIdx}`)">Label</label>
+                            </span>
+                            <span class="p-float-label" style="width:25%;">
+                              <Dropdown v-model="scoreRange.classification" :options="rangeClassifications" style="width:25%;" :aria-labelledby="$scopedId(`input-scoreRangeClassification-${scoreIdx}`)"/>
+                              <label :for="$scopedId(`input-scoreRangeClassification-${scoreIdx}`)">Classification</label>
+                            </span>
+                          </InputGroup>
+                          <span v-if="validationErrors[`scoreRanges.ranges.${scoreIdx}.label`]" class="mave-field-error">{{ validationErrors[`scoreRanges.ranges.${scoreIdx}.label`] }}</span>
+                          <span v-if="validationErrors[`scoreRanges.ranges.${scoreIdx}.classification`]" class="mave-field-error">{{ validationErrors[`scoreRanges.ranges.${scoreIdx}.classification`] }}</span>
+                      </div>
+                      <div style="padding-top: 2%;">
+                        <span class="p-float-label">
+                          <Textarea v-model="scoreRange.description" style="width:100%;" :aria-labelledby="$scopedId(`input-scoreRangeDescription-${scoreIdx}`)"/>
+                          <label :for="$scopedId(`input-scoreRangeDescription-${scoreIdx}`)">Description (optional)</label>
+                        </span>
+                        <span v-if="validationErrors[`scoreRanges.ranges.${scoreIdx}.description`]" class="mave-field-error">{{ validationErrors[`scoreRanges.ranges.${scoreIdx}.description`] }}</span>
+                      </div>
+                      <div>
+                        <InputGroup>
+                          <span class=p-float-label>
+                            <InputText v-model="scoreRange.range[0]" :aria-labelledby="$scopedId(`input-scoreRangeLower-${scoreIdx}`)" :disabled="scoreRangeBoundaryHelper[scoreIdx].lowerBoundIsInfinity"/>
+                            <label :for="$scopedId(`input-scoreRangeLower-${scoreIdx}`)"> {{ scoreRangeBoundaryHelper[scoreIdx].lowerBoundIsInfinity ? "-infinity" : "Lower Bound" }} </label>
+                          </span>
+                          <InputGroupAddon>to</InputGroupAddon>
+                          <span class=p-float-label>
+                            <InputText v-model="scoreRange.range[1]" :aria-labelledby="$scopedId(`input-scoreRangeUpper-${scoreIdx}`)" :disabled="scoreRangeBoundaryHelper[scoreIdx].upperBoundIsInfinity"/>
+                            <label :for="$scopedId(`input-scoreRangeUpper-${scoreIdx}`)"> {{ scoreRangeBoundaryHelper[scoreIdx].upperBoundIsInfinity ? "infinity" : "Upper Bound" }} </label>
+                          </span>
+                        </InputGroup>
+                      </div>
+                      <div>
+                        <span>
+                          <Checkbox v-model="scoreRangeBoundaryHelper[scoreIdx].lowerBoundIsInfinity" :binary="true" inputId="lowerBound" name="lower" @change="boundaryLimitUpdated(scoreIdx, 'lower')"/>
+                          <label for="lowerBound" class="ml-2"> No lower bound </label>
+                        </span>
+                        <span style="float:right;">
+                          <label for="upperBound" class="ml-2"> No upper bound </label>
+                          <Checkbox v-model="scoreRangeBoundaryHelper[scoreIdx].upperBoundIsInfinity" :binary="true" inputId="upperBound" name="upper" @change="boundaryLimitUpdated(scoreIdx, 'upper')"/>
+                        </span>
+                      </div>
+                      <span v-if="validationErrors[`scoreRanges.ranges.${scoreIdx}.range`]" class="mave-field-error">{{ validationErrors[`scoreRanges.ranges.${scoreIdx}.range`] }}</span>
+                    </template>
+                  </Card>
+                </div>
+                <div class="field" style="align-items: center; justify-content: center; display: flex">
+                  <Button label="Add new score range" icon="pi pi-plus" aria-label="Add range" outlined raised text @click="addScoreRange()"/>
+                </div>
+              </template>
+            </Card>
           </div>
           <div class="col-12 md:col-6">
             <div v-if="itemStatus == 'NotLoaded' || this.item.private">
@@ -555,6 +617,7 @@
                   </div>
                 </template>
               </Card>
+
               <Card>
                 <template #title>Variant scores</template>
                 <template #content>
@@ -612,9 +675,12 @@
   import Card from 'primevue/card'
   import Chips from 'primevue/chips'
   import Column from 'primevue/column'
+  import Checkbox from 'primevue/checkbox'
   import DataTable from 'primevue/datatable'
   import Dropdown from 'primevue/dropdown'
   import FileUpload from 'primevue/fileupload'
+  import InputGroup from 'primevue/inputgroup'
+  import InputGroupAddon from 'primevue/inputgroupaddon'
   import InputNumber from 'primevue/inputnumber'
   import InputText from 'primevue/inputtext'
   import Message from 'primevue/message'
@@ -662,9 +728,25 @@
     }
   }
 
+  function emptyScoreRange() {
+    return {
+        label: null,
+        description: null,
+        range: [null, null],
+        classification: null,
+      }
+  }
+
+  function emptyScoreRangeBoundaryHelper() {
+    return {
+      lowerBoundIsInfinity: false,
+      upperBoundIsInfinity: false
+    }
+  }
+
   export default {
     name: 'ScoreSetEditor',
-    components: { AutoComplete, Button, Card, Chips, Column, DataTable, DefaultLayout, Dropdown, EmailPrompt, EntityLink, FileUpload, InputNumber, InputText, Message, Multiselect, ProgressSpinner, SelectButton, TabPanel, TabView, Textarea },
+    components: { AutoComplete, Button, Card, Chips, Column, Checkbox, DataTable, DefaultLayout, Dropdown, EmailPrompt, EntityLink, FileUpload, InputGroup, InputGroupAddon, InputNumber, InputText, Message, Multiselect, ProgressSpinner, SelectButton, TabPanel, TabView, Textarea },
 
     setup: () => {
       const editableExperiments = useItems({
@@ -757,6 +839,12 @@
       existingTargetGene: null,
       targetGenes: [],
 
+      scoreRanges: {
+        wtScore: null,
+        ranges: [],
+      },
+      scoreRangeBoundaryHelper: [],
+
       // Static sets of options:
       sequenceTypes: [
         'DNA',
@@ -766,6 +854,10 @@
         'Protein coding',
         'Regulatory',
         'Other noncoding'
+      ],
+      rangeClassifications: [
+        'normal',
+        'abnormal'
       ],
 
       progressVisible: false,
@@ -1124,6 +1216,27 @@
           console.log(`Error while loading protein accession")`, err)
         }
       },
+
+      boundaryLimitUpdated: function(rangeIdx, boundary) {
+      const updatedRange = this.scoreRanges.ranges[rangeIdx]
+      if (boundary === "upper") {
+        updatedRange.range[1] = null
+      }
+      else if (boundary == "lower") {
+        updatedRange.range[0] = null
+      }
+    },
+
+    addScoreRange: function() {
+      this.scoreRanges.ranges.push(emptyScoreRange())
+      this.scoreRangeBoundaryHelper.push(emptyScoreRangeBoundaryHelper())
+    },
+
+    removeScoreRange: function(rangeIdx) {
+      this.scoreRanges.ranges.splice(rangeIdx, 1)
+      this.scoreRangeBoundaryHelper.splice(rangeIdx, 1)
+    },
+
       ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
       // Form fields
       ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1364,6 +1477,9 @@
           this.targetGene = emptyTargetGene()
           this.assembly = this.item.assembly
           this.targetGenes = this.item.targetGenes
+          this.scoreRanges = this.item.scoreRanges
+          this.scoreRangeBoundaryHelper = []
+          this.scoreRanges.ranges.forEach(() => this.scoreRangeBoundaryHelper.push(emptyScoreRangeBoundaryHelper()))
           this.extraMetadata = this.item.extraMetadata
         } else {
           this.experiment = null
@@ -1384,6 +1500,8 @@
           this.extraMetadata = {}
           this.resetTarget()
           this.targetGenes = []
+          this.scoreRanges = {wtScore: null, ranges: []}
+          this.scoreRangeBoundaryHelper = []
         }
       },
 
@@ -1399,6 +1517,8 @@
         this.fileCleared('targetGeneTargetSequenceSequenceFile')
         this.referenceGenome = null
         this.targetGene = emptyTargetGene()
+        this.scoreRanges = {wtScore: null, ranges: []}
+        this.scoreRangeBoundaryHelper = []
       },
 
       addTarget: function () {
@@ -1684,6 +1804,16 @@
 
   .field-column:first-child {
     margin-left: 0;
+  }
+
+  .mavedb-score-range-container {
+    display: flex;
+    flex-direction: row;
+    flex-flow: row wrap;
+  }
+
+  .mavedb-score-range-container > * {
+    flex: 1 100%;
   }
 
   /* Form fields */

--- a/src/components/screens/ScoreSetView.vue
+++ b/src/components/screens/ScoreSetView.vue
@@ -292,7 +292,7 @@
             <div v-if="scoreRange.label"><strong>Name:</strong> {{ scoreRange.label }}</div>
             <div v-if="scoreRange.description"><strong>Description:</strong> {{ scoreRange.description }}</div>
             <div v-if="scoreRange.classification"><strong>Classification:</strong> {{ scoreRange.classification }}</div>
-            <div v-if="scoreRange.range"><strong>Range:</strong> [{{ scoreRange.range[0] ? scoreRange.range[0] : "-infinity" }}, {{ scoreRange.range[1] ? scoreRange.range[1] : "infinity" }})</div>
+            <div v-if="scoreRange.range"><strong>Range:</strong> [{{ scoreRange.range[0] !== null ? scoreRange.range[0] : "-infinity" }}, {{ scoreRange.range[1] !== null ? scoreRange.range[1] : "infinity" }})</div>
             <br>
           </div>
         </div>

--- a/src/components/screens/ScoreSetView.vue
+++ b/src/components/screens/ScoreSetView.vue
@@ -284,6 +284,20 @@
           </div>
         </div>
 
+        <div class="mave-score-set-section-title">Score Ranges</div>
+        <div v-if="item.scoreRanges">
+          <div v-if="item.scoreRanges.wtScore"><strong>Wild Type Score:</strong> {{ item.scoreRanges.wtScore }}</div>
+          <br>
+          <div v-for="scoreRange of item.scoreRanges.ranges.sort((a, b) => a.range[0] - b.range[0])" :key="scoreRange">
+            <div v-if="scoreRange.label"><strong>Name:</strong> {{ scoreRange.label }}</div>
+            <div v-if="scoreRange.description"><strong>Description:</strong> {{ scoreRange.description }}</div>
+            <div v-if="scoreRange.classification"><strong>Classification:</strong> {{ scoreRange.classification }}</div>
+            <div v-if="scoreRange.range"><strong>Range:</strong> [{{ scoreRange.range[0] ? scoreRange.range[0] : "-infinity" }}, {{ scoreRange.range[1] ? scoreRange.range[1] : "infinity" }})</div>
+            <br>
+          </div>
+        </div>
+        <div v-else>Not specified</div>
+
         <div class="mave-score-set-section-title">External identifier</div>
         <strong>DOI: </strong>
         <div v-if="item.doiIdentifiers.length != 0">


### PR DESCRIPTION
Accept score ranges during score set creation, editing, and viewing.

Default of no score ranges
<img width="1126" alt="Screenshot 2024-09-20 at 11 00 28 AM" src="https://github.com/user-attachments/assets/0e4362f2-e959-4fb0-bb2e-241d650f5fd1">

Adding a single score range (not possible technically, since one abnormal and one normal is needed)
<img width="616" alt="Screenshot 2024-09-20 at 11 01 03 AM" src="https://github.com/user-attachments/assets/4e76be89-a69c-4385-983a-0b44ad0c0705">

Users may add an arbitrary number of score ranges
<img width="627" alt="Screenshot 2024-09-20 at 11 01 44 AM" src="https://github.com/user-attachments/assets/f5116fa0-8c31-4420-932c-ff3a1a967883">
