### PR TITLE
Only Allow Users to Select from Active Licenses

### DIFF
--- a/src/components/screens/ScoreSetCreator.vue
+++ b/src/components/screens/ScoreSetCreator.vue
@@ -322,11 +322,20 @@
                       </Message>
                     </div>
                   </div>
-                  <div v-if="licenseId && licenses && licenses.find((l) => l.id == licenseId)?.shortName == 'Other - See Data Usage Guidelines'"
+                  <div class="mavedb-wizard-row">
+                    <div class="mavedb-wizard-help">
+                      Would you like to define any additional restrictions governing the usage of data within this score set?
+                    </div>
+                    <div class="mavedb-wizard-content">
+                      <InputSwitch v-model="hasCustomUsagePolicy" :aria-labelledby="$scopedId('input-has-custom-usage-policy')" />
+                      <div class="mavedb-switch-value">{{ hasCustomUsagePolicy ? 'Yes, I would like to define additional usage guidelines' : 'No, I do not need to define additional usage guidenlines' }}</div>
+                    </div>
+                  </div>
+                  <div v-if="hasCustomUsagePolicy"
                     class="mavedb-wizard-row">
                     <div class="mavedb-wizard-help">
                       <label>
-                        A license and/or any restrictions governing the usage of the data in this score set.
+                        Any additional guidelines governing the usage of the data in this score set.
                       </label>
                       <div class="mavedb-help-small">
                         This may assert, for example, the original author's right to publish the data first.
@@ -1221,7 +1230,7 @@ export default {
       targetGeneIdentifierSuggestions[dbName] = useItems({ itemTypeName: `${dbName.toLowerCase()}-identifier-search` })
     }
 
-    const licenses = useItems({itemTypeName: 'license'})
+    const licenses = useItems({itemTypeName: 'active-license'})
     const taxonomies = useItems({itemTypeName: 'taxonomy'})
     const taxonomySuggestions = useItems({itemTypeName: 'taxonomy-search'})
     const geneNames = useItems({ itemTypeName: 'gene-names' })
