### PR TITLE
Fixed: Nucleotide heatmap was not displayed for regulatory targets.

### DIFF
--- a/src/components/ScoreSetHeatmap.vue
+++ b/src/components/ScoreSetHeatmap.vue
@@ -91,7 +91,9 @@ export default {
       return [...this.simpleVariants || [], ...this.wtVariants || []]
     },
     isNucleotideHeatmap: function() {
-      return _.get(this.scoreSet, 'targetGenes[0].category') === 'other_noncoding'
+      const targetCategory = _.get(this.scoreSet, 'targetGenes[0].category')
+      const proteinVariantsAreDefined = this.scores.every((elem) => elem.hgvs_pro !== null)
+      return !proteinVariantsAreDefined && (targetCategory === 'other_noncoding' || targetCategory == "regulatory")
     },
     heatmapRows: function() {
       return this.isNucleotideHeatmap ? HEATMAP_NUCLEOTIDE_ROWS : HEATMAP_AMINO_ACID_ROWS


### PR DESCRIPTION
This change allows a nucleotide heatmap to be displayed for non-coding and regulatory targets. We will prefer the protein heatmap, displaying it if all protein variants are defined. If not, we fall back to the nucleotide heatmap for non-coding and regulatory target categories.