### PR TITLE
Add Variant Search to Global Search

### DIFF
--- a/src/components/screens/SearchVariantsScreen.vue
+++ b/src/components/screens/SearchVariantsScreen.vue
@@ -8,7 +8,7 @@
         <div class="flex flex-wrap justify-content-center gap-3">
           <IconField iconPosition="left">
             <InputIcon class="pi pi-search"></InputIcon>
-            <InputText v-model="searchText" ref="searchTextInput" type="search" class="p-inputtext-sm" placeholder="HGVS string" style="width: 500px;" />
+            <InputText v-model="searchText" @keyup.enter="hgvsSearch" ref="searchTextInput" type="search" class="p-inputtext-sm" placeholder="HGVS string" style="width: 500px;" />
           </IconField>
           <Button class="p-button-plain" @click="hgvsSearch">Search</Button>
         </div>

--- a/src/components/screens/SearchVariantsScreen.vue
+++ b/src/components/screens/SearchVariantsScreen.vue
@@ -113,6 +113,7 @@ import InputText from 'primevue/inputtext'
 import Button from 'primevue/button'
 import Message from 'primevue/message'
 import {defineComponent} from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 // import {debounce} from 'vue-debounce'
 
 import config from '@/config'
@@ -124,6 +125,11 @@ const SCORE_SETS_TO_SHOW = 5
 export default defineComponent({
   name: 'SearchVariantsScreen',
   components: {Card, Column, DataTable, DefaultLayout, Dropdown, EntityLink, IconField, InputIcon, InputText, Button, Message},
+  setup() {
+    const route = useRoute()
+    const router = useRouter()
+    return { route, router }
+  },
 
   data: function() {
     return {
@@ -175,6 +181,46 @@ export default defineComponent({
         }
       }
     },
+    '$route.query.search': {
+      immediate: true,
+      handler(newVal) {
+        if (typeof newVal === 'string') {
+          this.searchText = newVal
+        } else if (!newVal) {
+          this.searchText = ''
+        }
+      }
+    },
+    '$route.query.gene': {
+      immediate: true,
+      handler(newVal) {
+        this.inputGene = typeof newVal === 'string' ? newVal : ''
+      }
+    },
+    '$route.query.variantType': {
+      immediate: true,
+      handler(newVal) {
+        this.inputVariantType = typeof newVal === 'string' ? newVal : ''
+      }
+    },
+    '$route.query.variantPosition': {
+      immediate: true,
+      handler(newVal) {
+        this.inputVariantPosition = typeof newVal === 'string' ? newVal : ''
+      }
+    },
+    '$route.query.refAllele': {
+      immediate: true,
+      handler(newVal) {
+        this.inputReferenceAllele = typeof newVal === 'string' ? newVal : ''
+      }
+    },
+    '$route.query.altAllele': {
+      immediate: true,
+      handler(newVal) {
+        this.inputAlternateAllele = typeof newVal === 'string' ? newVal : ''
+      }
+    },
   },
 
   computed: {
@@ -196,6 +242,11 @@ export default defineComponent({
 
   methods: {
     hgvsSearch: async function() {
+      // Remove fuzzy search params from the URL
+      const { gene, variantType, variantPosition, refAllele, altAllele, ...rest } = this.route.query;
+      this.router.replace({
+        query: { ...rest, search: this.searchText || undefined }
+      })
       this.alleles = []
       this.loading = true;
       if (this.searchText !== null && this.searchText !== '') {
@@ -280,6 +331,18 @@ export default defineComponent({
       }
     },
     fuzzySearch: async function() {
+      // Remove HGVS search param from the URL
+      const { search, ...rest } = this.route.query;
+      this.router.replace({
+        query: {
+          ...rest,
+          gene: this.inputGene || undefined,
+          variantType: this.inputVariantType || undefined,
+          variantPosition: this.inputVariantPosition || undefined,
+          refAllele: this.inputReferenceAllele || undefined,
+          altAllele: this.inputAlternateAllele || undefined
+        }
+      })
       this.alleles = []
       this.loading = true;
       await this.fetchFuzzySearchResults()
@@ -357,7 +420,28 @@ export default defineComponent({
         }
       }
     }
+  },
+
+  mounted() {
+    // If HGVS search param is present, run HGVS search
+    if (this.route.query.search && String(this.route.query.search).trim() !== '') {
+      this.hgvsSearchVisible = true;
+      this.fuzzySearchVisible = false;
+      this.hgvsSearch();
+    } else if (
+      this.route.query.gene ||
+      this.route.query.variantType ||
+      this.route.query.variantPosition ||
+      this.route.query.refAllele ||
+      this.route.query.altAllele
+    ) {
+      // If any fuzzy search param is present, run fuzzy search
+      this.hgvsSearchVisible = false;
+      this.fuzzySearchVisible = true;
+      this.fuzzySearch();
+    }
   }
+
 })
 
 </script>

--- a/src/components/screens/SearchView.vue
+++ b/src/components/screens/SearchView.vue
@@ -60,6 +60,7 @@ import { paths, components } from '@/schema/openapi'
 
 import type {LocationQueryValue} from "vue-router";
 import { textForTargetGeneCategory } from '@/lib/target-genes'
+import { routeToVariantSearchIfVariantIsSearchable } from '@/lib/search'
 
 type ShortScoreSet = components['schemas']['ShortScoreSet']
 type ShortTargetGene = components['schemas']['ShortTargetGene']
@@ -316,6 +317,12 @@ export default defineComponent({
       this.debouncedSearchFunction()
     },
     search: async function() {
+      // TODO#410 Because of the debounced search, this is super aggressive and will send the user to the variant search page as they are
+      // typing. I'm not sure that is the best user experience, but it seems unlikely people will actually be typing an HGVS string.
+      if (routeToVariantSearchIfVariantIsSearchable(this.searchText)) {
+        return
+      }
+
       this.$router.push({query: {
         ...(this.searchText && this.searchText.length > 0) ? {search: this.searchText} : {},
         ...(this.filterTargetNames.length > 0) ? {'target-name': this.filterTargetNames} : {},

--- a/src/lib/mave-hgvs.ts
+++ b/src/lib/mave-hgvs.ts
@@ -122,3 +122,13 @@ export function preferredVariantLabel(variant: SimpleMaveVariant): VariantLabel 
     return {mavedb_label: variant.accession}
   }
 }
+
+
+/**
+ * Regular expression for parsing a generic HGVS style variant.
+ *
+ * This should be used only for deciding whether a string is a valid HGVS variant, not for parsing it.
+ * It matches a string that starts with an identifier (e.g., "NM_001301717.2") followed by a colon and a description.
+ * The description can be anything (which isn't technically correct), including spaces and special characters.
+ */
+export const genericVariant = /^(?<identifier>[A-z_0-9.]+):(?<description>.*)$/gm

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,0 +1,59 @@
+import router from '@/router'
+import { genericVariant } from "./mave-hgvs"
+
+export function routeToVariantSearchIfVariantIsSearchable(searchText: string | null | undefined): boolean {
+    if (!searchText || searchText.trim() === '') {
+        return false
+    }
+
+    searchText = searchText.trim()
+    const hgvsMatches = genericVariant.exec(searchText)
+    if (hgvsMatches && hgvsMatches.groups) {
+        const identifier = hgvsMatches.groups.identifier
+        const description = hgvsMatches.groups.description
+
+        // Regex for RefSeq/Ensembl transcript IDs
+        const transcriptRegex = /^(N[CMPR]_|X[MR]_|ENST|ENSMUST|ENSMUST|XM_|XR_)[0-9]+(\.[0-9]+)?$/gm
+        if (transcriptRegex.test(identifier)) {
+            // Transcript: treat as normal HGVS
+            console.log(`Routing to search-variants with HGVS: ${hgvsMatches[0]}`)
+            router.push({ name: 'search-variants', query: { search: hgvsMatches[0] } })
+        } else {
+            // Assume identifier is an HGNC gene symbol, parse description for fuzzy search
+            // Example: BRCA1:c.123A>G or BRCA1:p.Arg123Gly
+            let gene = identifier
+            let variantType = ''
+            let variantPosition = ''
+            let refAllele = ''
+            let altAllele = ''
+
+            // Try to parse c. or p. notation
+            const fuzzyMatch = /^(c\.|p\.)?([A-Za-z]+)?([0-9]+)([A-Za-z*-]+)?(?:>([A-Za-z*-]+))?$/gm.exec(description)
+            if (fuzzyMatch) {
+                variantType = fuzzyMatch[1] || ''
+                if (variantType === 'c.') {
+                    variantPosition = fuzzyMatch[3] || ''
+                    refAllele = fuzzyMatch[4] || ''
+                    altAllele = fuzzyMatch[5] || ''
+                } else if (variantType === 'p.') {
+                    refAllele = fuzzyMatch[2] || ''
+                    variantPosition = fuzzyMatch[3] || ''
+                    altAllele = fuzzyMatch[4] || ''
+                }
+            }
+
+            router.push({
+                name: 'search-variants',
+                query: {
+                    gene,
+                    variantType,
+                    variantPosition,
+                    refAllele,
+                    altAllele
+                }
+            })
+        }
+        return true
+    }
+    return false
+}


### PR DESCRIPTION
Closes #408 

This pull request introduces enhancements to the variant search functionality, including support for HGVS string parsing, routing improvements, and query parameter handling.

### Enhancements to HGVS Search Functionality:
* Added an `@keyup.enter` event to the `InputText` component to trigger the `hgvsSearch` method when the Enter key is pressed, improving usability for keyboard users. (`src/components/screens/SearchVariantsScreen.vue`, [src/components/screens/SearchVariantsScreen.vueL11-R11](diffhunk://#diff-f588bed0e1f93a557eeb6be191d51dc5a16cde2a00d249de4bd32ddac158b585L11-R11))
* Introduced a regular expression (`genericVariant`) for identifying and validating HGVS-style variants, which is now used to determine if a search string is a valid HGVS query. (`src/lib/mave-hgvs.ts`, [src/lib/mave-hgvs.tsR125-R134](diffhunk://#diff-20be152becfc62d424d0b5d542826cfc0bb09fdf9c03c8d6f9b28cf974cd46a0R125-R134))

### Query Parameter Handling:
* Added watchers for query parameters (`$route.query.*`) to dynamically update corresponding input fields and trigger searches when the route changes. This ensures the application's state stays in sync with the URL. (`src/components/screens/SearchVariantsScreen.vue`, [src/components/screens/SearchVariantsScreen.vueR184-R223](diffhunk://#diff-f588bed0e1f93a557eeb6be191d51dc5a16cde2a00d249de4bd32ddac158b585R184-R223))
* Implemented logic in the `mounted` hook to automatically trigger either an HGVS search or a fuzzy search based on the presence of specific query parameters in the URL. (`src/components/screens/SearchVariantsScreen.vue`, [src/components/screens/SearchVariantsScreen.vueR423-R444](diffhunk://#diff-f588bed0e1f93a557eeb6be191d51dc5a16cde2a00d249de4bd32ddac158b585R423-R444))

### Routing Improvements:
* Introduced the `routeToVariantSearchIfVariantIsSearchable` function to handle routing based on the validity of the search text. This function supports both HGVS and fuzzy search routing by parsing the search string and updating the URL accordingly. (`src/lib/search.ts`, [src/lib/search.tsR1-R59](diffhunk://#diff-82164b7feebd2bb287f266221d19e985054c7ccf2f3b0e45a6421a5b0ef9e823R1-R59))
* Updated the `hgvsSearch` and `fuzzySearch` methods to clean up unrelated query parameters from the URL when switching between search types. (`src/components/screens/SearchVariantsScreen.vue`, [[1]](diffhunk://#diff-f588bed0e1f93a557eeb6be191d51dc5a16cde2a00d249de4bd32ddac158b585R245-R249) [[2]](diffhunk://#diff-f588bed0e1f93a557eeb6be191d51dc5a16cde2a00d249de4bd32ddac158b585R334-R345)

### Integration with SearchView:
* Integrated the `routeToVariantSearchIfVariantIsSearchable` function into the `SearchView` component to redirect users to the variant search page when a valid HGVS string is detected during typing. Note that since the toolbar funnels users to the search page, this also routes toolbar requests by proxy. (`src/components/screens/SearchView.vue`, [[1]](diffhunk://#diff-d84f04ef48c0df6e7e0ca63af7f8d03d086c33d0c6e123becaf4dbc8e654ba6bR63) [[2]](diffhunk://#diff-d84f04ef48c0df6e7e0ca63af7f8d03d086c33d0c6e123becaf4dbc8e654ba6bR320-R325)