@@ -1284,6 +1293,7 @@ export default {
     abstractText: null,
     methodText: null,
     licenseId: null,
+    hasCustomUsagePolicy: false,
     dataUsagePolicy: null,
 
     contributors: [],
@@ -2093,6 +2103,7 @@ export default {
         this.methodText = this.item.methodText
         this.licenseId = this.item.license.id
         this.dataUsagePolicy = this.item.dataUsagePolicy
+        this.hasCustomUsagePolicy = this.dataUsagePolicy ? true : false
 
         this.contributors = _.sortBy(this.item.contributors, ['familyName', 'givenName', 'orcidId'])
         this.doiIdentifiers = this.item.doiIdentifiers
@@ -2129,6 +2140,7 @@ export default {
         this.abstractText = null
         this.methodText = null
         this.licenseId = this.defaultLicenseId
+        this.hasCustomUsagePolicy = false
         this.dataUsagePolicy = null
 
         this.contributors = []
@@ -2168,7 +2180,7 @@ export default {
       ).filter(
         secondary => !primaryPublicationIdentifiers.some(primary => primary.identifier == secondary.identifier && primary.dbName == secondary.dbName)
       )
-      console.log(this.scoreRanges)
+
       const editedFields = {
         experimentUrn: this.experimentUrn ? this.experimentUrn : this.experiment?.urn,
         title: this.title,
@@ -2181,7 +2193,7 @@ export default {
         doiIdentifiers: this.doiIdentifiers.map((identifier) => _.pick(identifier, 'identifier')),
         primaryPublicationIdentifiers: primaryPublicationIdentifiers,
         secondaryPublicationIdentifiers: secondaryPublicationIdentifiers,
-        dataUsagePolicy: this.dataUsagePolicy,
+        dataUsagePolicy: this.hasCustomUsagePolicy ? this.dataUsagePolicy : null,
         extraMetadata: {},
 
         scoreRanges: {

--- a/src/components/screens/ScoreSetEditor.vue
+++ b/src/components/screens/ScoreSetEditor.vue
@@ -158,17 +158,24 @@
                 <div v-if="itemStatus == 'NotLoaded' || this.item.private == true">
                   <div class="field">
                     <span class="p-float-label">
-                      <Dropdown v-model="licenseId" :id="$scopedId('input-targetLicenseId')" :options="licenses"
-                        optionLabel="longName" optionValue="id" style="width: 50%"/>
+                      <Dropdown v-model="licenseId" :id="$scopedId('input-targetLicenseId')" :options="selectableLicenses"
+                        optionLabel="longName" optionValue="id" style="width: 100%" />
                       <label :for="$scopedId('input-targetLicenseId')">License</label>
                     </span>
-                    <span v-if="validationErrors['targetSequence.taxonomy']" class="mave-field-error">{{validationErrors['targetSequence.taxonomy']}}</span>
+                    <span v-if="validationErrors.licenseId" class="mave-field-error">{{validationErrors.licenseId}}</span>
                   </div>
-                  <Message v-if="licenseId && licenses && licenses.find((l) => l.id == licenseId)?.shortName != 'CC0'"
-                    severity="warn">
-                    Choosing a license with these restrictions may cause your dataset to be excluded from data federation
-                    and aggregation by MaveDB collaborators.
-                  </Message>
+                  <div v-if="licenseId && licenses && licenses.find((l) => l.id == licenseId)?.active !== true">
+                    <Message severity="warn">
+                      The currently selected license is outdated and no longer supported for new score sets. We highly recommend switching to an updated license
+                      to ensure your dataset is not excluded from data federation and aggregation by MaveDB collaborators.
+                    </Message>
+                  </div>
+                  <div v-else-if="licenseId && licenses && licenses.find((l) => l.id == licenseId)?.shortName != 'CC0'">
+                    <Message severity="warn">
+                      Choosing a license with these restrictions may cause your dataset to be excluded from data federation
+                      and aggregation by MaveDB collaborators.
+                    </Message>
+                  </div>
                   <div class="field">
                     <span class="p-float-label">
                       <Chips
@@ -938,6 +945,9 @@
       defaultLicenseId: function () {
         return this.licenses ? this.licenses.find((license) => license.shortName == 'CC0')?.id : null
       },
+      selectableLicenses: function () {
+        return this.licenses ? this.licenses.filter((license) => this.licenseIsSelectable(license)) : []
+      },
       geneNamesAsObject: function () {
         // Heinous workaround for string filtration, see: https://github.com/primefaces/primevue/issues/2059
         // When this is fixed, we'll need to also remove object accessors in other miscellaneous helpers below.
@@ -1401,6 +1411,16 @@
         // if no search text, then return all taxonomy list. Otherwise, return the searching results.
         // If not do in this way, dropdown button can't work.
         this.setTaxonomySearch(event.query)
+      },
+
+      // A license is selectable if it is the active license for a score set or if it is marked as active
+      // in the backend.
+      licenseIsSelectable: function(license) {
+        if (this.item?.license.id === license.id) {
+          return true
+        } else {
+          return license.active
+        }
       },
 
       targetsCleared: function () {

--- a/src/lib/item-types.js
+++ b/src/lib/item-types.js
@@ -11,7 +11,7 @@ const itemTypes = {
     }
   },
   'controlled-keywords-variant-search': {
-    name: 'controlled-keywords-variant-library-search', 
+    name: 'controlled-keywords-variant-library-search',
     restCollectionName: 'controlled-keywords',
     httpOptions: {
       list: {
@@ -21,7 +21,7 @@ const itemTypes = {
     }
   },
   'controlled-keywords-endo-system-search': {
-    name: 'controlled-keyword-endogenous-locus-library-method-system', 
+    name: 'controlled-keyword-endogenous-locus-library-method-system',
     restCollectionName: 'controlled-keywords',
     httpOptions: {
       list: {
@@ -31,7 +31,7 @@ const itemTypes = {
     }
   },
   'controlled-keywords-endo-mechanism-search': {
-    name: 'controlled-keywords-endogenous-locus-library-method-mechanism', 
+    name: 'controlled-keywords-endogenous-locus-library-method-mechanism',
     restCollectionName: 'controlled-keywords',
     httpOptions: {
       list: {
@@ -41,7 +41,7 @@ const itemTypes = {
     }
   },
   'controlled-keywords-in-vitro-system-search': {
-    name: 'controlled-keywords-in-vitro-construct-library-method-system', 
+    name: 'controlled-keywords-in-vitro-construct-library-method-system',
     restCollectionName: 'controlled-keywords',
     httpOptions: {
       list: {
@@ -51,7 +51,7 @@ const itemTypes = {
     }
   },
   'controlled-keywords-in-vitro-mechanism-search': {
-    name: 'controlled-keywords-in-vitro-construct-library-method-mechanism', 
+    name: 'controlled-keywords-in-vitro-construct-library-method-mechanism',
     restCollectionName: 'controlled-keywords',
     httpOptions: {
       list: {
@@ -61,7 +61,7 @@ const itemTypes = {
     }
   },
   'controlled-keywords-delivery-search': {
-    name: 'controlled-keywords-delivery-method', 
+    name: 'controlled-keywords-delivery-method',
     restCollectionName: 'controlled-keywords',
     httpOptions: {
       list: {
@@ -71,7 +71,7 @@ const itemTypes = {
     }
   },
   'controlled-keywords-phenotypic-dimensionality-search': {
-    name: 'controlled-keywords-phenotypic-assay-dimensionality', 
+    name: 'controlled-keywords-phenotypic-assay-dimensionality',
     restCollectionName: 'controlled-keywords',
     httpOptions: {
       list: {
@@ -81,7 +81,7 @@ const itemTypes = {
     }
   },
   'controlled-keywords-phenotypic-method-search': {
-    name: 'controlled-keywords-phenotypic-assay-method', 
+    name: 'controlled-keywords-phenotypic-assay-method',
     restCollectionName: 'controlled-keywords',
     httpOptions: {
       list: {
@@ -91,7 +91,7 @@ const itemTypes = {
     }
   },
   'controlled-keywords-phenotypic-modle-system-search': {
-    name: 'controlled-keywords-phenotypic-assay-model-system', 
+    name: 'controlled-keywords-phenotypic-assay-model-system',
     restCollectionName: 'controlled-keywords',
     httpOptions: {
       list: {
@@ -101,7 +101,7 @@ const itemTypes = {
     }
   },
   'controlled-keywords-phenotypic-profiling-strategy-search': {
-    name: 'controlled-keywords-phenotypic-assay-profiling-strategy', 
+    name: 'controlled-keywords-phenotypic-assay-profiling-strategy',
     restCollectionName: 'controlled-keywords',
     httpOptions: {
       list: {
@@ -111,7 +111,7 @@ const itemTypes = {
     }
   },
   'controlled-keywords-phenotypic-sequencing-type-search': {
-    name: 'controlled-keywords-phenotypic-assay-sequencing-read-type', 
+    name: 'controlled-keywords-phenotypic-assay-sequencing-read-type',
     restCollectionName: 'controlled-keywords',
     httpOptions: {
       list: {
@@ -143,6 +143,16 @@ const itemTypes = {
   'license': {
     name: 'license', // TODO Redundant, change this structure
     restCollectionName: 'licenses'
+  },
+  'active-license': {
+    name: 'active-license', // TODO Redundant, change this structure
+    restCollectionName: 'active-licenses',
+    httpOptions: {
+      list: {
+        method: 'get',
+        url: `${config.apiBaseUrl}/licenses/active`
+      }
+    }
   },
   'pubmedPublicationIdentifier': {
     name: 'pubmedPublicationIdentifier', // TODO Redundant, change this structure


### PR DESCRIPTION
During score set creation, we now only display active licenses to the user for selection. Because some score sets may have licenses selected which are no longer active, these licenses may be retained if they exist on a score set, but are un-selectable otherwise. Once a user updates a score set to get rid of such licenses, they will no longer be selectable. In addition, a new warning is displayed while editing such score sets so users are notified they are using a deprecated license.

Coupled to https://github.com/VariantEffect/mavedb-api/pull/344