### PR TITLE
Filter targetGeneSuggestionsList to only include target sequence based targets

### DIFF
--- a/src/components/screens/ScoreSetCreator.vue
+++ b/src/components/screens/ScoreSetCreator.vue
@@ -1393,7 +1393,12 @@ export default {
       return this.suggestionsForAutocomplete(this.supersededScoreSetSuggestions)
     },
     targetGeneSuggestionsList: function () {
-      return this.suggestionsForAutocomplete(this.targetGeneSuggestions)
+      const geneSuggestions = this.targetGeneSuggestions || []
+      const filteredGeneSuggestions = geneSuggestions.filter(gene => {
+        const seq = gene?.targetSequence
+        return seq && seq.sequence && seq.sequenceType
+      })
+      return this.suggestionsForAutocomplete(filteredGeneSuggestions)
     },
     taxonomySuggestionsList: function() {
       return this.suggestionsForAutocomplete(this.taxonomySuggestions)

--- a/src/components/screens/ScoreSetEditor.vue
+++ b/src/components/screens/ScoreSetEditor.vue
@@ -922,7 +922,12 @@ import { TARGET_GENE_CATEGORIES, textForTargetGeneCategory } from '@/lib/target-
         return this.suggestionsForAutocomplete(this.supersededScoreSetSuggestions)
       },
       targetGeneSuggestionsList: function () {
-        return this.suggestionsForAutocomplete(this.targetGeneSuggestions)
+        const geneSuggestions = this.targetGeneSuggestions || []
+        const filteredGeneSuggestions = geneSuggestions.filter(gene => {
+          const seq = gene?.targetSequence
+          return seq && seq.sequence && seq.sequenceType
+        })
+        return this.suggestionsForAutocomplete(filteredGeneSuggestions)
       },
       taxonomySuggestionsList: function() {
         return this.suggestionsForAutocomplete(this.taxonomySuggestions)


### PR DESCRIPTION
Not showing the existing target genes that only have accessions in autocomplete options. 