### PR TITLE
Support for Base Editor Data

### DIFF
--- a/src/components/screens/ScoreSetCreator.vue
+++ b/src/components/screens/ScoreSetCreator.vue
@@ -551,6 +551,20 @@
                   </div>
                 </div>
 
+                <div v-if="!isTargetSequence" class="mavedb-wizard-row">
+                  <div class="mavedb-wizard-help">
+                    <label :id="$scopedId('input-isBaseEditorData')">Does this score set reperesent base editor data?</label>
+                    <div class="mavedb-help-small">
+                      Base editor data is a type of functional assay that is similar in many respects to MAVE data. When uploading base editor data, you must
+                      also include a 'guide_sequence' column in your uploaded scores (and counts) file(s).
+                    </div>
+                  </div>
+                  <div class="mavedb-wizard-content">
+                    <InputSwitch v-model="isBaseEditor" :aria-labelledby="$scopedId('input-isBaseEditorData')"/>
+                    <div class="mavedb-switch-value">{{ isBaseEditor ? 'Yes, this score set represents base editor data.' : 'No, this score set does not represent base editor data.' }}</div>
+                  </div>
+                </div>
+
                 <div class="mavedb-wizard-row">
                   <div class="mavedb-wizard-help">
                     <label :id="$scopedId('input-scoreSetHasMultipleTargetsLabel')">Does this score set describe variants with respect to more than one target?</label>
@@ -1341,6 +1355,7 @@ export default {
     validationErrors: {},
 
     isTargetSequence: true,
+    isBaseEditor: false,
     isMultiTarget: false,
     isProvidingScoreRanges: false,
 
@@ -2236,6 +2251,10 @@ export default {
 
             if (!this.isTargetSequence && !target.isRelativeToChromosome) {
               targetGene.targetAccession.gene = targetGene.targetAccession.gene.name
+            }
+
+            if (!this.isTargetSequence) {
+              targetGene.targetAccession.isBaseEditor = this.isBaseEditor
             }
 
             return targetGene

--- a/src/components/screens/ScoreSetEditor.vue
+++ b/src/components/screens/ScoreSetEditor.vue
@@ -640,6 +640,13 @@
                         </template>
                       </DataTable>
                     </span>
+
+                    <div class="field-column">
+                      <div class="field" style="margin-top: 1em;">
+                        <InputSwitch v-model="isBaseEditor" :aria-labelledby="$scopedId('input-isBaseEditorData')"/>
+                        <span style="margin-left: 1em;">{{ isBaseEditor ? 'This score set represents base editor data.' : 'This score set does not represent base editor data.' }}</span>
+                      </div>
+                    </div>
                   </div>
                   <span v-if="validationErrors['targetGenes']" class="mave-field-error">{{validationErrors['targetGenes']}}</span>
                   <div class="field">
@@ -720,6 +727,7 @@
   import InputGroupAddon from 'primevue/inputgroupaddon'
   import InputNumber from 'primevue/inputnumber'
   import InputText from 'primevue/inputtext'
+  import InputSwitch from 'primevue/inputswitch'
   import Message from 'primevue/message'
   import Multiselect from 'primevue/multiselect'
   import ProgressSpinner from 'primevue/progressspinner'
@@ -784,7 +792,7 @@ import { TARGET_GENE_CATEGORIES, textForTargetGeneCategory } from '@/lib/target-
 
   export default {
     name: 'ScoreSetEditor',
-    components: { AutoComplete, Button, Card, Chips, Column, Checkbox, DataTable, DefaultLayout, Dropdown, EmailPrompt, EntityLink, FileUpload, InputGroup, InputGroupAddon, InputNumber, InputText, Message, Multiselect, ProgressSpinner, SelectButton, TabPanel, TabView, Textarea },
+    components: { AutoComplete, Button, Card, Chips, Column, Checkbox, DataTable, DefaultLayout, Dropdown, EmailPrompt, EntityLink, FileUpload, InputGroup, InputGroupAddon, InputNumber, InputText, InputSwitch, Message, Multiselect, ProgressSpinner, SelectButton, TabPanel, TabView, Textarea },
 
     setup: () => {
       const publicationIdentifierSuggestions = useItems({ itemTypeName: 'publication-identifier-search' })
@@ -899,7 +907,9 @@ import { TARGET_GENE_CATEGORIES, textForTargetGeneCategory } from '@/lib/target-
       metaAnalyzesScoreSetSuggestions: [],
       supersededScoreSetSuggestions: [],
       targetGeneAccessionSuggestions: [],
-      validationErrors: {}
+      validationErrors: {},
+
+      isBaseEditor: false
     }),
 
     computed: {
@@ -1551,6 +1561,10 @@ import { TARGET_GENE_CATEGORIES, textForTargetGeneCategory } from '@/lib/target-
             this.scoreRangeBoundaryHelper[idx].upperBoundIsInfinity = this.scoreRanges.ranges[idx].range[1] === null
           })
           this.extraMetadata = this.item.extraMetadata
+
+          if (this.targetGenes[0]?.targetAccession) {
+            this.isBaseEditor = this.targetGenes[0].targetAccession.isBaseEditor
+          }
         } else {
           this.experiment = null
           this.licenseId = this.defaultLicenseId
@@ -1660,7 +1674,12 @@ import { TARGET_GENE_CATEGORIES, textForTargetGeneCategory } from '@/lib/target-
           dataUsagePolicy: this.dataUsagePolicy,
           extraMetadata: {},
           // eslint-disable-next-line no-unused-vars
-          targetGenes: this.targetGenes.map(({ index, ...target }) => target), // drop index property from target genes before save
+          targetGenes: this.targetGenes.map(({ index, ...target }) => {  // drop index property from target genes before save
+            if (target.targetAccession) {
+              target.targetAccession.isBaseEditor = this.isBaseEditor
+            }
+            return target
+          }),
           scoreRanges: this.scoreRanges
         }
         if (!this.item) {

--- a/src/components/screens/ScoreSetView.vue
+++ b/src/components/screens/ScoreSetView.vue
@@ -290,6 +290,11 @@
             </div>
             <br>
           </div>
+          <div v-if="item.targetGenes[0].targetAccession">
+            <div v-if="item.targetGenes[0].targetAccession.isBaseEditor">
+              <strong>*This score set represents base editor data.</strong>
+            </div>
+          </div>
         </div>
 
         <div class="mave-score-set-section-title">Score Ranges</div>


### PR DESCRIPTION
Adds base editor support during creation and editing of score sets. Adds a note to the score set viewer under the targets when a score set represents base editor data.