### PR TITLE
Score Range Boundary Handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,11 @@
       "version": "2025.2.1",
       "dependencies": {
         "@fontsource/raleway": "^5.0.16",
+        "@fortawesome/fontawesome-svg-core": "^7.0.0",
+        "@fortawesome/free-brands-svg-icons": "^7.0.0",
+        "@fortawesome/free-regular-svg-icons": "^7.0.0",
+        "@fortawesome/free-solid-svg-icons": "^7.0.0",
+        "@fortawesome/vue-fontawesome": "^3.1.1",
         "axios": "^1.8.2",
         "chart.js": "^4.4.1",
         "d3": "^7.9.0",
@@ -631,6 +636,67 @@
       "resolved": "https://registry.npmjs.org/@fontsource/raleway/-/raleway-5.1.1.tgz",
       "integrity": "sha512-gCLRJLqdUYI7BDSzvoMFOSNvS4NXUIqSdzQ7PTEqoQDHWLTcoA0xhXgljivmVbJ2ziJq1NZO7tYpDLMlIFe66g==",
       "license": "OFL-1.1"
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.0.0.tgz",
+      "integrity": "sha512-PGMrIYXLGA5K8RWy8zwBkd4vFi4z7ubxtet6Yn13Plf6krRTwPbdlCwlcfmoX0R7B4Z643QvrtHmdQ5fNtfFCg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.0.0.tgz",
+      "integrity": "sha512-obBEF+zd98r/KtKVW6A+8UGWeaOoyMpl6Q9P3FzHsOnsg742aXsl8v+H/zp09qSSu/a/Hxe9LNKzbBaQq1CEbA==",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "7.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-brands-svg-icons": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-7.0.0.tgz",
+      "integrity": "sha512-C8oY28gq/Qx/cHReJa2AunKJUHvUZDVoPlSTHtAvjriaNfi+5nugW4cx7yA/xN3f/nYkElw11gFBoJ2xUDDFgg==",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "7.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-7.0.0.tgz",
+      "integrity": "sha512-qAh0mTaCY22sQzMK2lKBrtn/aR4keUu5XmtdYR7d702laMe0h+Ab4Kj2pExR9HZkKhjKoq8pbwt8Td+mjW/ipQ==",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "7.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.0.0.tgz",
+      "integrity": "sha512-njSLAllkOddYDCXgTFboXn54Oe5FcvpkWq+FoetOHR64PbN0608kM02Lze0xtISGpXgP+i26VyXRQA0Irh3Obw==",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "7.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/vue-fontawesome": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-3.1.1.tgz",
+      "integrity": "sha512-U5azn4mcUVpjHe4JO0Wbe7Ih8e3VbN83EH7OTBtA5/QGw9qcPGffqcmwsLyZYgEkpVkYbq/6dX1Iyl5KUGMp6Q==",
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6 || ~7",
+        "vue": ">= 3.0.0 < 4"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,11 @@
   },
   "dependencies": {
     "@fontsource/raleway": "^5.0.16",
+    "@fortawesome/fontawesome-svg-core": "^7.0.0",
+    "@fortawesome/free-brands-svg-icons": "^7.0.0",
+    "@fortawesome/free-regular-svg-icons": "^7.0.0",
+    "@fortawesome/free-solid-svg-icons": "^7.0.0",
+    "@fortawesome/vue-fontawesome": "^3.1.1",
     "axios": "^1.8.2",
     "chart.js": "^4.4.1",
     "d3": "^7.9.0",

--- a/src/components/RangeTable.vue
+++ b/src/components/RangeTable.vue
@@ -49,7 +49,9 @@
                     </tr>
                     <tr>
                         <td v-for="range in abnormalRanges.concat(normalRanges)" :key="range.label">
-                            <span>{{ range.range[0] !== null ? range.range[0] : "-Infinity" }} to {{ range.range[1] !== null ? range.range[1] : "Infinity" }}</span>
+                            <span>
+                                {{ range.inclusiveLowerBound ? '[' : '(' }}{{ range.range[0] !== null ? range.range[0] : "-Infinity" }}, {{ range.range[1] !== null ? range.range[1] : "Infinity" }}{{ range.inclusiveUpperBound ? ']' : ')' }}
+                            </span>
                         </td>
                     </tr>
                     <tr v-if="range && range.ranges.some((range: ScoreRange) => 'positiveLikelihoodRatio' in range)">

--- a/src/components/VariantMeasurementView.vue
+++ b/src/components/VariantMeasurementView.vue
@@ -222,14 +222,24 @@ export default {
           || undefined
     },
     variantScoreRange: function() {
+      const operatorTable = {
+        '<': function(a: number, b: number) { return a < b; },
+        '<=': function(a: number, b: number) { return a <= b; },
+        '>': function(a: number, b: number) { return a > b; },
+        '>=': function(a: number, b: number) { return a >= b; },
+      }
+
       const score = this.variantScores?.score
       const scoreRanges = this.variant?.scoreSet?.scoreRanges?.ranges
       if (scoreRanges && score != null) {
-        return scoreRanges.find((scoreRange: any) =>
+        return scoreRanges.find((scoreRange: any) => {
+          const lowerOperator = scoreRange.inclusiveLowerBound ? '<=' : '<'
+          const upperOperator = scoreRange.inclusiveUpperBound ? '>=' : '>'
+
           scoreRange.range && scoreRange.range.length == 2
-          && (scoreRange.range[0] === null || scoreRange.range[0] <= score) // TODO What about exclusive interval ends?
-          && (scoreRange.range[1] === null || scoreRange.range[1] >= score)
-        )
+          && (scoreRange.range[0] === null || operatorTable[lowerOperator](scoreRange.range[0], score))
+          && (scoreRange.range[1] === null || operatorTable[upperOperator](scoreRange.range[1], score))
+        })
       }
       return undefined
     },

--- a/src/components/screens/ScoreSetCreator.vue
+++ b/src/components/screens/ScoreSetCreator.vue
@@ -1032,30 +1032,52 @@
                       <div class="mavedb-wizard-help">
                         <label :id="$scopedId(`input-investigatorProvidedRangeBoundaries-${rangeIdx}`)">What are the upper and lower bounds of this score range?</label>
                         <div class="mavedb-help-small">
-                          The lower bound is inclusive while the upper bound is exclusive of the provided value. Score range boundaries should not overlap with the boundaries
-                          of other score ranges. If a range does not have an upper or lower bound, the value will be treated as either positive or negative infinity.
+                          Score range boundaries should not overlap with the boundaries of other score ranges. Use the toggles to indicate whether the lower or upper bound is inclusive or
+                          does not have a upper or lower bound. If a range does not have an upper or lower bound, the value will be treated as either positive or negative infinity.
                         </div>
                       </div>
                       <div class="mavedb-wizard-content">
                           <InputGroup>
-                            <span class=p-float-label>
-                              <InputText v-model="rangeObj.value.range[0]" :aria-labelledby="$scopedId(`input-investigatorProvidedRangeLower-${rangeIdx}`)" :disabled="rangeObj.infiniteLower"/>
-                              <label :for="$scopedId(`input-investigatorProvidedRangeLower-${rangeIdx}`)"> {{ rangeObj.infiniteLower ? "-infinity" : "Lower Bound" }} </label>
-                            </span>
+                              <Button
+                                class="score-range-toggle-button"
+                                @click="toggleInfinity(rangeIdx, 'lower')"
+                                :outlined="!rangeObj.infiniteLower"
+                              >
+                                <FontAwesomeIcon icon="fa-solid fa-infinity" class="score-range-toggle-icon" />
+                              </Button>
+                              <Button
+                                class="score-range-toggle-button"
+                                @click="toggleBoundary(rangeIdx, 'lower')"
+                                :outlined="!rangeObj.value.inclusiveLowerBound"
+                                :disabled="rangeObj.infiniteLower"
+                              >
+                                <FontAwesomeIcon icon="fa-solid fa-circle-half-stroke" class="score-range-toggle-icon" />
+                              </Button>
+                              <span class="p-float-label">
+                                <InputText v-model="rangeObj.value.range[0]" :aria-labelledby="$scopedId(`input-investigatorProvidedRangeLower-${rangeIdx}`)" :disabled="rangeObj.value.infiniteLower"/>
+                                <label :for="$scopedId(`input-investigatorProvidedRangeLower-${rangeIdx}`)"> {{ rangeObj.infiniteLower ? "-infinity" : rangeObj.value.inclusiveLowerBound ? "Lower Bound (inclusive)" : "Lower Bound (exclusive)" }} </label>
+                              </span>
                             <InputGroupAddon>to</InputGroupAddon>
-                            <span class=p-float-label>
-                              <InputText v-model="rangeObj.value.range[1]" :aria-labelledby="$scopedId(`input-investigatorProvidedRangeUpper-${rangeIdx}`)" :disabled="rangeObj.infiniteUpper"/>
-                              <label :for="$scopedId(`input-investigatorProvidedRangeUpper-${rangeIdx}`)"> {{ rangeObj.infiniteUpper ? "infinity" : "Upper Bound" }} </label>
-                            </span>
+                              <span class="p-float-label">
+                                <InputText v-model="rangeObj.value.range[1]" :aria-labelledby="$scopedId(`input-investigatorProvidedRangeUpper-${rangeIdx}`)" :disabled="rangeObj.value.infiniteUpper"/>
+                                <label :for="$scopedId(`input-investigatorProvidedRangeUpper-${rangeIdx}`)"> {{ rangeObj.infiniteUpper ? "infinity" : rangeObj.value.inclusiveUpperBound ? "Upper Bound (inclusive)" : "Upper Bound (exclusive)" }} </label>
+                              </span>
+                              <Button
+                                class="score-range-toggle-button"
+                                @click="toggleBoundary(rangeIdx, 'upper')"
+                                :outlined="!rangeObj.value.inclusiveUpperBound"
+                                :disabled="rangeObj.infiniteUpper"
+                              >
+                                <FontAwesomeIcon icon="fa-solid fa-circle-half-stroke" class="score-range-toggle-icon" />
+                              </Button>
+                              <Button
+                                class="score-range-toggle-button"
+                                @click="toggleInfinity(rangeIdx, 'upper')"
+                                :outlined="!rangeObj.infiniteUpper"
+                              >
+                                <FontAwesomeIcon icon="fa-solid fa-infinity" class="score-range-toggle-icon" />
+                              </Button>
                           </InputGroup>
-                          <span>
-                            <Checkbox :binary="true" v-model="rangeObj.infiniteLower" inputId="lowerBound" name="lower" @change="boundaryLimitUpdated(rangeIdx, 'lower')"/>
-                            <label for="lowerBound" class="ml-2"> No lower bound </label>
-                          </span>
-                          <span style="float:right;">
-                            <label for="upperBound" class="ml-2"> No upper bound </label>
-                            <Checkbox :binary="true" v-model="rangeObj.infiniteUpper" inputId="upperBound" name="upper" @change="boundaryLimitUpdated(rangeIdx, 'upper')"/>
-                          </span>
                           <span style="float:left;" v-if="validationErrors[`scoreRanges.investigatorProvided.ranges.${rangeIdx}.oddsPath.range`]" class="mave-field-error">{{ validationErrors[`scoreRanges.investigatorProvided.ranges.${rangeIdx}.oddsPath.range`] }}</span>
                       </div>
                     </div>
@@ -1227,6 +1249,7 @@ import axios from 'axios'
 import fasta from 'fasta-js'
 import _ from 'lodash'
 import {marked} from 'marked'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import AutoComplete from 'primevue/autocomplete'
 import Button from 'primevue/button'
 import Card from 'primevue/card'
@@ -1304,6 +1327,8 @@ function emptyScoreRangeWizardObj() {
       description: null,
       range: [null, null],
       classification: null,
+      inclusiveLowerBound: true,
+      inclusiveUpperBound: false,
       oddsPath:{
         ratio: null,
         evidence: null,
@@ -1330,6 +1355,7 @@ export default {
     EmailPrompt,
     EntityLink,
     FileUpload,
+    FontAwesomeIcon,
     InputNumber,
     InputSwitch,
     InputText,
@@ -2014,13 +2040,27 @@ export default {
       }
     },
 
-    boundaryLimitUpdated: function(rangeIdx, boundary) {
+    toggleBoundary: function(rangeIdx, boundary) {
       const updatedRange = this.scoreRanges.investigatorProvided.ranges[rangeIdx]
       if (boundary === "upper") {
-        updatedRange.value.range[1] = null
+        updatedRange.value.inclusiveUpperBound = !updatedRange.value.inclusiveUpperBound
       }
       else if (boundary == "lower") {
+        updatedRange.value.inclusiveLowerBound = !updatedRange.value.inclusiveLowerBound
+      }
+    },
+
+    toggleInfinity: function(rangeIdx, boundary) {
+      const updatedRange = this.scoreRanges.investigatorProvided.ranges[rangeIdx]
+      if (boundary === "upper") {
+        updatedRange.infiniteUpper = !updatedRange.infiniteUpper
+        updatedRange.value.range[1] = null
+        updatedRange.value.inclusiveUpperBound = false
+      }
+      else if (boundary == "lower") {
+        updatedRange.infiniteLower = !updatedRange.infiniteLower
         updatedRange.value.range[0] = null
+        updatedRange.value.inclusiveLowerBound = false
       }
     },
 
@@ -2339,6 +2379,10 @@ export default {
           investigatorProvided: {
             baselineScore: null,
             baselineScoreDescription: null,
+            infiniteUpper: false,
+            infiniteLower: false,
+            inclusiveLowerBound: true,
+            inclusiveUpperBound: false,
             ranges: [],
             oddsPathSource: [],
             source: []
@@ -2797,6 +2841,16 @@ export default {
 
 .p-dropdown-item:nth-child(even) .mave-taxonomy-organism-name {
   background: #e9e9e9;
+}
+
+.score-range-toggle-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.score-range-toggle-icon {
+  margin: 0 auto;
 }
 
 /* Cards */

--- a/src/components/screens/ScoreSetEditor.vue
+++ b/src/components/screens/ScoreSetEditor.vue
@@ -278,10 +278,10 @@
               </template>
             </Card>
             <div v-if="itemStatus == 'NotLoaded' || this.item.private">
-              <div v-if="scoreRanges">
+              <div v-if="editedScoreRanges.investigatorProvided">
                 <Card>
                   <template #title>Investigator Score ranges
-                    <Button icon="pi pi-times" severity="danger" aria-label="Delete all ranges" rounded text style="float:right;" @click="removeScoreRanges()"/>
+                    <Button icon="pi pi-times" severity="danger" aria-label="Delete all ranges" rounded text style="float:right;" @click="removeEditedScoreRanges()"/>
                   </template>
                   <template #content>
                       <Card>
@@ -289,21 +289,21 @@
                         <template #content>
                           <div style="padding-top: 1%;">
                             <span class="p-float-label">
-                              <InputNumber v-model="scoreRanges.investigatorProvided.baselineScore" :aria-labelledby="$scopedId('input-baselineScore')" style="width:100%;" :minFractionDigits="1" :maxFractionDigits="10" />
+                              <InputNumber v-model="editedScoreRanges.investigatorProvided.baselineScore" :aria-labelledby="$scopedId('input-baselineScore')" style="width:100%;" :minFractionDigits="1" :maxFractionDigits="10" />
                               <label :for="$scopedId('input-baselineScore')"> Baseline Score </label>
                             </span>
                             <span v-if="validationErrors[`scoreRanges.investigatorProvided.baselineScore`]" class="mave-field-error">{{ validationErrors[`scoreRanges.investigatorProvided.baselineScore`] }}</span>
                           </div>
                           <div style="padding-top: 1%;">
                             <span class="p-float-label">
-                              <Textarea v-model="scoreRanges.investigatorProvided.baselineScoreDescription" style="width:100%;" :aria-labelledby="$scopedId(`input-baselineScoreDescription`)" />
+                              <Textarea v-model="editedScoreRanges.investigatorProvided.baselineScoreDescription" style="width:100%;" :aria-labelledby="$scopedId(`input-baselineScoreDescription`)" />
                               <label :for="$scopedId(`input-baselineScoreDescription`)">Baseline Score Description</label>
                             </span>
                             <span v-if="validationErrors[`scoreRanges.investigatorProvided.baselineScoreDescription`]" class="mave-field-error">{{ validationErrors[`scoreRanges.investigatorProvided.baselineScoreDescription`] }}</span>
                           </div>
-                          <div v-if="scoreRanges.investigatorProvided.ranges.some(range => range.oddsPath)">
+                          <div v-if="editedScoreRanges.investigatorProvided.ranges.some(range => range.oddsPath)">
                             <span class="p-float-label">
-                              <Multiselect ref="scoreRangePublicationIdentifiersInput" v-model="scoreRanges.investigatorProvided.source"
+                              <Multiselect ref="scoreRangePublicationIdentifiersInput" v-model="editedScoreRanges.investigatorProvided.source"
                                 :id="$scopedId('input-scoreRangePublicationIdentifiersInput')" :options="publicationIdentifiers"
                                 optionLabel="identifier" placeholder="Select a source for the score ranges."
                                 :selectionLimit="1" style="width: 100%;">
@@ -322,104 +322,104 @@
                           </div>
                         </template>
                       </Card>
-                      <div v-for="(scoreRange, scoreIdx) of scoreRanges.investigatorProvided.ranges" :key="scoreIdx" class="mavedb-score-range-container">
+                      <div v-for="(rangeObj, rangeIdx) of editedScoreRanges.investigatorProvided.ranges" :key="rangeIdx" class="mavedb-score-range-container">
                         <Card>
-                          <template #title>Range {{ scoreIdx+1 }}:
-                            <Button icon="pi pi-times" severity="danger" aria-label="Delete range" rounded text style="float:right;" @click="removeScoreRange(scoreIdx)"/>
+                          <template #title>Range {{ rangeIdx+1 }}:
+                            <Button icon="pi pi-times" severity="danger" aria-label="Delete range" rounded text style="float:right;" @click="removeEditedScoreRange(rangeIdx)"/>
                           </template>
                           <template #content>
                             <div style="padding-top: 1%;">
                                 <InputGroup>
                                   <span class="p-float-label" style="width:75%;">
-                                    <InputText v-model="scoreRange.label" style="width:75%;" :aria-labelledby="$scopedId(`input-scoreRangeLabel-${scoreIdx}`)"></InputText>
-                                    <label :for="$scopedId(`input-scoreRangeLabel-${scoreIdx}`)">Label</label>
+                                    <InputText v-model="rangeObj.label" style="width:75%;" :aria-labelledby="$scopedId(`input-scoreRangeLabel-${rangeIdx}`)"></InputText>
+                                    <label :for="$scopedId(`input-scoreRangeLabel-${rangeIdx}`)">Label</label>
                                   </span>
                                   <span class="p-float-label" style="width:25%;">
-                                    <Dropdown v-model="scoreRange.classification" :options="rangeClassifications" optionLabel="label" optionValue="value" style="width:25%;" :aria-labelledby="$scopedId(`input-scoreRangeClassification-${scoreIdx}`)"/>
-                                    <label :for="$scopedId(`input-scoreRangeClassification-${scoreIdx}`)">Classification</label>
+                                    <Dropdown v-model="rangeObj.classification" :options="rangeClassifications" optionLabel="label" optionValue="value" style="width:25%;" :aria-labelledby="$scopedId(`input-scoreRangeClassification-${rangeIdx}`)"/>
+                                    <label :for="$scopedId(`input-scoreRangeClassification-${rangeIdx}`)">Classification</label>
                                   </span>
                                 </InputGroup>
-                                <span v-if="validationErrors[`scoreRanges.investigatorProvided.ranges.${scoreIdx}.label`]" class="mave-field-error">{{ validationErrors[`scoreRanges.investigatorProvided.ranges.${scoreIdx}.label`] }}</span>
-                                <span v-if="validationErrors[`scoreRanges.investigatorProvided.ranges.${scoreIdx}.classification`]" class="mave-field-error">{{ validationErrors[`scoreRanges.investigatorProvided.ranges.${scoreIdx}.classification`] }}</span>
+                                <span v-if="validationErrors[`scoreRanges.investigatorProvided.ranges.${rangeIdx}.label`]" class="mave-field-error">{{ validationErrors[`scoreRanges.investigatorProvided.ranges.${rangeIdx}.label`] }}</span>
+                                <span v-if="validationErrors[`scoreRanges.investigatorProvided.ranges.${rangeIdx}.classification`]" class="mave-field-error">{{ validationErrors[`scoreRanges.investigatorProvided.ranges.${rangeIdx}.classification`] }}</span>
                             </div>
                             <div style="padding-top: 1%;">
                               <span class="p-float-label">
-                                <Textarea v-model="scoreRange.description" style="width:100%;" :aria-labelledby="$scopedId(`input-scoreRangeDescription-${scoreIdx}`)"/>
-                                <label :for="$scopedId(`input-scoreRangeDescription-${scoreIdx}`)">Description (optional)</label>
+                                <Textarea v-model="rangeObj.description" style="width:100%;" :aria-labelledby="$scopedId(`input-scoreRangeDescription-${rangeIdx}`)"/>
+                                <label :for="$scopedId(`input-scoreRangeDescription-${rangeIdx}`)">Description (optional)</label>
                               </span>
-                              <span v-if="validationErrors[`scoreRanges.investigatorProvided.ranges.${scoreIdx}.description`]" class="mave-field-error">{{ validationErrors[`scoreRanges.investigatorProvided.ranges.${scoreIdx}.description`] }}</span>
+                              <span v-if="validationErrors[`scoreRanges.investigatorProvided.ranges.${rangeIdx}.description`]" class="mave-field-error">{{ validationErrors[`scoreRanges.investigatorProvided.ranges.${rangeIdx}.description`] }}</span>
                             </div>
                             <div style="padding-top: 1%;">
                               <InputGroup style="background-color: #fff;">
                                   <Button
                                     class="score-range-toggle-button"
-                                    @click="toggleInfinity(scoreIdx, 'lower')"
-                                    :outlined="!scoreRangeBoundaryHelper[scoreIdx].lowerBoundIsInfinity"
+                                    @click="toggleInfinity(rangeIdx, 'lower')"
+                                    :outlined="!editedScoreRangeBoundaryHelper[rangeIdx].lowerBoundIsInfinity"
                                   >
                                     <FontAwesomeIcon icon="fa-solid fa-infinity" class="score-range-toggle-icon" />
                                   </Button>
                                   <Button
                                     class="score-range-toggle-button"
-                                    @click="toggleBoundary(scoreIdx, 'lower')"
-                                    :outlined="!scoreRange.inclusiveLowerBound"
-                                    :disabled="scoreRangeBoundaryHelper[scoreIdx].lowerBoundIsInfinity"
+                                    @click="toggleBoundary(rangeIdx, 'lower')"
+                                    :outlined="!rangeObj.inclusiveLowerBound"
+                                    :disabled="editedScoreRangeBoundaryHelper[rangeIdx].lowerBoundIsInfinity"
                                   >
                                     <FontAwesomeIcon icon="fa-solid fa-circle-half-stroke" class="score-range-toggle-icon" />
                                   </Button>
                                   <span class="p-float-label">
-                                    <InputText v-model="scoreRange.range[0]" :aria-labelledby="$scopedId(`input-investigatorProvidedRangeLower-${scoreIdx}`)" :disabled="scoreRangeBoundaryHelper[scoreIdx].lowerBoundIsInfinity"/>
-                                    <label :for="$scopedId(`input-investigatorProvidedRangeLower-${scoreIdx}`)"> {{ scoreRangeBoundaryHelper[scoreIdx].lowerBoundIsInfinity ? "-infinity" : scoreRange.inclusiveLowerBound ? "Lower Bound (inclusive)" : "Lower Bound (exclusive)" }} </label>
+                                    <InputText v-model="rangeObj.range[0]" :aria-labelledby="$scopedId(`input-investigatorProvidedRangeLower-${rangeIdx}`)" :disabled="editedScoreRangeBoundaryHelper[rangeIdx].lowerBoundIsInfinity"/>
+                                    <label :for="$scopedId(`input-investigatorProvidedRangeLower-${rangeIdx}`)"> {{ editedScoreRangeBoundaryHelper[rangeIdx].lowerBoundIsInfinity ? "-infinity" : rangeObj.inclusiveLowerBound ? "Lower Bound (inclusive)" : "Lower Bound (exclusive)" }} </label>
                                   </span>
                                 <InputGroupAddon>to</InputGroupAddon>
                                   <span class="p-float-label">
-                                    <InputText v-model="scoreRange.range[1]" :aria-labelledby="$scopedId(`input-investigatorProvidedRangeUpper-${scoreIdx}`)" :disabled="scoreRangeBoundaryHelper[scoreIdx].upperBoundIsInfinity"/>
-                                    <label :for="$scopedId(`input-investigatorProvidedRangeUpper-${scoreIdx}`)"> {{ scoreRangeBoundaryHelper[scoreIdx].upperBoundIsInfinity ? "infinity" : scoreRange.inclusiveUpperBound ? "Upper Bound (inclusive)" : "Upper Bound (exclusive)" }} </label>
+                                    <InputText v-model="rangeObj.range[1]" :aria-labelledby="$scopedId(`input-investigatorProvidedRangeUpper-${rangeIdx}`)" :disabled="editedScoreRangeBoundaryHelper[rangeIdx].upperBoundIsInfinity"/>
+                                    <label :for="$scopedId(`input-investigatorProvidedRangeUpper-${rangeIdx}`)"> {{ editedScoreRangeBoundaryHelper[rangeIdx].upperBoundIsInfinity ? "infinity" : rangeObj.inclusiveUpperBound ? "Upper Bound (inclusive)" : "Upper Bound (exclusive)" }} </label>
                                   </span>
                                   <Button
                                     class="score-range-toggle-button"
-                                    @click="toggleBoundary(scoreIdx, 'upper')"
-                                    :outlined="!scoreRange.inclusiveUpperBound"
-                                    :disabled="scoreRangeBoundaryHelper[scoreIdx].upperBoundIsInfinity"
+                                    @click="toggleBoundary(rangeIdx, 'upper')"
+                                    :outlined="!rangeObj.inclusiveUpperBound"
+                                    :disabled="editedScoreRangeBoundaryHelper[rangeIdx].upperBoundIsInfinity"
                                   >
                                     <FontAwesomeIcon icon="fa-solid fa-circle-half-stroke" class="score-range-toggle-icon" />
                                   </Button>
                                   <Button
                                     class="score-range-toggle-button"
-                                    @click="toggleInfinity(scoreIdx, 'upper')"
-                                    :outlined="!scoreRangeBoundaryHelper[scoreIdx].upperBoundIsInfinity"
+                                    @click="toggleInfinity(rangeIdx, 'upper')"
+                                    :outlined="!editedScoreRangeBoundaryHelper[rangeIdx].upperBoundIsInfinity"
                                   >
                                     <FontAwesomeIcon icon="fa-solid fa-infinity" class="score-range-toggle-icon" />
                                   </Button>
                               </InputGroup>
                             </div>
-                            <span v-if="validationErrors[`scoreRanges.investigatorProvided.ranges.${scoreIdx}.range`]" class="mave-field-error">{{ validationErrors[`scoreRanges.investigatorProvided.ranges.${scoreIdx}.range`] }}</span>
-                            <span v-if="validationErrors[`scoreRanges.investigatorProvided.ranges.${scoreIdx}.inclusiveLowerBound`]" class="mave-field-error">{{ validationErrors[`scoreRanges.investigatorProvided.ranges.${scoreIdx}.inclusiveLowerBound`] }}</span>
-                            <span v-if="validationErrors[`scoreRanges.investigatorProvided.ranges.${scoreIdx}.inclusiveUpperBound`]" class="mave-field-error">{{ validationErrors[`scoreRanges.investigatorProvided.ranges.${scoreIdx}.inclusiveUpperBound`] }}</span>
-                            <div v-if="scoreRange.oddsPath">
+                            <span v-if="validationErrors[`scoreRanges.investigatorProvided.ranges.${rangeIdx}.range`]" class="mave-field-error">{{ validationErrors[`scoreRanges.investigatorProvided.ranges.${rangeIdx}.range`] }}</span>
+                            <span v-if="validationErrors[`scoreRanges.investigatorProvided.ranges.${rangeIdx}.inclusiveLowerBound`]" class="mave-field-error">{{ validationErrors[`scoreRanges.investigatorProvided.ranges.${rangeIdx}.inclusiveLowerBound`] }}</span>
+                            <span v-if="validationErrors[`scoreRanges.investigatorProvided.ranges.${rangeIdx}.inclusiveUpperBound`]" class="mave-field-error">{{ validationErrors[`scoreRanges.investigatorProvided.ranges.${rangeIdx}.inclusiveUpperBound`] }}</span>
+                            <div v-if="rangeObj.oddsPath">
                               <Card>
                                 <template #title>OddsPath Ratio and Evidence Strength
-                                  <Button icon="pi pi-times" severity="danger" aria-label="Delete odds path" rounded text style="float:right;" @click="removeOddsPath(scoreIdx)"/>
+                                  <Button icon="pi pi-times" severity="danger" aria-label="Delete odds path" rounded text style="float:right;" @click="removeOddsPath(rangeIdx)"/>
                                 </template>
                                 <template #content>
                                   <div>
                                     <InputGroup>
                                       <span class=p-float-label style="margin-right: 1em;">
-                                        <InputNumber v-model="scoreRange.oddsPath.ratio" :aria-labelledby="$scopedId('input-oddsPathRatio')" style="width:50%;" :minFractionDigits="1" :maxFractionDigits="10" />
+                                        <InputNumber v-model="rangeObj.oddsPath.ratio" :aria-labelledby="$scopedId('input-oddsPathRatio')" style="width:50%;" :minFractionDigits="1" :maxFractionDigits="10" />
                                         <label :for="$scopedId('input-oddsPathRatio')"> OddsPath Ratio </label>
                                       </span>
                                       <span class=p-float-label>
                                         <Dropdown
-                                          v-model="scoreRange.oddsPath.evidence"
+                                          v-model="rangeObj.oddsPath.evidence"
                                           :aria-labelledby="$scopedId('input-oddsPathEvidence')"
                                           style="width:50%;"
-                                          :disabled="scoreRange.classification === null"
-                                          :options="scoreRange.classification ? evidenceStrengths[scoreRange.classification].concat(evidenceStrengths.indeterminate) : []"
+                                          :disabled="rangeObj.classification === null"
+                                          :options="rangeObj.classification ? evidenceStrengths[rangeObj.classification].concat(evidenceStrengths.indeterminate) : []"
                                         />
-                                        <label :for="$scopedId('input-oddsPathEvidence')"> {{ scoreRange.classification === null ? "Select a range classification" : "OddsPath Evidence Strength (Optional)" }}  </label>
+                                        <label :for="$scopedId('input-oddsPathEvidence')"> {{ rangeObj.classification === null ? "Select a range classification" : "OddsPath Evidence Strength (Optional)" }}  </label>
                                       </span>
                                     </InputGroup>
-                                    <span v-if="validationErrors[`scoreRanges.investigatorProvided.ranges.${scoreIdx}.oddsPath.ratio`]" class="mave-field-error">{{ validationErrors[`scoreRanges.investigatorProvided.ranges.${scoreIdx}.oddsPath.ratio`] }}</span>
-                                    <span v-if="validationErrors[`scoreRanges.investigatorProvided.ranges.${scoreIdx}.oddsPath.evidence`]" class="mave-field-error">{{ validationErrors[`scoreRanges.investigatorProvided.ranges.${scoreIdx}.oddsPath.evidence`] }}</span>
+                                    <span v-if="validationErrors[`scoreRanges.investigatorProvided.ranges.${rangeIdx}.oddsPath.ratio`]" class="mave-field-error">{{ validationErrors[`scoreRanges.investigatorProvided.ranges.${rangeIdx}.oddsPath.ratio`] }}</span>
+                                    <span v-if="validationErrors[`scoreRanges.investigatorProvided.ranges.${rangeIdx}.oddsPath.evidence`]" class="mave-field-error">{{ validationErrors[`scoreRanges.investigatorProvided.ranges.${rangeIdx}.oddsPath.evidence`] }}</span>
                                   </div>
                                 </template>
                               </Card>
@@ -427,16 +427,16 @@
                             <div v-else>
                               <Card>
                                 <template #title>Add Odds Path
-                                  <Button icon="pi pi-plus" aria-label="Add Odds Path" rounded text style="float:right;" @click="addOddsPath(scoreIdx)"/>
+                                  <Button icon="pi pi-plus" aria-label="Add Odds Path" rounded text style="float:right;" @click="addOddsPath(rangeIdx)"/>
                                 </template>
                               </Card>
                             </div>
                           </template>
                         </Card>
                       </div>
-                      <div v-if="scoreRanges.investigatorProvided.ranges.some(range => range.oddsPath)">
+                      <div v-if="editedScoreRanges.investigatorProvided.ranges.some(range => range.oddsPath)">
                         <span class="p-float-label">
-                          <Multiselect ref="oddsPathPublicationIdentifiersInput" v-model="scoreRanges.investigatorProvided.oddsPathSource"
+                          <Multiselect ref="oddsPathPublicationIdentifiersInput" v-model="editedScoreRanges.investigatorProvided.oddsPathSource"
                             :id="$scopedId('input-oddsPathPublicationIdentifiersInput')" :options="publicationIdentifiers"
                             optionLabel="identifier" placeholder="Select a source for the OddsPath calculation."
                             :selectionLimit="1" style="width: 100%;">
@@ -456,7 +456,7 @@
                       </div>
                       <span v-if="validationErrors[`scoreRanges.investigatorProvided.ranges`]" class="mave-field-error">{{ validationErrors[`scoreRanges.investigatorProvided.ranges`] }}</span>
                       <div class="field" style="align-items: center; justify-content: center; display: flex; padding-top: 1%;">
-                        <Button label="Add new score range" icon="pi pi-plus" aria-label="Add range" outlined raised text @click="addScoreRange()"/>
+                        <Button label="Add new score range" icon="pi pi-plus" aria-label="Add range" outlined raised text @click="addEditedScoreRange()"/>
                       </div>
                   </template>
                 </Card>
@@ -464,7 +464,7 @@
               <div v-else>
                 <Card>
                   <template #title>Add Score Ranges
-                    <Button icon="pi pi-plus" aria-label="Add score ranges" rounded text style="float:right;" @click="addScoreRanges()"/>
+                    <Button icon="pi pi-plus" aria-label="Add score ranges" rounded text style="float:right;" @click="addEditedScoreRanges()"/>
                   </template>
                 </Card>
               </div>
@@ -881,7 +881,7 @@
     }
   }
 
-  function emptyScoreRange() {
+  function emptyEditedScoreRange() {
     return {
         label: null,
         description: null,
@@ -893,7 +893,7 @@
       }
   }
 
-  function emptyScoreRangeBoundaryHelper() {
+  function emptyEditedScoreRangeBoundaryHelper() {
     return {
       lowerBoundIsInfinity: false,
       upperBoundIsInfinity: false
@@ -988,19 +988,11 @@
       existingTargetGene: null,
       targetGenes: [],
 
-      scoreRanges: {
-        investigatorProvided: {
-          baselineScore: null,
-          baselineScoreDescription: null,
-          ranges: [],
-          oddsPathSource: [],
-          source: [],
-          inclusiveLowerBound: true,
-          inclusiveUpperBound: false,
-        }
+      editedScoreRanges: {
+        investigatorProvided: null
       },
-      activeScoreRangeTab: 0,
-      scoreRangeBoundaryHelper: [],
+      activeEditedScoreRangeTab: 0,
+      editedScoreRangeBoundaryHelper: [],
 
       // Static sets of options:
       sequenceTypes: [
@@ -1087,14 +1079,6 @@
           return this.geneNames.map(name => ({ name }))
         }
       },
-      scoreRangeKeys: function () {
-        return Object.keys(this.scoreRanges).filter((key) => key != 'recordType').map((key) => {
-          return {
-            key: key,
-            label: key.charAt(0).toUpperCase() + key.slice(1).replace(/([A-Z])/g, ' $1')
-          }
-        })
-      }
     },
 
     watch: {
@@ -1399,7 +1383,7 @@
       },
 
       toggleBoundary: function(rangeIdx, boundary) {
-        const updatedRange = this.scoreRanges.investigatorProvided.ranges[rangeIdx]
+        const updatedRange = this.editedScoreRanges.investigatorProvided.ranges[rangeIdx]
         if (boundary === "upper") {
           updatedRange.inclusiveUpperBound = !updatedRange.inclusiveUpperBound
         }
@@ -1409,47 +1393,47 @@
       },
 
       toggleInfinity: function(rangeIdx, boundary) {
-        const updatedRange = this.scoreRanges.investigatorProvided.ranges[rangeIdx]
+        const updatedRange = this.editedScoreRanges.investigatorProvided.ranges[rangeIdx]
         if (boundary === "upper") {
-          this.scoreRangeBoundaryHelper[rangeIdx].upperBoundIsInfinity = !this.scoreRangeBoundaryHelper[rangeIdx].upperBoundIsInfinity
+          this.editedScoreRangeBoundaryHelper[rangeIdx].upperBoundIsInfinity = !this.editedScoreRangeBoundaryHelper[rangeIdx].upperBoundIsInfinity
           updatedRange.range[1] = null
           updatedRange.inclusiveUpperBound = false
         }
         else if (boundary == "lower") {
-          this.scoreRangeBoundaryHelper[rangeIdx].lowerBoundIsInfinity = !this.scoreRangeBoundaryHelper[rangeIdx].lowerBoundIsInfinity
+          this.editedScoreRangeBoundaryHelper[rangeIdx].lowerBoundIsInfinity = !this.editedScoreRangeBoundaryHelper[rangeIdx].lowerBoundIsInfinity
           updatedRange.range[0] = null
           updatedRange.inclusiveLowerBound = false
         }
       },
 
-      addScoreRange: function() {
-        this.scoreRanges.investigatorProvided.ranges.push(emptyScoreRange())
-        this.scoreRangeBoundaryHelper.push(emptyScoreRangeBoundaryHelper())
+      addEditedScoreRange: function() {
+        this.editedScoreRanges.investigatorProvided.ranges.push(emptyEditedScoreRange())
+        this.editedScoreRangeBoundaryHelper.push(emptyEditedScoreRangeBoundaryHelper())
       },
 
-      removeScoreRange: function(rangeIdx) {
-        this.scoreRanges.investigatorProvided.ranges.splice(rangeIdx, 1)
-        this.scoreRangeBoundaryHelper.splice(rangeIdx, 1)
+      removeEditedScoreRange: function(rangeIdx) {
+        this.editedScoreRanges.investigatorProvided.ranges.splice(rangeIdx, 1)
+        this.editedScoreRangeBoundaryHelper.splice(rangeIdx, 1)
       },
 
-      removeScoreRanges: function() {
-        this.scoreRanges = null
-        this.scoreRangeBoundaryHelper = null
+      removeEditedScoreRanges: function() {
+        this.editedScoreRanges = null
+        this.editedScoreRangeBoundaryHelper = null
       },
 
-      addScoreRanges: function() {
-        this.scoreRanges = {investigatorProvided: {baselineScore: null, baselineScoreDescription: null, ranges: [], oddsPathSource: [], source: []}}
-        this.scoreRangeBoundaryHelper = []
-        this.scoreRanges.investigatorProvided.ranges.push(emptyScoreRange())
-        this.scoreRangeBoundaryHelper.push(emptyScoreRangeBoundaryHelper())
+      addEditedScoreRanges: function() {
+        this.editedScoreRanges.investigatorProvided = {baselineScore: null, baselineScoreDescription: null, ranges: [], oddsPathSource: [], source: []}
+        this.editedScoreRangeBoundaryHelper = []
+        this.editedScoreRanges.investigatorProvided.ranges.push(emptyEditedScoreRange())
+        this.editedScoreRangeBoundaryHelper.push(emptyEditedScoreRangeBoundaryHelper())
       },
 
       removeOddsPath: function(rangeIdx) {
-        this.scoreRanges.investigatorProvided.ranges[rangeIdx].oddsPath = null
+        this.editedScoreRanges.investigatorProvided.ranges[rangeIdx].oddsPath = null
       },
 
       addOddsPath: function(rangeIdx) {
-        this.scoreRanges.investigatorProvided.ranges[rangeIdx].oddsPath = {
+        this.editedScoreRanges.investigatorProvided.ranges[rangeIdx].oddsPath = {
           ratio: null,
           evidence: null,
         }
@@ -1715,25 +1699,26 @@
           this.targetGene = emptyTargetGene()
           this.assembly = this.item.assembly
           this.targetGenes = this.item.targetGenes
-          this.scoreRanges = this.item.scoreRanges
-          this.scoreRangeBoundaryHelper = []
-          this.scoreRanges?.investigatorProvided.ranges.forEach((range, idx) => {
-            this.scoreRangeBoundaryHelper.push(emptyScoreRangeBoundaryHelper())
-            this.scoreRangeBoundaryHelper[idx].lowerBoundIsInfinity = this.scoreRanges.investigatorProvided.ranges[idx].range[0] === null
-            this.scoreRangeBoundaryHelper[idx].upperBoundIsInfinity = this.scoreRanges.investigatorProvided.ranges[idx].range[1] === null
+          // Only allow investigator provided ranges to be edited
+          this.editedScoreRanges = {investigatorProvided: this.item.scoreRanges?.investigatorProvided || null}
+          this.editedScoreRangeBoundaryHelper = []
+          this.editedScoreRanges?.investigatorProvided?.ranges.forEach((range, idx) => {
+            this.editedScoreRangeBoundaryHelper.push(emptyEditedScoreRangeBoundaryHelper())
+            this.editedScoreRangeBoundaryHelper[idx].lowerBoundIsInfinity = this.editedScoreRanges.investigatorProvided.ranges[idx].range[0] === null
+            this.editedScoreRangeBoundaryHelper[idx].upperBoundIsInfinity = this.editedScoreRanges.investigatorProvided.ranges[idx].range[1] === null
           })
           this.extraMetadata = this.item.extraMetadata
 
-          if (this.item.scoreRanges?.investigatorProvided.oddsPathSource) {
-            this.scoreRanges.investigatorProvided.oddsPathSource = this.publicationIdentifiers.filter((publication) => {
-              return this.item.scoreRanges.investigatorProvided.oddsPathSource.some((source) => {
+          if (this.item.editedScoreRanges?.investigatorProvided.oddsPathSource) {
+            this.editedScoreRanges.investigatorProvided.oddsPathSource = this.publicationIdentifiers.filter((publication) => {
+              return this.item.editedScoreRanges.investigatorProvided.oddsPathSource.some((source) => {
                 return publication.identifier === source.identifier && publication.dbName === source.dbName
               })
             })
           }
-          if (this.item.scoreRanges?.investigatorProvided.source) {
-            this.scoreRanges.investigatorProvided.source = this.publicationIdentifiers.filter((publication) => {
-              return this.item.scoreRanges.investigatorProvided.source.some((source) => {
+          if (this.item.editedScoreRanges?.investigatorProvided.source) {
+            this.editedScoreRanges.investigatorProvided.source = this.publicationIdentifiers.filter((publication) => {
+              return this.item.editedScoreRanges.investigatorProvided.source.some((source) => {
                 return publication.identifier === source.identifier && publication.dbName === source.dbName
               })
             })
@@ -1759,20 +1744,10 @@
           this.dataUsagePolicy = null
           this.taxonomy = null
           this.extraMetadata = {}
-          this.scoreRanges = {
-            investigatorProvided: {
-              baselineScore: undefined,
-              baselineScoreDescription: undefined,
-              ranges: [],
-              oddsPathSource: [],
-              source: [],
-              infiniteUpper: false,
-              infiniteLower: false,
-              inclusiveLowerBound: true,
-              inclusiveUpperBound: false,
-            }
+          this.editedScoreRanges = {
+            investigatorProvided: null
           }
-          this.scoreRangeBoundaryHelper = []
+          this.editedScoreRangeBoundaryHelper = []
           this.resetTarget()
           this.targetGenes = []
         }
@@ -1867,21 +1842,34 @@
             }
             return target
           }),
+          // Retain existing score ranges. We will merge the edited ranges with the existing ones.
           scoreRanges: this.item.scoreRanges ? {
-            ...this.item.scoreRanges, // retain any existing score ranges. We only have edited investigator provided ranges so we handle them separately.
-          } : null,
-        }
-        if (this.scoreRanges) {
-          editedFields.scoreRanges = {
             ...this.item.scoreRanges,
-            investigatorProvided: {
-              baselineScore: this.scoreRanges.investigatorProvided.baselineScore,
-              baselineScoreDescription: this.scoreRanges.investigatorProvided.baselineScoreDescription,
-              ranges: this.scoreRanges.investigatorProvided.ranges,
-              oddsPathSource: this.scoreRanges.investigatorProvided.oddsPathSource.map((source) => _.pick(source, ['identifier', 'dbName'])),
-              source: this.scoreRanges.investigatorProvided.source.map((source) => _.pick(source, ['identifier', 'dbName']))
-            }
+          } : {},
+        }
+        // We should check any edited score range key we allow users to edit. Presently, this is only the investigator provided ranges.
+        if (this.editedScoreRanges?.investigatorProvided) {
+          editedFields.scoreRanges.investigatorProvided = {
+            baselineScore: this.editedScoreRanges.investigatorProvided.baselineScore,
+            baselineScoreDescription: this.editedScoreRanges.investigatorProvided.baselineScoreDescription,
+            ranges: this.editedScoreRanges.investigatorProvided.ranges,
+            oddsPathSource: this.editedScoreRanges.investigatorProvided.oddsPathSource.map((source) => _.pick(source, ['identifier', 'dbName'])),
+            source: this.editedScoreRanges.investigatorProvided.source.map((source) => _.pick(source, ['identifier', 'dbName']))
           }
+        }
+        else {
+          if (editedFields.scoreRanges && editedFields.scoreRanges.investigatorProvided !== undefined) {
+            delete editedFields.scoreRanges.investigatorProvided
+          }
+        }
+        // If no score ranges are objects, then set to null.
+        if (
+          editedFields.scoreRanges &&
+          Object.values(editedFields.scoreRanges).every(
+            (val) => typeof val !== 'object' || val === null || Array.isArray(val)
+          )
+        ) {
+          editedFields.scoreRanges = null
         }
         if (!this.item) {
           editedFields.supersededScoreSetUrn = this.supersededScoreSet ? this.supersededScoreSet.urn : null

--- a/src/components/screens/ScoreSetEditor.vue
+++ b/src/components/screens/ScoreSetEditor.vue
@@ -342,37 +342,59 @@
                                 <span v-if="validationErrors[`scoreRanges.investigatorProvided.ranges.${scoreIdx}.label`]" class="mave-field-error">{{ validationErrors[`scoreRanges.investigatorProvided.ranges.${scoreIdx}.label`] }}</span>
                                 <span v-if="validationErrors[`scoreRanges.investigatorProvided.ranges.${scoreIdx}.classification`]" class="mave-field-error">{{ validationErrors[`scoreRanges.investigatorProvided.ranges.${scoreIdx}.classification`] }}</span>
                             </div>
-                            <div style="padding-top: 2%;">
+                            <div style="padding-top: 1%;">
                               <span class="p-float-label">
                                 <Textarea v-model="scoreRange.description" style="width:100%;" :aria-labelledby="$scopedId(`input-scoreRangeDescription-${scoreIdx}`)"/>
                                 <label :for="$scopedId(`input-scoreRangeDescription-${scoreIdx}`)">Description (optional)</label>
                               </span>
                               <span v-if="validationErrors[`scoreRanges.investigatorProvided.ranges.${scoreIdx}.description`]" class="mave-field-error">{{ validationErrors[`scoreRanges.investigatorProvided.ranges.${scoreIdx}.description`] }}</span>
                             </div>
-                            <div>
-                              <InputGroup>
-                                <span class=p-float-label>
-                                  <InputText v-model="scoreRange.range[0]" :aria-labelledby="$scopedId(`input-scoreRangeLower-${scoreIdx}`)" :disabled="scoreRangeBoundaryHelper[scoreIdx].lowerBoundIsInfinity"/>
-                                  <label :for="$scopedId(`input-scoreRangeLower-${scoreIdx}`)"> {{ scoreRangeBoundaryHelper[scoreIdx].lowerBoundIsInfinity ? "-infinity" : "Lower Bound" }} </label>
-                                </span>
+                            <div style="padding-top: 1%;">
+                              <InputGroup style="background-color: #fff;">
+                                  <Button
+                                    class="score-range-toggle-button"
+                                    @click="toggleInfinity(scoreIdx, 'lower')"
+                                    :outlined="!scoreRangeBoundaryHelper[scoreIdx].lowerBoundIsInfinity"
+                                  >
+                                    <FontAwesomeIcon icon="fa-solid fa-infinity" class="score-range-toggle-icon" />
+                                  </Button>
+                                  <Button
+                                    class="score-range-toggle-button"
+                                    @click="toggleBoundary(scoreIdx, 'lower')"
+                                    :outlined="!scoreRange.inclusiveLowerBound"
+                                    :disabled="scoreRangeBoundaryHelper[scoreIdx].lowerBoundIsInfinity"
+                                  >
+                                    <FontAwesomeIcon icon="fa-solid fa-circle-half-stroke" class="score-range-toggle-icon" />
+                                  </Button>
+                                  <span class="p-float-label">
+                                    <InputText v-model="scoreRange.range[0]" :aria-labelledby="$scopedId(`input-investigatorProvidedRangeLower-${scoreIdx}`)" :disabled="scoreRangeBoundaryHelper[scoreIdx].lowerBoundIsInfinity"/>
+                                    <label :for="$scopedId(`input-investigatorProvidedRangeLower-${scoreIdx}`)"> {{ scoreRangeBoundaryHelper[scoreIdx].lowerBoundIsInfinity ? "-infinity" : scoreRange.inclusiveLowerBound ? "Lower Bound (inclusive)" : "Lower Bound (exclusive)" }} </label>
+                                  </span>
                                 <InputGroupAddon>to</InputGroupAddon>
-                                <span class=p-float-label>
-                                  <InputText v-model="scoreRange.range[1]" :aria-labelledby="$scopedId(`input-scoreRangeUpper-${scoreIdx}`)" :disabled="scoreRangeBoundaryHelper[scoreIdx].upperBoundIsInfinity"/>
-                                  <label :for="$scopedId(`input-scoreRangeUpper-${scoreIdx}`)"> {{ scoreRangeBoundaryHelper[scoreIdx].upperBoundIsInfinity ? "infinity" : "Upper Bound" }} </label>
-                                </span>
+                                  <span class="p-float-label">
+                                    <InputText v-model="scoreRange.range[1]" :aria-labelledby="$scopedId(`input-investigatorProvidedRangeUpper-${scoreIdx}`)" :disabled="scoreRangeBoundaryHelper[scoreIdx].upperBoundIsInfinity"/>
+                                    <label :for="$scopedId(`input-investigatorProvidedRangeUpper-${scoreIdx}`)"> {{ scoreRangeBoundaryHelper[scoreIdx].upperBoundIsInfinity ? "infinity" : scoreRange.inclusiveUpperBound ? "Upper Bound (inclusive)" : "Upper Bound (exclusive)" }} </label>
+                                  </span>
+                                  <Button
+                                    class="score-range-toggle-button"
+                                    @click="toggleBoundary(scoreIdx, 'upper')"
+                                    :outlined="!scoreRange.inclusiveUpperBound"
+                                    :disabled="scoreRangeBoundaryHelper[scoreIdx].upperBoundIsInfinity"
+                                  >
+                                    <FontAwesomeIcon icon="fa-solid fa-circle-half-stroke" class="score-range-toggle-icon" />
+                                  </Button>
+                                  <Button
+                                    class="score-range-toggle-button"
+                                    @click="toggleInfinity(scoreIdx, 'upper')"
+                                    :outlined="!scoreRangeBoundaryHelper[scoreIdx].upperBoundIsInfinity"
+                                  >
+                                    <FontAwesomeIcon icon="fa-solid fa-infinity" class="score-range-toggle-icon" />
+                                  </Button>
                               </InputGroup>
                             </div>
-                            <div>
-                              <span>
-                                <Checkbox v-model="scoreRangeBoundaryHelper[scoreIdx].lowerBoundIsInfinity" :binary="true" inputId="lowerBound" name="lower" @change="boundaryLimitUpdated(scoreIdx, 'lower')"/>
-                                <label for="lowerBound" class="ml-2"> No lower bound </label>
-                              </span>
-                              <span style="float:right;">
-                                <label for="upperBound" class="ml-2"> No upper bound </label>
-                                <Checkbox v-model="scoreRangeBoundaryHelper[scoreIdx].upperBoundIsInfinity" :binary="true" inputId="upperBound" name="upper" @change="boundaryLimitUpdated(scoreIdx, 'upper')"/>
-                              </span>
-                            </div>
                             <span v-if="validationErrors[`scoreRanges.investigatorProvided.ranges.${scoreIdx}.range`]" class="mave-field-error">{{ validationErrors[`scoreRanges.investigatorProvided.ranges.${scoreIdx}.range`] }}</span>
+                            <span v-if="validationErrors[`scoreRanges.investigatorProvided.ranges.${scoreIdx}.inclusiveLowerBound`]" class="mave-field-error">{{ validationErrors[`scoreRanges.investigatorProvided.ranges.${scoreIdx}.inclusiveLowerBound`] }}</span>
+                            <span v-if="validationErrors[`scoreRanges.investigatorProvided.ranges.${scoreIdx}.inclusiveUpperBound`]" class="mave-field-error">{{ validationErrors[`scoreRanges.investigatorProvided.ranges.${scoreIdx}.inclusiveUpperBound`] }}</span>
                             <div v-if="scoreRange.oddsPath">
                               <Card>
                                 <template #title>OddsPath Ratio and Evidence Strength
@@ -432,6 +454,7 @@
                         <span v-if="validationErrors[`scoreRanges.investigatorProvided.oddsPathSource`]" class="mave-field-error">{{
                           validationErrors[`scoreRanges.investigatorProvided.oddsPathSource`] }}</span>
                       </div>
+                      <span v-if="validationErrors[`scoreRanges.investigatorProvided.ranges`]" class="mave-field-error">{{ validationErrors[`scoreRanges.investigatorProvided.ranges`] }}</span>
                       <div class="field" style="align-items: center; justify-content: center; display: flex; padding-top: 1%;">
                         <Button label="Add new score range" icon="pi pi-plus" aria-label="Add range" outlined raised text @click="addScoreRange()"/>
                       </div>
@@ -796,6 +819,7 @@
   import fasta from 'fasta-js'
   import _ from 'lodash'
   import {marked} from 'marked'
+  import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
   import AutoComplete from 'primevue/autocomplete'
   import Button from 'primevue/button'
   import Card from 'primevue/card'
@@ -864,6 +888,8 @@
         range: [null, null],
         classification: null,
         oddsPath: null,
+        inclusiveLowerBound: true,
+        inclusiveUpperBound: false,
       }
   }
 
@@ -876,7 +902,7 @@
 
   export default {
     name: 'ScoreSetEditor',
-    components: { AutoComplete, Button, Card, Chips, Column, Checkbox, DataTable, DefaultLayout, Dropdown, EmailPrompt, EntityLink, FileUpload, InputGroup, InputGroupAddon, InputNumber, InputText, InputSwitch, Message, Multiselect, ProgressSpinner, SelectButton, TabPanel, TabView, Textarea },
+    components: { AutoComplete, Button, Card, Chips, Column, Checkbox, DataTable, DefaultLayout, Dropdown, EmailPrompt, EntityLink, FileUpload, FontAwesomeIcon, InputGroup, InputGroupAddon, InputNumber, InputText, InputSwitch, Message, Multiselect, ProgressSpinner, SelectButton, TabPanel, TabView, Textarea },
 
     setup: () => {
       const publicationIdentifierSuggestions = useItems({ itemTypeName: 'publication-identifier-search' })
@@ -969,6 +995,8 @@
           ranges: [],
           oddsPathSource: [],
           source: [],
+          inclusiveLowerBound: true,
+          inclusiveUpperBound: false,
         }
       },
       activeScoreRangeTab: 0,
@@ -1370,13 +1398,27 @@
         }
       },
 
-      boundaryLimitUpdated: function(rangeIdx, boundary) {
+      toggleBoundary: function(rangeIdx, boundary) {
         const updatedRange = this.scoreRanges.investigatorProvided.ranges[rangeIdx]
         if (boundary === "upper") {
-          updatedRange.range[1] = null
+          updatedRange.inclusiveUpperBound = !updatedRange.inclusiveUpperBound
         }
         else if (boundary == "lower") {
+          updatedRange.inclusiveLowerBound = !updatedRange.inclusiveLowerBound
+        }
+      },
+
+      toggleInfinity: function(rangeIdx, boundary) {
+        const updatedRange = this.scoreRanges.investigatorProvided.ranges[rangeIdx]
+        if (boundary === "upper") {
+          this.scoreRangeBoundaryHelper[rangeIdx].upperBoundIsInfinity = !this.scoreRangeBoundaryHelper[rangeIdx].upperBoundIsInfinity
+          updatedRange.range[1] = null
+          updatedRange.inclusiveUpperBound = false
+        }
+        else if (boundary == "lower") {
+          this.scoreRangeBoundaryHelper[rangeIdx].lowerBoundIsInfinity = !this.scoreRangeBoundaryHelper[rangeIdx].lowerBoundIsInfinity
           updatedRange.range[0] = null
+          updatedRange.inclusiveLowerBound = false
         }
       },
 
@@ -1717,7 +1759,19 @@
           this.dataUsagePolicy = null
           this.taxonomy = null
           this.extraMetadata = {}
-          this.scoreRanges = { investigatorProvided: { baselineScore: undefined, baselineScoreDescription: undefined, ranges: [], oddsPathSource: [], source: [] } }
+          this.scoreRanges = {
+            investigatorProvided: {
+              baselineScore: undefined,
+              baselineScoreDescription: undefined,
+              ranges: [],
+              oddsPathSource: [],
+              source: [],
+              infiniteUpper: false,
+              infiniteLower: false,
+              inclusiveLowerBound: true,
+              inclusiveUpperBound: false,
+            }
+          }
           this.scoreRangeBoundaryHelper = []
           this.resetTarget()
           this.targetGenes = []
@@ -2080,6 +2134,16 @@
 
   .p-dropdown-item:nth-child(even) .mave-taxonomy-organism-name {
     background: #e9e9e9;
+  }
+
+  .score-range-toggle-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .score-range-toggle-icon {
+    margin: 0 auto;
   }
 
   /* Cards */

--- a/src/lib/ranges.ts
+++ b/src/lib/ranges.ts
@@ -67,6 +67,8 @@ export interface ScoreRange {
     } | undefined
     positiveLikelihoodRatio?: number | undefined
     evidenceStrength?: number | undefined
+    inclusiveLowerBound: boolean
+    inclusiveUpperBound: boolean
 }
 
 export function prepareRangesForHistogram(scoreRanges: ScoreRanges): HistogramShader[] {

--- a/src/main.js
+++ b/src/main.js
@@ -18,6 +18,13 @@ import 'primevue/resources/themes/mdc-light-indigo/theme.css'
 import 'primevue/resources/primevue.min.css'
 import 'primeicons/primeicons.css'
 
+/* add fontawesome core */
+/* import all the icons in Free Solid, Free Regular, and Brands styles */
+import { library } from '@fortawesome/fontawesome-svg-core'
+import { fas } from '@fortawesome/free-solid-svg-icons'
+import { far } from '@fortawesome/free-regular-svg-icons'
+import { fab } from '@fortawesome/free-brands-svg-icons'
+
 // Check localStorage in case the user is already logged in.
 initializeOrcidAuthentication()
 
@@ -47,6 +54,9 @@ createApp(App)
     .use(vueComponentId)
     .directive('tooltip', Tooltip)
     .mount('#app')
+
+// Add the FontAwesome icons to the library so that they can be used in components.
+library.add(fas, far, fab)
 
 initRestClient({apiBaseUrl: config.apiBaseUrl})
 


### PR DESCRIPTION
This pull request introduces improvements to the handling and display of score range boundaries in the application in support of https://github.com/VariantEffect/mavedb-api/pull/487. The main focus is on allowing users to specify whether the lower and upper bounds of a score range are inclusive or exclusive, and to toggle infinite boundaries with a more intuitive UI. Additionally, the code updates how these boundaries are processed and displayed throughout the application.

**Score Range Boundary Handling and UI Improvements:**

* Added inclusive/exclusive toggles and infinity buttons for score range boundaries in the `ScoreSetCreator` wizard, replacing previous checkbox-based controls. This provides a clearer and more flexible way for users to define score ranges. (`src/components/screens/ScoreSetCreator.vue`) [[1]](diffhunk://#diff-8d0fbd799b491d545f24fc258ec717f51fa0e1ebd192be00ed39a78f3e0d2b52L1035-L1058) [[2]](diffhunk://#diff-8d0fbd799b491d545f24fc258ec717f51fa0e1ebd192be00ed39a78f3e0d2b52L2017-R2063) [[3]](diffhunk://#diff-8d0fbd799b491d545f24fc258ec717f51fa0e1ebd192be00ed39a78f3e0d2b52R2846-R2855)
* Updated the default score range object and state to include `inclusiveLowerBound` and `inclusiveUpperBound` flags, ensuring new ranges have explicit boundary types. (`src/components/screens/ScoreSetCreator.vue`) [[1]](diffhunk://#diff-8d0fbd799b491d545f24fc258ec717f51fa0e1ebd192be00ed39a78f3e0d2b52R1330-R1331) [[2]](diffhunk://#diff-8d0fbd799b491d545f24fc258ec717f51fa0e1ebd192be00ed39a78f3e0d2b52R2382-R2385)
* Improved the display of score ranges in `RangeTable.vue` to show interval notation with brackets/parentheses, accurately reflecting inclusivity/exclusivity. (`src/components/RangeTable.vue`)
* Refined score range matching logic in `VariantMeasurementView.vue` to use the new inclusive/exclusive boundary flags when determining which range a score falls into. (`src/components/VariantMeasurementView.vue`)

**Dependency and Component Updates:**

* Added FontAwesome and related icon libraries to `package.json` and imported `FontAwesomeIcon` for use in the new UI controls. (`package.json`, `src/components/screens/ScoreSetCreator.vue`) [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R12-R16) [[2]](diffhunk://#diff-8d0fbd799b491d545f24fc258ec717f51fa0e1ebd192be00ed39a78f3e0d2b52R1252) [[3]](diffhunk://#diff-8d0fbd799b491d545f24fc258ec717f51fa0e1ebd192be00ed39a78f3e0d2b52R1358)

**Other Minor Fixes:**

* Updated `ScoreSetEditor.vue` to reference the correct edited score ranges object, ensuring consistency with the new boundary handling. (`src/components/screens/ScoreSetEditor.vue`)

**Boundary UI Examples:**

<img width="951" height="132" alt="Screenshot 2025-08-08 at 11 55 55 AM" src="https://github.com/user-attachments/assets/0ea4ab7b-5f1b-412d-a379-8510635902a8" />
<img width="944" height="132" alt="Screenshot 2025-08-08 at 11 56 58 AM" src="https://github.com/user-attachments/assets/9fc45bf8-621d-4e7e-a764-7b7fc1117da2" />