### PR TITLE
Add Help & Support Page with Dedicated Forum Linkouts

### DIFF
--- a/src/components/layout/Toolbar.vue
+++ b/src/components/layout/Toolbar.vue
@@ -8,7 +8,9 @@
   </div>
   <div class="mavedb-toolbar">
     <div v-if="config.PREVIEW_SITE" class="mavedb-beta-banner">
-      This is a beta test site. For the production site, please visit <a href="https://mavedb.org.">mavedb.org</a>.
+      This is a beta test site. For the production site, please visit <a href="https://mavedb.org.">mavedb.org</a>. To
+      give feedback, please use our
+      <a href="https://mavedb.zulipchat.com/#narrow/channel/511813-beta-testers">Zulip message board</a>.
     </div>
     <Menubar class="mavedb-menubar" :model="availableMenuItems">
       <template #start>
@@ -288,5 +290,6 @@ export default {
 
 .mavedb-beta-banner a {
   color: #fff;
+  text-decoration: underline;
 }
 </style>

--- a/src/components/layout/Toolbar.vue
+++ b/src/components/layout/Toolbar.vue
@@ -113,8 +113,17 @@ export default {
           route: '/search'
         },
         {
-          label: 'Documentation',
-          route: '/docs'
+          label: 'Support',
+          items: [
+            {
+              label: 'Get Help',
+              route: '/help'
+            },
+            {
+              label: 'Documentation',
+              route: '/docs'
+            }
+          ]
         },
         {
           label: 'New experiment',

--- a/src/components/screens/HelpScreen.vue
+++ b/src/components/screens/HelpScreen.vue
@@ -1,0 +1,73 @@
+<template>
+  <DefaultLayout>
+    <div class="help-screen-container">
+      <h1>Help & Support</h1>
+      <p>
+        Welcome to MaveDB! If you need assistance, want to report a bug, or have a feature request, you're in the right
+        place.
+      </p>
+      <ul>
+        <li>
+          <strong>Chat with us:</strong>
+          <a href="https://zulip.mavedb.com" target="_blank" rel="noopener"> Join our Zulip chat</a> to ask questions,
+          get help, or discuss upcoming development work.
+        </li>
+        <li>
+          <strong>Documentation:</strong>
+          <a href="/docs" target="_blank" rel="noopener"> Check out our documentation</a> for guides and reference.
+        </li>
+        <li>
+          <strong>Submit a bug report or feature request:</strong>
+          You can use our <a href="https://zulip.mavedb.com" target="_blank" rel="noopener">Zulip chat</a> to let us
+          know about any
+          <a
+            href="https://mavedb.zulipchat.com/#narrow/channel/511174-bug-reports/topic/channel.20events/with/525122858"
+            target="_blank"
+            rel="noopener"
+            >bugs</a
+          >
+          causing you problems or any
+          <a
+            href="https://mavedb.zulipchat.com/#narrow/channel/511173-features/topic/channel.20events/with/525122848"
+            target="_blank"
+            rel="noopener"
+            >features</a
+          >
+          you'd like to see. Alternatively, you can submit an issue directly on our
+          <a href="github.com/varianteffect/mavedb-ui/issues" target="_blank" rel="noopener">GitHub repository</a>.
+        </li>
+      </ul>
+    </div>
+  </DefaultLayout>
+</template>
+
+<script>
+import DefaultLayout from '@/components/layout/DefaultLayout.vue'
+
+export default {
+  name: 'HelpScreen',
+  components: {DefaultLayout}
+}
+</script>
+
+<style scoped>
+.help-screen-container {
+  margin: 40px auto;
+  padding: 32px;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+}
+.help-screen-container h1 {
+  margin-top: 0px;
+  margin-bottom: 20px;
+}
+.help-screen-container ul {
+  margin: 20px 0;
+  padding-left: 20px;
+}
+.help-screen-container li {
+  margin-bottom: 16px;
+  font-size: 1.1em;
+}
+</style>

--- a/src/components/screens/HomeScreen.vue
+++ b/src/components/screens/HomeScreen.vue
@@ -108,6 +108,10 @@
                 </td>
               </tr>
             </table>
+            <p>
+              To provide feedback, please join our Zulip message board. Use <a href="https://mavedb.zulipchat.com/join/5cvqzctbnme2lqmjwnbjg4ty/">this link</a> to join the
+              organization. Once you have joined, you can create topics for discussion in the <a href="https://mavedb.zulipchat.com/#narrow/channel/511813-beta-testers">beta-testers channel</a>.
+            </p>
           </template>
         </Card>
       </div>

--- a/src/components/screens/HomeScreen.vue
+++ b/src/components/screens/HomeScreen.vue
@@ -136,6 +136,10 @@
               and the
               <a href="https://brotmanbaty.org/">Brotman Baty Institute.</a>
             </p>
+            <p>
+              If you have questions, comments, or suggestions, check out the <router-link to="/help">Help & Support</router-link> page
+              for information about how to get in touch.
+            </p>
           </template>
         </Card>
       </div>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -9,6 +9,7 @@ import ExperimentCreator from '@/components/screens/ExperimentCreator.vue'
 import ExperimentEditor from '@/components/screens/ExperimentEditor.vue'
 import ExperimentSetView from '@/components/screens/ExperimentSetView.vue'
 import ExperimentView from '@/components/screens/ExperimentView.vue'
+import HelpScreen from '@/components/screens/HelpScreen.vue'
 import HomeScreen from '@/components/screens/HomeScreen.vue'
 import OidcCallback from '@/components/screens/OidcCallback.vue'
 import OidcCallbackError from '@/components/screens/OidcCallbackError.vue'
@@ -69,6 +70,10 @@ const routes: RouteRecordRaw[] = [
     meta: {
       title: import.meta.env.VITE_SITE_TITLE + ' | Documentation'
     }
+  },
+  {
+    path: '/help',
+    component: HelpScreen,
   },
   {
     path: '/settings',

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -73,7 +73,7 @@ const routes: RouteRecordRaw[] = [
   },
   {
     path: '/help',
-    component: HelpScreen,
+    component: HelpScreen
   },
   {
     path: '/settings',


### PR DESCRIPTION
This pull request introduces a dedicated help screen and updates to the navigation and routing to integrate this feature.

### Navigation Updates:
* Added a "Support" menu item to the toolbar, which includes links to "Get Help" and "Documentation" (`src/components/layout/Toolbar.vue`).

### Help Screen Implementation:
* Created a new `HelpScreen` component with a user-friendly interface providing links to chat support, documentation, and bug/feature reporting (`src/components/screens/HelpScreen.vue`).

### Routing Updates:
* Imported the `HelpScreen` component into the router configuration (`src/router/index.js`).
* Added a new route for the `/help` path, which renders the `HelpScreen` component (`src/router/index.js`).