### PR TITLE
Scoreset heatmap and protein visualization improvements and addition of hydrophobicity and chemical classes to Amino acids

### DIFF
--- a/src/components/ProteinStructureView.vue
+++ b/src/components/ProteinStructureView.vue
@@ -46,6 +46,9 @@ export default {
     rowSelected: {
       type: Object,
     },
+    rowGroupSelected: {
+      type: Object,
+    },
     residueTooltips: {
       type: Array,
       default: () => []
@@ -58,14 +61,18 @@ export default {
     watch(() => props.rowSelected, (newValue) => {
       if (_.isNumber(newValue?.rowNumber)) {
         colorBy.value = [newValue.rowNumber, 'color']
-      } else {
-        colorBy.value = 'mean.color'
+      }
+    })
+
+    watch(() => props.rowGroupSelected, (newValue) => {
+      if (newValue?.colorBy && newValue.colorBy !== colorBy.value) {
+        colorBy.value = newValue.colorBy
       }
     })
 
     return {
       ...useScopedId(),
-      colorBy
+      colorBy,
     }
   },
 
@@ -110,6 +117,8 @@ export default {
       ]
       if (_.isNumber(this.rowSelected?.rowNumber) && this.rowSelected?.label) {
         return [...baseOptions, {name: this.rowSelected.label, value: [this.rowSelected.rowNumber, 'color']}]
+      } else if (this.rowGroupSelected?.label && this.rowGroupSelected?.colorBy) {
+        return [...baseOptions, {name: this.rowGroupSelected.label, value: this.rowGroupSelected.colorBy}]
       }
       return baseOptions
     },

--- a/src/components/ProteinStructureView.vue
+++ b/src/components/ProteinStructureView.vue
@@ -44,7 +44,7 @@ export default {
       default: () => []
     },
     rowSelected: {
-      type: Number,
+      type: Object,
     },
     residueTooltips: {
       type: Array,
@@ -56,8 +56,8 @@ export default {
     const colorBy = ref('mean.color')
 
     watch(() => props.rowSelected, (newValue) => {
-      if (_.isNumber(newValue)) {
-        colorBy.value = [newValue, 'color']
+      if (_.isNumber(newValue?.rowNumber)) {
+        colorBy.value = [newValue.rowNumber, 'color']
       } else {
         colorBy.value = 'mean.color'
       }
@@ -74,11 +74,6 @@ export default {
     viewerInstance: null,
     selectedAlphaFold: null,
     stage: null,
-    colorByOptions: [
-      {name: 'Mean Score', value: 'mean.color'},
-      {name: 'Min Missense Score', value: 'minMissense.color'},
-      {name: 'Max Missense Score', value: 'maxMissense.color'},
-    ],
     colorScheme: 'bfactor',
     colorSchemeOptions: [
       'atomindex',
@@ -107,6 +102,17 @@ export default {
   }),
 
   computed: {
+    colorByOptions: function() {
+      const baseOptions = [
+        {name: 'Mean Score', value: 'mean.color'},
+        {name: 'Min Missense Score', value: 'minMissense.color'},
+        {name: 'Max Missense Score', value: 'maxMissense.color'},
+      ]
+      if (_.isNumber(this.rowSelected?.rowNumber) && this.rowSelected?.label) {
+        return [...baseOptions, {name: this.rowSelected.label, value: [this.rowSelected.rowNumber, 'color']}]
+      }
+      return baseOptions
+    },
     selectionDataWithSelectedColorBy: function() {
         return _.map(this.selectionData, (x) => ({
           start_residue_number: x.start_residue_number,

--- a/src/components/ScoreSetHeatmap.vue
+++ b/src/components/ScoreSetHeatmap.vue
@@ -149,7 +149,7 @@ type HeatmapLayout = 'normal' | 'compact'
 export default defineComponent({
   name: 'ScoreSetHeatmap',
   components: {SelectButton, Button},
-  emits: ['variantSelected', 'variantColumnRangesSelected', 'variantRowSelected', 'heatmapVisible', 'exportChart', 'onDidClickShowProteinStructure'],
+  emits: ['variantSelected', 'variantColumnRangesSelected', 'variantRowSelected', 'variantRowsSelected', 'heatmapVisible', 'exportChart', 'onDidClickShowProteinStructure'],
 
   props: {
     coordinates: {
@@ -226,7 +226,7 @@ export default defineComponent({
     layout: 'normal' as HeatmapLayout
   }),
 
-  expose: ['simpleAndWtVariants', 'heatmap', 'scrollToPosition'],
+  expose: ['simpleAndWtVariants', 'heatmap', 'scrollToPosition', 'heatmapRows'],
 
 
   computed: {
@@ -862,6 +862,9 @@ export default defineComponent({
     variantRowSelected: function(data: HeatmapDatum[]) {
       this.$emit('variantRowSelected', data)
     },
+    variantRowsSelected: function(data: HeatmapDatum[][]) {
+      this.$emit('variantRowsSelected', data)
+    },
 
     renderOrRefreshHeatmaps: function() {
       if (!this.simpleAndWtVariants) {
@@ -901,6 +904,7 @@ export default defineComponent({
           .columnRangesSelected(this.variantColumnRangesSelected)
           .axisSelectionMode('y')
           .rowSelected(this.variantRowSelected)
+          .rowsSelected(this.variantRowsSelected)
       }
 
       if (this.layout == 'compact') {

--- a/src/components/ScoreSetHeatmap.vue
+++ b/src/components/ScoreSetHeatmap.vue
@@ -889,6 +889,7 @@ export default defineComponent({
         .yCoordinate(this.yCoord)
         .accessorField(this.accession)
         .tooltipHtml(this.tooltipHtmlGetter)
+        .tooltipTickLabelHtml(this.sequenceType == 'protein' ? this.tooltipTickLabelHtmlGetter : null)
         .datumSelected(this.variantSelected)
 
       if (!this.heatmap) {
@@ -955,6 +956,17 @@ export default defineComponent({
       } else {
         this.stackedHeatmap.clearSelection()
       }
+    },
+
+    tooltipTickLabelHtmlGetter: function(rowNumber: number) {
+      const currentRow = this.heatmapRows[this.heatmapRows.length - 1 - rowNumber]
+      if (this.sequenceType == 'protein') {
+        const aminoAcid = AMINO_ACIDS.find((aa) => aa.codes.single == currentRow.code)
+        if (aminoAcid) {
+          return `Name: ${aminoAcid.name} (${aminoAcid.codes.triple})<br/>Hydrophobicity: ${aminoAcid.hydrophobicity?.originalValue} (Kyte-Doolittle)<br/>Class: ${aminoAcid.class}`
+        }
+      }
+      return null
     },
 
     tooltipHtmlGetter: function(variant: HeatmapDatum) {

--- a/src/components/ScoreSetHeatmap.vue
+++ b/src/components/ScoreSetHeatmap.vue
@@ -51,15 +51,24 @@ import {parseSimpleProVariant, parseSimpleNtVariant, variantNotNullOrNA} from '@
 import { saveChartAsFile } from '@/lib/chart-export'
 import { Heatmap } from '@/lib/heatmap'
 // import {SPARSITY_THRESHOLD} from '@/lib/scoreSetHeatmap'
-import { AMINO_ACIDS, AMINO_ACIDS_WITH_TER, AMINO_ACIDS_BY_HYDROPHILIA } from '@/lib/amino-acids'
+import { AMINO_ACIDS, AMINO_ACIDS_WITH_TER } from '@/lib/amino-acids'
 import { NUCLEOTIDE_BASES } from '@/lib/nucleotides'
 import type {ScoreRange} from '@/lib/ranges'
 
+const HEATMAP_AMINO_ACIDS_SORTED = _.sortBy(
+  AMINO_ACIDS,
+  [ (aa) => _.indexOf(['unique', 'aromatic', 'non-polar', 'polar-neutral', 'negative-charged', 'positive-charged'], aa.class), 'hydrophobicity.originalValue'],
+)
 const HEATMAP_AMINO_ACID_ROWS: HeatmapRowSpecification[] = [
   { code: '=', label: '\uff1d' },
   { code: '*', label: '\uff0a' },
   { code: '-', label: '\uff0d' },
-  ...AMINO_ACIDS_BY_HYDROPHILIA.map((aaCode) => ({ code: aaCode, label: aaCode }))
+  ...HEATMAP_AMINO_ACIDS_SORTED.map((aa) => ({
+      code: aa.codes.single,
+      label: aa.codes.single,
+      groupCode: aa.class,
+      groupLabel: aa.class == 'positive-charged' ? '(+)' : aa.class == 'negative-charged' ? '(-)' : aa.class,
+  }))
 ]
 
 /** Codes used in the right part of a MaveHGVS-pro string representing a single variation in a protein sequence. */
@@ -873,6 +882,7 @@ export default defineComponent({
       this.heatmap = makeHeatmap()
         .margins({top: 0, bottom: 25, left: 20, right: 20})
         .legendTitle("Functional Score")
+        .drawYGroups(this.sequenceType == 'dna' ? false : true)
         .render(this.$refs.simpleVariantsHeatmapContainer, this.$refs.heatmapContainer)
         .rows(this.heatmapRows)
         .xCoordinate(this.xCoord)

--- a/src/components/ScoreSetHeatmap.vue
+++ b/src/components/ScoreSetHeatmap.vue
@@ -149,7 +149,7 @@ type HeatmapLayout = 'normal' | 'compact'
 export default defineComponent({
   name: 'ScoreSetHeatmap',
   components: {SelectButton, Button},
-  emits: ['variantSelected', 'variantColumnRangesSelected', 'variantRowSelected', 'variantRowsSelected', 'heatmapVisible', 'exportChart', 'onDidClickShowProteinStructure'],
+  emits: ['variantSelected', 'variantColumnRangesSelected', 'variantRowSelected', 'variantRowGroupSelected', 'heatmapVisible', 'exportChart', 'onDidClickShowProteinStructure'],
 
   props: {
     coordinates: {
@@ -862,8 +862,8 @@ export default defineComponent({
     variantRowSelected: function(data: HeatmapDatum[]) {
       this.$emit('variantRowSelected', data)
     },
-    variantRowsSelected: function(data: HeatmapDatum[][]) {
-      this.$emit('variantRowsSelected', data)
+    variantRowGroupSelected: function(group: {groupCode: string, groupLabel: string | null, data: HeatmapDatum[][]}) {
+      this.$emit('variantRowGroupSelected', group)
     },
 
     renderOrRefreshHeatmaps: function() {
@@ -904,7 +904,7 @@ export default defineComponent({
           .columnRangesSelected(this.variantColumnRangesSelected)
           .axisSelectionMode('y')
           .rowSelected(this.variantRowSelected)
-          .rowsSelected(this.variantRowsSelected)
+          .rowGroupSelected(this.variantRowGroupSelected)
       }
 
       if (this.layout == 'compact') {

--- a/src/components/ScoreSetHeatmap.vue
+++ b/src/components/ScoreSetHeatmap.vue
@@ -46,14 +46,85 @@ import Button from 'primevue/button'
 import {defineComponent, PropType} from 'vue'
 
 import geneticCodes from '@/lib/genetic-codes'
-import makeHeatmap, {heatmapRowForNucleotideVariant, heatmapRowForProteinVariant, HEATMAP_AMINO_ACID_ROWS, HEATMAP_NUCLEOTIDE_ROWS, HeatmapDatum} from '@/lib/heatmap'
+import makeHeatmap, {HeatmapDatum, HeatmapRowSpecification} from '@/lib/heatmap'
 import {parseSimpleProVariant, parseSimpleNtVariant, variantNotNullOrNA} from '@/lib/mave-hgvs'
 import { saveChartAsFile } from '@/lib/chart-export'
 import { Heatmap } from '@/lib/heatmap'
-import {SPARSITY_THRESHOLD} from '@/lib/score-set-heatmap'
-import { AMINO_ACIDS, AMINO_ACIDS_WITH_TER } from '@/lib/amino-acids'
+// import {SPARSITY_THRESHOLD} from '@/lib/scoreSetHeatmap'
+import { AMINO_ACIDS, AMINO_ACIDS_WITH_TER, AMINO_ACIDS_BY_HYDROPHILIA } from '@/lib/amino-acids'
 import { NUCLEOTIDE_BASES } from '@/lib/nucleotides'
 import type {ScoreRange} from '@/lib/ranges'
+
+const HEATMAP_AMINO_ACID_ROWS: HeatmapRowSpecification[] = [
+  { code: '=', label: '\uff1d' },
+  { code: '*', label: '\uff0a' },
+  { code: '-', label: '\uff0d' },
+  ...AMINO_ACIDS_BY_HYDROPHILIA.map((aaCode) => ({ code: aaCode, label: aaCode }))
+]
+
+/** Codes used in the right part of a MaveHGVS-pro string representing a single variation in a protein sequence. */
+const MAVE_HGVS_PRO_CHANGE_CODES = [
+  { codes: { single: '=' } }, // Synonymous AA variant
+  { codes: { single: '*', triple: 'TER' } }, // Stop codon
+  { codes: { single: '-', triple: 'DEL' } } // Deletion
+]
+
+const HEATMAP_NUCLEOTIDE_ROWS: HeatmapRowSpecification[] = [
+  ...NUCLEOTIDE_BASES.map((ntCode) => ({ code: ntCode.codes.single, label: ntCode.codes.single }))
+]
+/**
+ * Given a MaveHGVS-pro amino acid code or code representing deletion, synonmyous variation, or stop codon, return the
+ * heatmap row number on which a single-AA variant should be displayed.
+ *
+ * @param aaCodeOrChange A one- or three-character code representing an amino acid or the result of a variation at a
+ *   single locus in a protein sequence. If not an amino acid code, it should be a code representing synonymous
+ *   variation (=), stop codon (*), or deletion (- or del).
+ * @returns The heatmap row number, from 0 (the bottom row) to 22 (the top row).
+ */
+function heatmapRowForProteinVariant(aaCodeOrChange: string): number | null {
+  const singleLetterCode = singleLetterAminoAcidOrHgvsCode(aaCodeOrChange)
+  const ranking = singleLetterCode ? HEATMAP_AMINO_ACID_ROWS.findIndex((rowSpec) => rowSpec.code == singleLetterCode) : null
+  return (ranking != null && ranking >= 0) ? ranking : null
+}
+
+/**
+ * Given a MaveHGVS-pro amino acid code or code representing deletion, synonmyous variation, or stop codon, return the
+ * corresponding single-character code (which is the code used in our heatmap's y-axis).
+ *
+ * @param aaCodeOrChange A one- or three-character code representing an amino acid or the result of a variation at a
+ *   single locus in a protein sequence. If not an amino acid code, it should be a code representing synonymous
+ *   variation (=), stop codon (*), or deletion (- or del).
+ * @return The one-character code representing the same amino acid or change, or null if the input was not a supported
+ *   amino acid or change.
+ */
+function singleLetterAminoAcidOrHgvsCode(aaCodeOrChange: string): string | null {
+  const code = aaCodeOrChange.toUpperCase()
+  if (code.length == 1) {
+    return code
+  }
+  if (code.length == 3) {
+    return AMINO_ACIDS.find((aa) => aa.codes.triple == code)?.codes?.single
+      || MAVE_HGVS_PRO_CHANGE_CODES.find((change) => change.codes.triple == code)?.codes?.single
+      || null
+  }
+  // TODO What about D-amino acids? The "d-" prefix has been capitalized at this point, so if we need to handle these,
+  // we should match against capitalized five-letter codes.
+  return null
+}
+
+/**
+ * Given a MaveHGVS-pro amino acid code or code representing deletion, synonmyous variation, or stop codon, return the
+ * heatmap row number on which a single-AA variant should be displayed.
+ *
+ * @param ntCodeOrChange A one-character code representing a nucleotide base or the result of a variation at a
+ *   single locus in a nucleotide sequence.
+ * @returns The heatmap row number, from 0 (the bottom row) to 3 (the top row).
+ */
+function heatmapRowForNucleotideVariant(ntCodeOrChange: string): number | null {
+  const singleLetterCode = ntCodeOrChange.toUpperCase()
+  const ranking = singleLetterCode ? HEATMAP_NUCLEOTIDE_ROWS.findIndex((rowSpec) => rowSpec.code == singleLetterCode) : null
+  return (ranking != null && ranking >= 0) ? ranking : null
+}
 
 function stdev(array: number[]) {
   if (!array || array.length === 0) {

--- a/src/components/ScoreSetHistogram.vue
+++ b/src/components/ScoreSetHistogram.vue
@@ -1,10 +1,7 @@
 <template>
-  <TabMenu v-if="hasTabBar" v-model:active-index="activeViz" class="mavedb-histogram-viz-select" :model="vizOptions" />
-  <div
-    v-if="clinicalControlsEnabled && (!refreshedClinicalControls || !associatedClinicalControls)"
-    style="font-size: x-small"
-  >
-    <ProgressSpinner style="height: 12px; width: 12px" />
+  <TabMenu class="mave-histogram-viz-select" v-if="hasTabBar" v-model:activeIndex="activeViz" :model="vizOptions" />
+  <div v-if="clinicalControlsEnabled && (!refreshedClinicalControls || !associatedClinicalControls)" style="font-size: small;">
+    <ProgressSpinner style="height: 24px; width: 24px;" />
     Loading clinical control options in the background. Additional histogram views will be available once loaded.
   </div>
   <div v-if="showControls" class="mavedb-histogram-controls">
@@ -463,25 +460,18 @@ export default defineComponent({
           //       (dnaHgvs ? `${spliceHgvs} (${dnaHgvs})` : spliceHgvs)
           //       : dnaHgvs
           // )
-          const mappedVariantLabel = mappedProteinHgvs
-            ? mappedDnaHgvs
-              ? `${mappedProteinHgvs} (${mappedDnaHgvs})`
-              : mappedProteinHgvs
-            : mappedDnaHgvs
-          const unmappedVariantLabel = unmappedProteinHgvs
-            ? unmappedDnaHgvs
-              ? `${unmappedProteinHgvs} (${unmappedDnaHgvs})`
-              : unmappedProteinHgvs
-            : unmappedSpliceHgvs
-              ? unmappedDnaHgvs
-                ? `${unmappedSpliceHgvs} (${unmappedDnaHgvs})`
-                : unmappedSpliceHgvs
-              : unmappedDnaHgvs
+          const mappedVariantLabel = mappedProteinHgvs ?
+              (mappedDnaHgvs ? `${mappedProteinHgvs} (${mappedDnaHgvs})` : mappedProteinHgvs)
+              : mappedDnaHgvs
+          const unmappedVariantLabel = unmappedProteinHgvs ?
+              (unmappedDnaHgvs ? `${unmappedProteinHgvs} (${unmappedDnaHgvs})` : unmappedProteinHgvs)
+              : unmappedSpliceHgvs ?
+                (unmappedDnaHgvs ? `${unmappedSpliceHgvs} (${unmappedDnaHgvs})` : unmappedSpliceHgvs)
+                : unmappedDnaHgvs
 
-          const variantLabel =
-            this.coordinates == 'mapped'
-              ? (mappedVariantLabel ?? variant.mavedb_label ?? unmappedVariantLabel)
-              : (variant.mavedb_label ?? unmappedVariantLabel)
+          const variantLabel = this.coordinates == 'mapped' ?
+              mappedVariantLabel ?? variant.mavedb_label ?? unmappedVariantLabel
+              : variant.mavedb_label ?? unmappedVariantLabel
           if (variantLabel) {
             parts.push(variantLabel)
           }

--- a/src/components/ScoreSetVisualizer.vue
+++ b/src/components/ScoreSetVisualizer.vue
@@ -38,6 +38,7 @@ import ScoreSetHeatmap from '@/components/ScoreSetHeatmap'
 import Splitter from 'primevue/splitter'
 import SplitterPanel from 'primevue/splitterpanel'
 import _ from 'lodash'
+import { AMINO_ACIDS } from '@/lib/amino-acids'
 
 export default {
   name: 'ScoreSetVisualizer',
@@ -83,7 +84,16 @@ export default {
       this.selectedResidueRanges = ranges
     },
     didSelectHeatmapRow: function(data) {
-      this.rowSelected = _.get(data, '0.y', null)
+      const aaRows = this.$refs.scoreSetHeatmap.heatmapRows
+      const rowNumber = _.get(data, '0.y', null)
+      if (!_.isNumber(rowNumber)) return
+
+      const selectedRow = aaRows[aaRows.length - rowNumber - 1]
+      const aa = AMINO_ACIDS.find((a) => a.codes?.single === selectedRow?.code)
+      this.rowSelected = {
+        rowNumber,
+        label: aa?.name || selectedRow?.code,
+      }
     },
     rgbToHex: (rgb) => {
       const nums = _.words(rgb, /[0-9]+/g)

--- a/src/components/ScoreSetVisualizer.vue
+++ b/src/components/ScoreSetVisualizer.vue
@@ -110,33 +110,26 @@ export default {
       const heatmapColorScale = this.$refs.scoreSetHeatmap?.heatmap?.colorScale()
 
       if (heatmapColorScale) {
-        let meanScores
-        if (!data || data.length === 0 || data[0].length === 0) {
-          meanScores = []
-        } else {
-          meanScores = new Array(data[0].length)
-        }
-
         const numRows = data.length
-        const numCols = data[0].length
+        const maxX = _.max(_.map(data, (rowData) => _.max(_.map(rowData, 'x'))))
+        const minX = _.min(_.map(data, (rowData) => _.min(_.map(rowData, 'x'))))
 
-        for (let j = 0; j < numCols; j++) {
+        for (let x = minX; x <= maxX; x++) {
           let scoreSum = 0
           let scoreCount = 0
           for (let i = 0; i < numRows; i++) {
-            if (_.has(data, [i, j, 'meanScore'])) {
+            const cellData = _.find(data[i], (d) => d.x === x)
+            if (_.isNumber(cellData?.meanScore)) {
               scoreCount += 1
-              scoreSum += _.get(data, [i, j, 'meanScore'], 0)
+              scoreSum += cellData.meanScore
             }
           }
-          meanScores[j] = scoreSum / scoreCount
-        }
-        meanScores.forEach((meanScore, index) => {
-          _.set(this.selectionData, [index, _.camelCase(groupCode)], {
+          const meanScore = scoreSum / scoreCount
+          _.set(this.selectionData, [x-1, _.camelCase(groupCode)], {
             score: meanScore,
             color: _.isNumber(meanScore) ? this.rgbToHex(heatmapColorScale(meanScore)) : '#000',
           })
-        })
+        }
         this.rowGroupSelected = {
           label: groupCode,
           colorBy: `${_.camelCase(groupCode)}.color`,

--- a/src/components/screens/ScoreSetView.vue
+++ b/src/components/screens/ScoreSetView.vue
@@ -94,7 +94,10 @@
           />
         </div>
       </div>
-      <div class="mavedb-1000px-col">
+      <div v-else-if="scoresDataStatus=='Loading' || scoresDataStatus=='NotLoaded'">
+        <ProgressSpinner style="width: 36px; height: 36px; margin: 12px auto; display: block;" />
+      </div>
+      <div class="mave-1000px-col">
         <div class="clearfix">
           <div v-if="config.CLINICAL_FEATURES_ENABLED" class="mavedb-assay-facts-container">
             <AssayFactSheet :score-set="item" />
@@ -359,12 +362,11 @@ export default {
       variantSearchSuggestions
     }
   },
-
+ 
   data: () => ({
     clinicalMode: config.CLINICAL_FEATURES_ENABLED,
     scores: null,
     codingVariants: null,
-    readMore: true,
     showHeatmap: true,
     isScoreSetVisualizerVisible: false,
     heatmapExists: false,
@@ -372,8 +374,8 @@ export default {
     userIsAuthorized: {
       delete: false,
       publish: false,
-      update: false
-    }
+      update: false,
+    },
   }),
 
   computed: {

--- a/src/lib/amino-acids.ts
+++ b/src/lib/amino-acids.ts
@@ -1,25 +1,31 @@
-/** Amino acids and their codes. */
+/** Amino acids, their codes, hydrophobicity based on Kyte-Doolittle scale, and class based on Enrich2 paper (fig.1).
+ *
+ * Kyte-Doolittle data source: https://github.com/channotation/chap/blob/master/share/data/hydrophobicity/kyte_doolittle_1982.json
+ * reference: http://www.sciencedirect.com/science/article/pii/0022283682905150
+ *
+ * Enrich2 reference: https://genomebiology.biomedcentral.com/articles/10.1186/s13059-017-1272-5/figures/1
+ */
 export const AMINO_ACIDS = [
-  {name: 'Alanine', codes: {single: 'A', triple: 'ALA', dAminoAcidCode: 'd-ALA'}},
-  {name: 'Arginine', codes: {single: 'R', triple: 'ARG', dAminoAcidCode: 'd-ARG'}},
-  {name: 'Asparagine', codes: {single: 'N', triple: 'ASN', dAminoAcidCode: 'd-ASN'}},
-  {name: 'Aspartic Acid', codes: {single: 'D', triple: 'ASP', dAminoAcidCode: 'd-ASP'}},
-  {name: 'Cysteine', codes: {single: 'C', triple: 'CYS', dAminoAcidCode: 'd-CYS'}},
-  {name: 'Glutamic Acid', codes: {single: 'E', triple: 'GLU', dAminoAcidCode: 'd-GLU'}},
-  {name: 'Glutamine', codes: {single: 'Q', triple: 'GLN', dAminoAcidCode: 'd-GLN'}},
-  {name: 'Glycine', codes: {single: 'G', triple: 'GLY', dAminoAcidCode: ''}},
-  {name: 'Histidine', codes: {single: 'H', triple: 'HIS', dAminoAcidCode: 'd-HIS'}},
-  {name: 'Isoleucine', codes: {single: 'I', triple: 'ILE', dAminoAcidCode: 'd-ILE'}},
-  {name: 'Leucine', codes: {single: 'L', triple: 'LEU', dAminoAcidCode: 'd-LEU'}},
-  {name: 'Lysine', codes: {single: 'K', triple: 'LYS', dAminoAcidCode: 'd-LYS'}},
-  {name: 'Methionine', codes: {single: 'M', triple: 'MET', dAminoAcidCode: 'd-MET'}},
-  {name: 'Phenylalanine', codes: {single: 'F', triple: 'PHE', dAminoAcidCode: 'd-PHE'}},
-  {name: 'Proline', codes: {single: 'P', triple: 'PRO', dAminoAcidCode: 'd-PRO'}},
-  {name: 'Serine', codes: {single: 'S', triple: 'SER', dAminoAcidCode: 'd-SER'}},
-  {name: 'Threonine', codes: {single: 'T', triple: 'THR', dAminoAcidCode: 'd-THR'}},
-  {name: 'Tryptophan', codes: {single: 'W', triple: 'TRP', dAminoAcidCode: 'd-TRP'}},
-  {name: 'Tyrosine', codes: {single: 'Y', triple: 'TYR', dAminoAcidCode: 'd-TYR'}},
-  {name: 'Valine', codes: {single: 'V', triple: 'VAL', dAminoAcidCode: 'd-VAL'}}
+  {name: 'Alanine', codes: {single: 'A', triple: 'ALA', dAminoAcidCode: 'd-ALA'}, class: 'non-polar', hydrophobicity: {normalizedValue: 0.40000000, originalValue: 1.80}},
+  {name: 'Arginine', codes: {single: 'R', triple: 'ARG', dAminoAcidCode: 'd-ARG'}, class: 'positive-charged', hydrophobicity: {normalizedValue: -1.00000000, originalValue: -4.50}},
+  {name: 'Asparagine', codes: {single: 'N', triple: 'ASN', dAminoAcidCode: 'd-ASN'}, class: 'polar-neutral', hydrophobicity: {normalizedValue: -0.77777778, originalValue: -3.50}},
+  {name: 'Aspartic Acid', codes: {single: 'D', triple: 'ASP', dAminoAcidCode: 'd-ASP'}, class: 'negative-charged', hydrophobicity: {normalizedValue: -0.77777778, originalValue: -3.50}},
+  {name: 'Cysteine', codes: {single: 'C', triple: 'CYS', dAminoAcidCode: 'd-CYS'}, class: 'polar-neutral', hydrophobicity: {normalizedValue: 0.55555556, originalValue: 2.50}},
+  {name: 'Glutamic Acid', codes: {single: 'E', triple: 'GLU', dAminoAcidCode: 'd-GLU'}, class: 'negative-charged', hydrophobicity: {normalizedValue: -0.77777778, originalValue: -3.50}},
+  {name: 'Glutamine', codes: {single: 'Q', triple: 'GLN', dAminoAcidCode: 'd-GLN'}, class: 'polar-neutral', hydrophobicity: {normalizedValue: -0.77777778, originalValue: -3.50}},
+  {name: 'Glycine', codes: {single: 'G', triple: 'GLY', dAminoAcidCode: ''}, class: 'unique', hydrophobicity: {normalizedValue: -0.08888889, originalValue: -0.40}},
+  {name: 'Histidine', codes: {single: 'H', triple: 'HIS', dAminoAcidCode: 'd-HIS'}, class: 'positive-charged', hydrophobicity: {normalizedValue: -0.71111111, originalValue: -3.20}},
+  {name: 'Isoleucine', codes: {single: 'I', triple: 'ILE', dAminoAcidCode: 'd-ILE'}, class: 'non-polar', hydrophobicity: {normalizedValue: 1.00000000, originalValue: 4.50}},
+  {name: 'Leucine', codes: {single: 'L', triple: 'LEU', dAminoAcidCode: 'd-LEU'}, class: 'non-polar', hydrophobicity: {normalizedValue: 0.84444444, originalValue: 3.80}},
+  {name: 'Lysine', codes: {single: 'K', triple: 'LYS', dAminoAcidCode: 'd-LYS'}, class: 'positive-charged', hydrophobicity: {normalizedValue: -0.86666667, originalValue: -3.90}},
+  {name: 'Methionine', codes: {single: 'M', triple: 'MET', dAminoAcidCode: 'd-MET'}, class: 'polar-neutral', hydrophobicity: {normalizedValue: 0.42222222, originalValue: 1.90}},
+  {name: 'Phenylalanine', codes: {single: 'F', triple: 'PHE', dAminoAcidCode: 'd-PHE'}, class: 'aromatic', hydrophobicity: {normalizedValue: 0.62222222, originalValue: 2.80}},
+  {name: 'Proline', codes: {single: 'P', triple: 'PRO', dAminoAcidCode: 'd-PRO'}, class: 'unique', hydrophobicity: {normalizedValue: -0.35555556, originalValue: -1.60}},
+  {name: 'Serine', codes: {single: 'S', triple: 'SER', dAminoAcidCode: 'd-SER'}, class: 'polar-neutral', hydrophobicity: {normalizedValue: -0.17777778, originalValue: -0.80}},
+  {name: 'Threonine', codes: {single: 'T', triple: 'THR', dAminoAcidCode: 'd-THR'}, class: 'polar-neutral', hydrophobicity: {normalizedValue: -0.15555556, originalValue: -0.70}},
+  {name: 'Tryptophan', codes: {single: 'W', triple: 'TRP', dAminoAcidCode: 'd-TRP'}, class: 'aromatic', hydrophobicity: {normalizedValue: -0.20000000, originalValue: -0.90}},
+  {name: 'Tyrosine', codes: {single: 'Y', triple: 'TYR', dAminoAcidCode: 'd-TYR'}, class: 'aromatic', hydrophobicity: {normalizedValue: -0.28888889, originalValue: -1.30}},
+  {name: 'Valine', codes: {single: 'V', triple: 'VAL', dAminoAcidCode: 'd-VAL'}, class: 'non-polar', hydrophobicity: {normalizedValue: 0.93333333, originalValue: 4.20}}
 ]
 
 export const AMINO_ACIDS_WITH_TER = [...AMINO_ACIDS, {name: 'Termination', codes: {single: '*', triple: 'Ter'}}]

--- a/src/lib/heatmap.ts
+++ b/src/lib/heatmap.ts
@@ -92,7 +92,7 @@ export interface Heatmap {
   datumSelected: Accessor<((d: HeatmapDatum) => void) | null, Heatmap>
   columnRangesSelected: Accessor<((ranges: Array<{start: number; end: number}>) => void) | null, Heatmap>
   rowSelected: Accessor<((data: HeatmapDatum[]) => void) | null, Heatmap>
-  rowRangesSelected: Accessor<((ranges: Array<{start: number, end: number}>) => void) | null, Heatmap>
+  rowsSelected: Accessor<((data: HeatmapDatum[][]) => void) | null, Heatmap>
   excludeDatum: Accessor<((d: HeatmapDatum) => boolean), Heatmap>
 
   // Data fields
@@ -182,7 +182,7 @@ export default function makeHeatmap(): Heatmap {
   let datumSelected: ((d: HeatmapDatum) => void) | null = null
   let columnRangesSelected: ((ranges: Array<{start: number; end: number}>) => void) | null = null
   let rowSelected: ((data: HeatmapDatum[]) => void) | null = null
-  let rowRangesSelected: ((ranges: Array<{start: number, end: number}>) => void) | null = null
+  let rowsSelected: ((data: HeatmapDatum[][]) => void) | null = null
   let excludeDatum: ((d: HeatmapDatum) => boolean) = (d) => false as boolean
 
   // Layout
@@ -386,7 +386,15 @@ export default function makeHeatmap(): Heatmap {
           .style('stroke', '#808')
           .raise()
       }
-      if (rowRangesSelected) rowRangesSelected([{ start: startRowNumber, end: startRowNumber + rowCount - 1 }])
+
+      if (rowsSelected) {
+        // return 2D array of data in the selected rows
+        const selectedRows: HeatmapDatum[][] = []
+        for (let i = startRowNumber; i < startRowNumber + rowCount; i++) {
+          selectedRows.push(data.filter((d: HeatmapDatum) => yCoordinate(d) === i))
+        }
+        rowsSelected(selectedRows)
+      }
   }
 
   const click = function (event: MouseEvent, d: HeatmapDatum) {
@@ -1249,11 +1257,11 @@ export default function makeHeatmap(): Heatmap {
       return chart
     },
 
-    rowRangesSelected: (value?: ((ranges: Array<{start: number, end: number}>) => void) | null) => {
+    rowsSelected: (value?: ((data: HeatmapDatum[][]) => void) | null) => {
       if (value === undefined) {
-        return rowRangesSelected
+        return rowsSelected
       }
-      rowRangesSelected = value
+      rowsSelected = value
       return chart
     },
 

--- a/src/lib/heatmap.ts
+++ b/src/lib/heatmap.ts
@@ -10,7 +10,7 @@ export const DEFAULT_PIVOT_COLOR = '#FFFFFF'
 export const DEFAULT_MAXIMUM_COLOR = '#B00020'
 
 const LABEL_SIZE = 10
-const LEGEND_SIZE = 75
+const LEGEND_SIZE = 80
 
 /**
  * Margins of the heatmap content inside the SVG, expressed in screen units (pixels).
@@ -971,6 +971,11 @@ export default function makeHeatmap(): Heatmap {
               )
               .select('.domain')
               .remove()
+
+            // Center the text labels after the axis is created
+            yAxisLabels.selectAll('g.tick text')
+              .attr('text-anchor', 'middle')
+              .attr('x', -8)
 
             if (axisSelectionMode == 'y') {
               yAxisLabels.style('cursor', 'pointer').on('click', function (event) {

--- a/src/lib/heatmap.ts
+++ b/src/lib/heatmap.ts
@@ -1,8 +1,5 @@
 import * as d3 from 'd3'
-import _, {range} from 'lodash'
-
-import {AMINO_ACIDS, AMINO_ACIDS_BY_HYDROPHILIA} from './amino-acids.js'
-import {NUCLEOTIDE_BASES} from './nucleotides.js'
+import _ from 'lodash'
 
 type FieldGetter<T> = (d: HeatmapDatum) => T
 type Getter<T> = () => T
@@ -14,25 +11,6 @@ export const DEFAULT_MAXIMUM_COLOR = '#B00020'
 
 const LABEL_SIZE = 10
 const LEGEND_SIZE = 75
-
-/** Codes used in the right part of a MaveHGVS-pro string representing a single variation in a protein sequence. */
-export const MAVE_HGVS_PRO_CHANGE_CODES = [
-  {codes: {single: '='}}, // Synonymous AA variant
-  {codes: {single: '*', triple: 'TER'}}, // Stop codon
-  {codes: {single: '-', triple: 'DEL'}} // Deletion
-]
-
-export const HEATMAP_NUCLEOTIDE_ROWS: HeatmapRowSpecification[] = [
-  ...NUCLEOTIDE_BASES.map((ntCode) => ({code: ntCode.codes.single, label: ntCode.codes.single}))
-]
-
-/** List of single-character codes for the heatmap's rows, from bottom to top. */
-export const HEATMAP_AMINO_ACID_ROWS: HeatmapRowSpecification[] = [
-  {code: '=', label: '\uff1d'},
-  {code: '*', label: '\uff0a'},
-  {code: '-', label: '\uff0d'},
-  ...AMINO_ACIDS_BY_HYDROPHILIA.map((aaCode) => ({code: aaCode, label: aaCode}))
-]
 
 /**
  * Margins of the heatmap content inside the SVG, expressed in screen units (pixels).
@@ -53,9 +31,9 @@ export interface HeatmapNodeSize {
 }
 
 export interface HeatmapRowSpecification {
-  /** A single-character amino acid code or single-character code from MAVE_HGVS_PRO_CHANGE_CODES. */
+  /** A single-character code for this row. */
   code: string
-  /** The tick mark label text to display for this change, which is usually the same as the code. */
+  /** The tick mark label text to display for this row, which is usually the same as the code. */
   label: string
   /** An optional CSS class name to apply to the row's tick mark label. */
   cssClass?: string
@@ -200,9 +178,9 @@ export default function makeHeatmap(): Heatmap {
   // Layout
   let margins: HeatmapMargins = {top: 20, right: 20, bottom: 30, left: 20}
   let nodeBorderRadius: number = 4
-  let nodePadding: number = 0.1
-  let nodeSize: HeatmapNodeSize = {width: 20, height: 20}
-  let rows: HeatmapRowSpecification[] = HEATMAP_AMINO_ACID_ROWS
+  let nodePadding: number = .1
+  let nodeSize: HeatmapNodeSize = { width: 20, height: 20}
+  let rows: HeatmapRowSpecification[] = []
 
   // Colors
   let colorScaleControlPoints: HeatmapColorScaleControlPoint[] | null = null
@@ -1358,66 +1336,6 @@ export default function makeHeatmap(): Heatmap {
   }
 
   return chart
-}
-
-/**
- * Given a MaveHGVS-pro amino acid code or code representing deletion, synonmyous variation, or stop codon, return the
- * corresponding single-character code (which is the code used in our heatmap's y-axis).
- *
- * @param aaCodeOrChange A one- or three-character code representing an amino acid or the result of a variation at a
- *   single locus in a protein sequence. If not an amino acid code, it should be a code representing synonymous
- *   variation (=), stop codon (*), or deletion (- or del).
- * @return The one-character code representing the same amino acid or change, or null if the input was not a supported
- *   amino acid or change.
- */
-export function singleLetterAminoAcidOrHgvsCode(aaCodeOrChange: string): string | null {
-  const code = aaCodeOrChange.toUpperCase()
-  if (code.length == 1) {
-    return code
-  }
-  if (code.length == 3) {
-    return (
-      AMINO_ACIDS.find((aa) => aa.codes.triple == code)?.codes?.single ||
-      MAVE_HGVS_PRO_CHANGE_CODES.find((change) => change.codes.triple == code)?.codes?.single ||
-      null
-    )
-  }
-  // TODO What about D-amino acids? The "d-" prefix has been capitalized at this point, so if we need to handle these,
-  // we should match against capitalized five-letter codes.
-  return null
-}
-
-/**
- * Given a MaveHGVS-pro amino acid code or code representing deletion, synonmyous variation, or stop codon, return the
- * heatmap row number on which a single-AA variant should be displayed.
- *
- * @param aaCodeOrChange A one- or three-character code representing an amino acid or the result of a variation at a
- *   single locus in a protein sequence. If not an amino acid code, it should be a code representing synonymous
- *   variation (=), stop codon (*), or deletion (- or del).
- * @returns The heatmap row number, from 0 (the bottom row) to 22 (the top row).
- */
-export function heatmapRowForProteinVariant(aaCodeOrChange: string): number | null {
-  const singleLetterCode = singleLetterAminoAcidOrHgvsCode(aaCodeOrChange)
-  const ranking = singleLetterCode
-    ? HEATMAP_AMINO_ACID_ROWS.findIndex((rowSpec) => rowSpec.code == singleLetterCode)
-    : null
-  return ranking != null && ranking >= 0 ? ranking : null
-}
-
-/**
- * Given a MaveHGVS-pro amino acid code or code representing deletion, synonmyous variation, or stop codon, return the
- * heatmap row number on which a single-AA variant should be displayed.
- *
- * @param ntCodeOrChange A one-character code representing a nucleotide base or the result of a variation at a
- *   single locus in a nucleotide sequence.
- * @returns The heatmap row number, from 0 (the bottom row) to 3 (the top row).
- */
-export function heatmapRowForNucleotideVariant(ntCodeOrChange: string): number | null {
-  const singleLetterCode = ntCodeOrChange.toUpperCase()
-  const ranking = singleLetterCode
-    ? HEATMAP_NUCLEOTIDE_ROWS.findIndex((rowSpec) => rowSpec.code == singleLetterCode)
-    : null
-  return ranking != null && ranking >= 0 ? ranking : null
 }
 
 /**


### PR DESCRIPTION
Updates to heatmap, scoreset view, and protein visualization to include hydrophobicity and chemical classification for amino acids.

- Adds Kyte-Doolittle hydrophobicity values and chemical classifications to amino acids
- Adds tooltips to display amino acid details on y-axis tick labels of heatmap
- Adds chemical class groupings to y-axis of heatmap, with clickable labels to select group of rows
- Calculates mean score at each residue position when group is selected, and assigns color based on heatmap color scale to use on protein structure visualziation
- Updates protein visualization to display current color by selection (amino acid or chemical class group) as option in select button, alongside mean, min. and max. missense options previously available.

