### PR TITLE
Limit “copy from existing target gene” to the user’s own target genes.

### DIFF
--- a/src/components/screens/ScoreSetCreator.vue
+++ b/src/components/screens/ScoreSetCreator.vue
@@ -584,7 +584,7 @@
                   <div class="mavedb-wizard-help">
                     <label>Copy target from a previously created target</label>
                     <div class="mavedb-help-small">
-                      Use this autocomplete field to find an existing target in MaveDB and fill this target with its metadata. You'll still be able to edit any fields below.
+                      Use this autocomplete field to find an existing target from one of your published or unpublished score sets in MaveDB and fill this target with its metadata. You'll still be able to edit any fields below.
                     </div>
                   </div>
                   <div class="mavedb-wizard-content field">

--- a/src/lib/item-types.js
+++ b/src/lib/item-types.js
@@ -237,7 +237,7 @@ const itemTypes = {
     httpOptions: {
       list: {
         method: 'post',
-        url: `${config.apiBaseUrl}/target-genes/search`
+        url: `${config.apiBaseUrl}/me/target-genes/search`
       }
     }
   },


### PR DESCRIPTION
This UI change depends on https://github.com/VariantEffect/mavedb-api/pull/341.