### PR TITLE
Update ScoreSetCreator and Editor to support object based external identifier setting

### DIFF
--- a/src/components/screens/ScoreSetCreator.vue
+++ b/src/components/screens/ScoreSetCreator.vue
@@ -693,9 +693,9 @@
                             <AutoComplete style="width: 100%;"
                                 v-model="createdTargetGenes[targetIdx].targetGene.externalIdentifiers[dbName].identifier"
                                 :id="$scopedId(`input-${dbName.toLowerCase()}Identifier`)" field="identifier"
-                                :suggestions="targetGeneIdentifierSuggestionsList[dbName]" :forceSelection="true"
+                                :suggestions="targetGeneIdentifierSuggestionsList[dbName]" :forceSelection="false"
                                 @complete="searchTargetGeneIdentifiers(dbName, $event)"
-                                @change="addDefaultOffset(dbName, targetIdx)"
+                                @change="addDefaultOffset(dbName, targetIdx); externalIdentifierTextToObject(dbName, targetIdx, $event)"
                               />
                             <label :for="$scopedId(`input-${dbName.toLowerCase()}Identifier`)">{{ dbName }} identifier</label>
                           </div>
@@ -1971,6 +1971,20 @@ export default {
       const currentTargetGene = this.createdTargetGenes[targetIdx].targetGene
       if (!currentTargetGene.externalIdentifiers[dbName]?.offset){
         currentTargetGene.externalIdentifiers[dbName].offset = 0
+      }
+    },
+
+    externalIdentifierTextToObject: function (dbName, targetIdx, event) {
+      const currentTargetGene = this.createdTargetGenes[targetIdx].targetGene
+      const externalIdentifier = currentTargetGene.externalIdentifiers[dbName]
+
+      if (!event.value) {
+        externalIdentifier.identifier = null
+        return
+      }
+
+      if (!externalIdentifier.identifier?.identifier) {
+        externalIdentifier.identifier = { identifier: event.value, dbName: dbName }
       }
     },
 

--- a/src/components/screens/ScoreSetEditor.vue
+++ b/src/components/screens/ScoreSetEditor.vue
@@ -1367,13 +1367,13 @@ import { TARGET_GENE_CATEGORIES, textForTargetGeneCategory } from '@/lib/target-
 
         // Only accept the current search text if we haven't set an identifier. When the user starts typing, the current
         // identifier is cleared.
-        const currentIdentifier = this.targetGene.externalIdentifiers[dbName]?.identifier
+        const currentIdentifier = this.targetGene.externalIdentifiers[dbName]?.identifier?.identifier
         if (!currentIdentifier) {
           if (searchText == '') {
             this.targetGene.externalIdentifiers[dbName].identifier = null
           } else if (validateIdentifier(dbName, searchText)) {
             const identifier = normalizeIdentifier(dbName, searchText)
-            this.targetGene.externalIdentifiers[dbName].identifier = { identifier }
+            this.targetGene.externalIdentifiers[dbName].identifier = { identifier: identifier, dbName: dbName }
             input.modelValue = null
 
             // Clear the text input.


### PR DESCRIPTION
Previously, trying to add a external gene identifier that was not already present in our database would result in the front end silently ignoring the user input. This change removes the restriction that user input be selected from the autocomplete list and fixes the input so that it is in the format expected by the score set creation schema.