### PR TITLE
Histogram Options for Variants Based On Protein Effect

### DIFF
--- a/src/components/ScoreSetHeatmap.vue
+++ b/src/components/ScoreSetHeatmap.vue
@@ -96,7 +96,6 @@ interface VariantClassHeatmapDatum {
   /** One variant in the class. All of its properties are shared by the other variants except its score, which should be ignored. */
   instance?: Variant
 }
-// import {SPARSITY_THRESHOLD} from '@/lib/score-set-heatmap'
 
 const HEATMAP_AMINO_ACIDS_SORTED = _.sortBy(AMINO_ACIDS, [
   (aa) =>

--- a/src/components/ScoreSetHeatmap.vue
+++ b/src/components/ScoreSetHeatmap.vue
@@ -74,6 +74,7 @@ import {
   PARSED_POST_MAPPED_VARIANT_PROPERTIES,
   HgvsReferenceSequenceType,
   inferReferenceSequenceFromVariants,
+  isStartOrStopLoss,
   Variant
 } from '@/lib/variants'
 
@@ -95,6 +96,7 @@ interface VariantClassHeatmapDatum {
   /** One variant in the class. All of its properties are shared by the other variants except its score, which should be ignored. */
   instance?: Variant
 }
+// import {SPARSITY_THRESHOLD} from '@/lib/score-set-heatmap'
 
 const HEATMAP_AMINO_ACIDS_SORTED = _.sortBy(AMINO_ACIDS, [
   (aa) =>
@@ -445,7 +447,7 @@ export default defineComponent({
     parseSimpleVariant: function () {
       return this.sequenceType == 'dna' ? parseSimpleNtVariant : parseSimpleProVariant
     },
- 
+
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Variants to display
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -615,7 +617,7 @@ export default defineComponent({
 
     colorScaleDomain: function () {
       const baselineScore = this.scoreSet.scoreRanges?.investigatorProvided?.baselineScore
-      
+
       const scores = this.heatmapData.map((v) => v.meanScore).filter((score) => score != null)
       const minValue = _.min<number>(scores)
       const maxValue = _.max<number>(scores)
@@ -997,7 +999,7 @@ export default defineComponent({
           }
           // If hideStartAndStopLoss is set to true, omit start- and stop-loss variants. The parent component shouuld
           // set this option when viewing scores in clinical mode from an assay using a synthetic target sequence.
-          if (this.hideStartAndStopLoss && this.isStartOrStopLoss(variant)) {
+          if (this.hideStartAndStopLoss && isStartOrStopLoss(variant)) {
             numIgnoredVariants++
             return null
           }
@@ -1280,33 +1282,6 @@ export default defineComponent({
 
     showProteinStructure() {
       this.proteinStructureVisible = true
-    },
-
-    isStartOrStopLoss: function (variant) {
-      const hgvsP = [variant.post_mapped_hgvs_p, variant.translated_hgvs_p, variant.hgvs_pro].find((hgvs) =>
-        variantNotNullOrNA(hgvs)
-      )
-      if (!hgvsP) {
-        return false
-      }
-      // TODO We may be reparsing a variant.
-      const parsedVariant = parseSimpleProVariant(hgvsP)
-      if (!parsedVariant) {
-        return false
-      }
-      if (parsedVariant.position == 1 && parsedVariant.original == 'Met' && parsedVariant.substitution != 'Met') {
-        // Start loss
-        return true
-      }
-      if (
-        parsedVariant.position == 1 &&
-        (parsedVariant.original == 'Ter' || parsedVariant.original == '*') &&
-        parsedVariant.substitution != 'Ter' &&
-        parsedVariant.substitution != '*'
-      ) {
-        // Stop loss
-        return true
-      }
     },
 
     translateDnaToAminoAcids1Char: function (dna) {

--- a/src/components/ScoreSetHistogram.vue
+++ b/src/components/ScoreSetHistogram.vue
@@ -332,7 +332,7 @@ export default defineComponent({
             {
               classifier: (d: HistogramDatum) => this.variantIsOther(d),
               options: {
-                color: '#999999',
+                color: '#709090',
                 title: 'Other'
               }
             }
@@ -443,7 +443,7 @@ export default defineComponent({
             series.push({
               classifier: (d: HistogramDatum) => this.variantIsOther(d),
               options: {
-                color: '#999999',
+                color: '#709090',
                 title: 'Other'
               }
             })

--- a/src/components/ScoreSetHistogram.vue
+++ b/src/components/ScoreSetHistogram.vue
@@ -139,13 +139,12 @@ import Dropdown from 'primevue/dropdown'
 import ProgressSpinner from 'primevue/progressspinner'
 import Rating from 'primevue/rating'
 import TabMenu from 'primevue/tabmenu'
-import {defineComponent, PropType, ref} from 'vue'
+import { defineComponent, PropType } from 'vue'
 
 import RangeTable from '@/components/RangeTable.vue'
 import useScopedId from '@/composables/scoped-id'
 import config from '@/config'
-import {AMINO_ACIDS} from '@/lib/amino-acids'
-import {saveChartAsFile} from '@/lib/chart-export'
+import { saveChartAsFile } from '@/lib/chart-export'
 import {
   BENIGN_CLINICAL_SIGNIFICANCE_CLASSIFICATIONS,
   CLINVAR_REVIEW_STATUS_STARS,
@@ -169,8 +168,8 @@ import makeHistogram, {
   HistogramDatum,
   HistogramBin
 } from '@/lib/histogram'
-import {prepareRangesForHistogram, ScoreRanges, ScoreSetRanges} from '@/lib/ranges'
-import {parseSimpleProVariant, variantNotNullOrNA} from '@/lib/mave-hgvs'
+import { prepareRangesForHistogram, ScoreRanges, ScoreSetRanges } from '@/lib/ranges'
+import { variantNotNullOrNA } from '@/lib/mave-hgvs'
 import { DEFAULT_VARIANT_EFFECT_TYPES, isStartOrStopLoss, variantIsMissense, variantIsNonsense, variantIsOther, variantIsSynonymous, VARIANT_EFFECT_TYPE_OPTIONS, Variant } from '@/lib/variants'
 
 function naToUndefined(x: string | null | undefined) {

--- a/src/components/ScoreSetHistogram.vue
+++ b/src/components/ScoreSetHistogram.vue
@@ -217,6 +217,10 @@ export default defineComponent({
     variants: {
       type: Array as PropType<Variant[]>,
       required: true
+    },
+    clinicalModeActive: {
+      type: Boolean,
+      default: false
     }
   },
 

--- a/src/components/ScoreSetHistogram.vue
+++ b/src/components/ScoreSetHistogram.vue
@@ -859,7 +859,7 @@ export default defineComponent({
         (this.selectedControlVariantTypeFilters.includes('Synonymous') && variantIsSynonymous(variant)) ||
         (this.selectedControlVariantTypeFilters.includes('Nonsense') && variantIsNonsense(variant)) ||
         (this.selectedControlVariantTypeFilters.includes('Start/Stop Loss') && isStartOrStopLoss(variant)) ||
-        (this.selectedControlVariantTypeFilters.includes('Other') && !variantIsMissense(variant) && !this.variantIsSynonymous(variant) && !this.variantIsNonsense(variant) && !isStartOrStopLoss(variant))
+        (this.selectedControlVariantTypeFilters.includes('Other') && !variantIsMissense(variant) && !variantIsSynonymous(variant) && !variantIsNonsense(variant) && !isStartOrStopLoss(variant))
       )
     },
     exportChart() {

--- a/src/components/ScoreSetHistogram.vue
+++ b/src/components/ScoreSetHistogram.vue
@@ -23,93 +23,99 @@
     Loading clinical control options in the background. Additional histogram views will be available once loaded.
   </div>
   <div v-if="showControls" class="mavedb-histogram-custom-controls">
-    <div v-if="showClinicalControlOptions" class="mavedb-histogram-control">
-      <label class="mavedb-histogram-control-label" for="mavedb-histogram-db-select">Clinical control database: </label>
-      <Dropdown
-        v-model="controlDb"
-        :disabled="!refreshedClinicalControls"
-        input-id="mavedb-histogram-db-select"
-        option-label="dbName"
-        :options="clinicalControlOptions"
-        style="align-items: center; height: 1.5rem"
-      />
-      <label class="mavedb-histogram-control-label" for="mavedb-histogram-version-select"
+    <fieldset class="mavedb-histogram-controls-panel">
+      <legend>Clinical Series Options</legend>
+      <div v-if="showClinicalControlOptions" class="mavedb-histogram-control">
+        <label class="mavedb-histogram-control-label" for="mavedb-histogram-db-select">Clinical control database: </label>
+        <Dropdown
+          v-model="controlDb"
+          :disabled="!refreshedClinicalControls"
+          input-id="mavedb-histogram-db-select"
+          option-label="dbName"
+          :options="clinicalControlOptions"
+          style="align-items: center; height: 1.5rem"
+        />
+        <label class="mavedb-histogram-control-label" for="mavedb-histogram-version-select"
         >Clinical control version:
-      </label>
-      <Dropdown
-        v-model="controlVersion"
-        :disabled="!refreshedClinicalControls"
-        input-id="mavedb-histogram-version-select"
-        :options="controlDb?.availableVersions"
-        style="align-items: center; height: 1.5rem"
-      />
-    </div>
-    <div class="mavedb-histogram-control">
-      <label class="mavedb-histogram-control-label" for="mavedb-histogram-star-select"
-        >Minimum ClinVar review status 'gold stars':
-      </label>
-      <Rating
-        v-model="customMinStarRating"
-        :disabled="!refreshedClinicalControls"
-        input-id="mavedb-histogram-star-select"
-        :stars="4"
-        style="display: inline"
-      />
-    </div>
-    <div class="mavedb-histogram-control">
-      <span class="mavedb-histogram-control-label">Include variants with protein effect: </span>
-      <div class="flex flex-wrap gap-3">
-        <div
-          v-for="typeOption of variantTypeOptions"
-          :key="typeOption.name"
-          class="flex gap-1 align-items-center"
-        >
-          <Checkbox
-            v-model="customSelectedControlVariantTypeFilters"
-            :disabled="!refreshedClinicalControls"
-            :name="scopedId('variant-type-inputs')"
-            :value="typeOption.name"
-          />
-          <label :for="scopedId('variant-type-inputs')">{{ typeOption.shortDescription }}</label>
+        </label>
+        <Dropdown
+          v-model="controlVersion"
+          :disabled="!refreshedClinicalControls"
+          input-id="mavedb-histogram-version-select"
+          :options="controlDb?.availableVersions"
+          style="align-items: center; height: 1.5rem"
+        />
+      </div>
+      <div class="mavedb-histogram-control">
+        <label class="mavedb-histogram-control-label" for="mavedb-histogram-star-select">
+          Minimum ClinVar review status 'gold stars':
+        </label>
+        <Rating
+          v-model="customMinStarRating"
+          :disabled="!refreshedClinicalControls"
+          input-id="mavedb-histogram-star-select"
+          :stars="4"
+          style="display: inline"
+        />
+      </div>
+      <div class="mavedb-histogram-control">
+        <span class="mavedb-histogram-control-label">Limit to variants with protein effect: </span>
+        <div class="flex flex-wrap gap-3">
+          <div
+            v-for="typeOption of variantTypeOptions"
+            :key="typeOption.name"
+            class="flex gap-1 align-items-center"
+          >
+            <Checkbox
+              v-model="customSelectedControlVariantTypeFilters"
+              :disabled="!refreshedClinicalControls || (typeOption.name === 'Start/Stop Loss' && clinicalModeActive)"
+              :name="scopedId('variant-type-inputs')"
+              :value="typeOption.name"
+            />
+            <label :for="scopedId('variant-type-inputs')">{{ typeOption.shortDescription }}</label>
+          </div>
         </div>
       </div>
-    </div>
-    <div class="mavedb-histogram-control">
-      <span class="mavedb-histogram-control-label">Include variants with classification: </span>
-      <div class="flex flex-wrap gap-3">
-        <div
-          v-for="classification of clinicalSignificanceClassificationOptions"
-          :key="classification.name"
-          class="flex gap-1 align-items-center"
-        >
-          <Checkbox
-            v-model="customSelectedClinicalSignificanceClassifications"
-            :disabled="!refreshedClinicalControls"
-            :name="scopedId('clinical-significance-inputs')"
-            :value="classification.name"
-          />
-          <label :for="scopedId('clinical-significance-inputs')">{{ classification.shortDescription }}</label>
+      <div class="mavedb-histogram-control">
+        <span class="mavedb-histogram-control-label">Include variants with classification: </span>
+        <div class="flex flex-wrap gap-3">
+          <div
+            v-for="classification of clinicalSignificanceClassificationOptions"
+            :key="classification.name"
+            class="flex gap-1 align-items-center"
+          >
+            <Checkbox
+              v-model="customSelectedClinicalSignificanceClassifications"
+              :disabled="!refreshedClinicalControls"
+              :name="scopedId('clinical-significance-inputs')"
+              :value="classification.name"
+            />
+            <label :for="scopedId('clinical-significance-inputs')">{{ classification.shortDescription }}</label>
+          </div>
         </div>
       </div>
-    </div>
-    <div class="mavedb-histogram-control">
-      <span class="mavedb-histogram-control-label">Variants by protein effect: </span>
-      <div class="flex flex-wrap gap-3">
-        <div
-          v-for="typeOption of variantTypeOptions"
-          :key="typeOption.name"
-          class="flex gap-1 align-items-center"
-        >
-          <Checkbox
-            v-model="customSelectedVariantTypeFilters"
-            :disabled="!refreshedClinicalControls"
-            :name="scopedId('variant-type-inputs')"
-            :value="typeOption.name"
-          />
-          <label :for="scopedId('variant-type-inputs')">{{ typeOption.shortDescription }}</label>
+    </fieldset>
+    <fieldset class="mavedb-histogram-controls-panel">
+      <legend>Protein Effect Series Options</legend>
+      <div class="mavedb-histogram-control">
+        <span class="mavedb-histogram-control-label">Variants by protein effect: </span>
+        <div class="flex flex-wrap gap-3">
+          <div
+            v-for="typeOption of variantTypeOptions"
+            :key="typeOption.name"
+            class="flex gap-1 align-items-center"
+          >
+            <Checkbox
+              v-model="customSelectedVariantTypeFilters"
+              :disabled="!refreshedClinicalControls || (typeOption.name === 'Start/Stop Loss' && clinicalModeActive)"
+              :name="scopedId('variant-type-inputs')"
+              :value="typeOption.name"
+            />
+            <label :for="scopedId('variant-type-inputs')">{{ typeOption.shortDescription }}</label>
+          </div>
         </div>
       </div>
-    </div>
+    </fieldset>
   </div>
   <div ref="histogramContainer" class="mavedb-histogram-container" />
   <!-- The child component will attempt to immediately emit the range which is active when it is created. Since Vue lifecycle events bubble up from child to parent, this causes this component to attempt
@@ -165,7 +171,7 @@ import makeHistogram, {
 } from '@/lib/histogram'
 import {prepareRangesForHistogram, ScoreRanges, ScoreSetRanges} from '@/lib/ranges'
 import {parseSimpleProVariant, variantNotNullOrNA} from '@/lib/mave-hgvs'
-import {Variant} from '@/lib/variants'
+import { DEFAULT_VARIANT_EFFECT_TYPES, isStartOrStopLoss, VARIANT_EFFECT_TYPE_OPTIONS, Variant } from '@/lib/variants'
 
 function naToUndefined(x: string | null | undefined) {
   if (variantNotNullOrNA(x)) {
@@ -230,7 +236,6 @@ export default defineComponent({
 
   data: function () {
     const scoreSetHasRanges = config.CLINICAL_FEATURES_ENABLED && this.scoreSet.scoreRanges != null
-
     return {
       config: config,
 
@@ -252,27 +257,11 @@ export default defineComponent({
       clinicalSignificanceClassificationOptions: clinvarClinicalSignificanceClassifications(
         DEFAULT_CLINICAL_CONTROL_VERSION
       ),
-      variantTypeOptions: [
-        {
-          name: 'Synonymous',
-          description: 'Show all synonymous variants',
-          shortDescription: 'Synonymous variants'
-        },
-        {
-          name: 'Missense',
-          description: 'Show all missense variants',
-          shortDescription: 'Missense variants'
-        },
-        {
-          name: 'Nonsense',
-          description: 'Show all nonsense variants',
-          shortDescription: 'Nonsense variants'
-        },
-      ],
+      variantTypeOptions: VARIANT_EFFECT_TYPE_OPTIONS,
       customMinStarRating: DEFAULT_MIN_STAR_RATING,
       customSelectedClinicalSignificanceClassifications: DEFAULT_CLINICAL_SIGNIFICANCE_CLASSIFICATIONS,
-      customSelectedVariantTypeFilters: [] as typeof this.variantTypeOptions[0]['name'][],
-      customSelectedControlVariantTypeFilters: ['Synonymous', 'Missense', 'Nonsense'],
+      customSelectedVariantTypeFilters: [] as string[],
+      customSelectedControlVariantTypeFilters: DEFAULT_VARIANT_EFFECT_TYPES,
       histogram: null as Histogram | null
     }
   },
@@ -331,6 +320,20 @@ export default defineComponent({
               options: {
                 color: '#a3984e',
                 title: 'Nonsense'
+              }
+            },
+            ...(this.clinicalModeActive ? [] : [{
+              classifier: (d: HistogramDatum) => isStartOrStopLoss(d),
+              options: {
+              color: '#6d4ea3',
+              title: 'Start/Stop Loss'
+              }
+            }]),
+            {
+              classifier: (d: HistogramDatum) => this.variantIsOther(d),
+              options: {
+                color: '#999999',
+                title: 'Other'
               }
             }
           ]
@@ -422,6 +425,26 @@ export default defineComponent({
               options: {
                 color: '#a3984e',
                 title: 'Nonsense'
+              }
+            })
+          }
+
+          if (this.selectedVariantTypeFilters.includes('Start/Stop Loss')) {
+            series.push({
+              classifier: (d: HistogramDatum) => isStartOrStopLoss(d),
+              options: {
+                color: '#6d4ea3',
+                title: 'Start/Stop Loss'
+              }
+            })
+          }
+
+          if (this.selectedVariantTypeFilters.includes('Other')) {
+            series.push({
+              classifier: (d: HistogramDatum) => this.variantIsOther(d),
+              options: {
+                color: '#999999',
+                title: 'Other'
               }
             })
           }
@@ -734,6 +757,11 @@ export default defineComponent({
         this.renderOrRefreshHistogram()
       }
     },
+    clinicalModeActive: {
+      handler: function () {
+        this.renderOrRefreshHistogram()
+      }
+    },
     clinicalSignificanceClassificationOptions: {
       handler: function () {
         // Ensure the conflicting significance remains selected even when the version changes its name.
@@ -866,11 +894,21 @@ export default defineComponent({
       const altAllele = parsedVariant.substitution.toUpperCase()
       return altAllele == 'TER' || altAllele == '*'
     },
+    variantIsOther(variant: Variant) {
+      return (
+        !this.variantIsMissense(variant) &&
+        !this.variantIsSynonymous(variant) &&
+        !this.variantIsNonsense(variant) &&
+        !isStartOrStopLoss(variant)
+      )
+    },
     filterControlVariantByEffect(variant: Variant) {
       return (
         (this.selectedControlVariantTypeFilters.includes('Missense') && this.variantIsMissense(variant)) ||
         (this.selectedControlVariantTypeFilters.includes('Synonymous') && this.variantIsSynonymous(variant)) ||
-        (this.selectedControlVariantTypeFilters.includes('Nonsense') && this.variantIsNonsense(variant))
+        (this.selectedControlVariantTypeFilters.includes('Nonsense') && this.variantIsNonsense(variant)) ||
+        (this.selectedControlVariantTypeFilters.includes('Start/Stop Loss') && isStartOrStopLoss(variant)) ||
+        (this.selectedControlVariantTypeFilters.includes('Other') && !this.variantIsMissense(variant) && !this.variantIsSynonymous(variant) && !this.variantIsNonsense(variant) && !isStartOrStopLoss(variant))
       )
     },
     getHgvsProFromVariant(variant: Variant) {
@@ -1080,6 +1118,16 @@ export default defineComponent({
 </script>
 
 <style scoped>
+.mavedb-histogram-controls-panel {
+  border: 2px solid #d7d7d7;
+  padding: 0.5rem 1rem;
+  border-radius: 5px;
+  background: #fafafa;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
 .mavedb-histogram-controls {
   display: flex;
   flex-direction: row;

--- a/src/components/ScoreSetHistogram.vue
+++ b/src/components/ScoreSetHistogram.vue
@@ -68,7 +68,7 @@
           >
             <Checkbox
               v-model="customSelectedControlVariantTypeFilters"
-              :disabled="!refreshedClinicalControls || (typeOption.name === 'Start/Stop Loss' && clinicalModeActive)"
+              :disabled="!refreshedClinicalControls"
               :name="scopedId('variant-type-inputs')"
               :value="typeOption.name"
             />
@@ -107,7 +107,7 @@
           >
             <Checkbox
               v-model="customSelectedVariantTypeFilters"
-              :disabled="!refreshedClinicalControls || (typeOption.name === 'Start/Stop Loss' && clinicalModeActive)"
+              :disabled="!refreshedClinicalControls"
               :name="scopedId('variant-type-inputs')"
               :value="typeOption.name"
             />
@@ -223,7 +223,7 @@ export default defineComponent({
       type: Array as PropType<Variant[]>,
       required: true
     },
-    clinicalModeActive: {
+    hideStartAndStopLossByDefault: {
       type: Boolean,
       default: false
     }
@@ -260,7 +260,9 @@ export default defineComponent({
       customMinStarRating: DEFAULT_MIN_STAR_RATING,
       customSelectedClinicalSignificanceClassifications: DEFAULT_CLINICAL_SIGNIFICANCE_CLASSIFICATIONS,
       customSelectedVariantTypeFilters: [] as string[],
-      customSelectedControlVariantTypeFilters: DEFAULT_VARIANT_EFFECT_TYPES,
+      customSelectedControlVariantTypeFilters: DEFAULT_VARIANT_EFFECT_TYPES.concat(
+        this.hideStartAndStopLossByDefault ? [] : ['Start/Stop Loss']
+      ),
       histogram: null as Histogram | null
     }
   },
@@ -321,7 +323,7 @@ export default defineComponent({
                 title: 'Nonsense'
               }
             },
-            ...(this.clinicalModeActive ? [] : [{
+            ...(this.hideStartAndStopLossByDefault ? [] : [{
               classifier: (d: HistogramDatum) => isStartOrStopLoss(d),
               options: {
               color: '#6d4ea3',
@@ -756,7 +758,7 @@ export default defineComponent({
         this.renderOrRefreshHistogram()
       }
     },
-    clinicalModeActive: {
+    hideStartAndStopLossByDefault: {
       handler: function () {
         this.renderOrRefreshHistogram()
       }

--- a/src/components/screens/ScoreSetView.vue
+++ b/src/components/screens/ScoreSetView.vue
@@ -84,7 +84,7 @@
             :score-set="item"
             :variants="variants"
             @export-chart="setHistogramExport"
-            :clinical-mode-active="clinicalMode"
+            :hide-start-and-stop-loss-by-default="hideStartAndStopLoss"
           />
         </div>
         <div v-if="showHeatmap && !isScoreSetVisualizerVisible" class="mavedb-score-set-heatmap-pane">

--- a/src/components/screens/ScoreSetView.vue
+++ b/src/components/screens/ScoreSetView.vue
@@ -84,6 +84,7 @@
             :score-set="item"
             :variants="variants"
             @export-chart="setHistogramExport"
+            :clinical-mode-active="clinicalMode"
           />
         </div>
         <div v-if="showHeatmap && !isScoreSetVisualizerVisible" class="mavedb-score-set-heatmap-pane">

--- a/src/lib/clinical-controls.ts
+++ b/src/lib/clinical-controls.ts
@@ -65,7 +65,7 @@ export const CONFLICTING_CLINICAL_SIGNIFICANCE_CLASSIFICATIONS = [
   'Conflicting classifications of pathogenicity'
 ]
 
-export const CLINVAR_REVIEW_STATUS_STARS: {[status: string]: number} = {
+export const CLINVAR_REVIEW_STATUS_STARS: { [status: string]: number } = {
   'no assertion criteria provided': 0,
   'criteria provided, conflicting interpretations': 1,
   'criteria provided, conflicting classifications': 1,
@@ -127,11 +127,6 @@ export function clinvarClinicalSignificanceClassifications(
   return [
     ...CLINVAR_CLINICAL_SIGNIFICANCE_CLASSIFICATIONS,
     clinvarConflictingSignificanceClassificationForVersion(version),
-    {
-      name: 'Missense',
-      description: 'Missense variant',
-      shortDescription: 'Missense'
-    }
   ]
 }
 

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -55,6 +55,41 @@ export interface ParsedPostMappedVariantProperties {
   [type: string]: keyof VariantPropertiesAddedByPreparingCodingVariants
 }
 
+export const VARIANT_EFFECT_TYPE_OPTIONS = [
+  {
+    name: 'Synonymous',
+    description: 'Show all synonymous variants',
+    shortDescription: 'Synonymous variants'
+  },
+  {
+    name: 'Missense',
+    description: 'Show all missense variants',
+    shortDescription: 'Missense variants'
+  },
+  {
+    name: 'Nonsense',
+    description: 'Show all nonsense variants',
+    shortDescription: 'Nonsense variants'
+  },
+  {
+    name: 'Start/Stop Loss',
+    description: 'Show all start/stop loss variants',
+    shortDescription: 'Start/Stop Loss variants'
+  },
+  {
+    name: 'Other',
+    description: 'Show all other variant types',
+    shortDescription: 'Others'
+  }
+]
+
+export const DEFAULT_VARIANT_EFFECT_TYPES = [
+  'Missense',
+  'Nonsense',
+  'Synonymous',
+  'Other',
+]
+
 export const PARSED_POST_MAPPED_VARIANT_PROPERTIES: ParsedPostMappedVariantProperties = {
   c: 'parsedPostMappedHgvsC',
   g: 'parsedPostMappedHgvsC',
@@ -65,6 +100,7 @@ function getParsedPostMappedHgvs(variant: Variant, type: HgvsReferenceSequenceTy
   const field = PARSED_POST_MAPPED_VARIANT_PROPERTIES[type]
   return field ? variant[field] : undefined
 }
+
 
 /**
  * Add parsed post-mapped HGVS c. and p. strings to variants wherever possible.

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -1,9 +1,9 @@
 import _ from 'lodash'
 
-import {parseSimpleNtVariant, parseSimpleProVariant, SimpleDnaVariation, SimpleProteinVariation} from './mave-hgvs'
+import { parseSimpleNtVariant, parseSimpleProVariant, SimpleDnaVariation, SimpleProteinVariation, variantNotNullOrNA } from './mave-hgvs'
 import geneticCodes from './genetic-codes'
-import {AMINO_ACIDS_WITH_TER, singleLetterAminoAcidOrHgvsCode} from './amino-acids'
-import {DEFAULT_CLNREVSTAT_FIELD, DEFAULT_CLNSIG_FIELD} from './clinical-controls'
+import { AMINO_ACIDS_WITH_TER, singleLetterAminoAcidOrHgvsCode } from './amino-acids'
+import { DEFAULT_CLNREVSTAT_FIELD, DEFAULT_CLNSIG_FIELD } from './clinical-controls'
 
 export type HgvsReferenceSequenceType = 'c' | 'p' // | 'n'
 
@@ -41,7 +41,7 @@ export interface Variant extends RawVariant, VariantPropertiesAddedByPreparingCo
 }
 
 export const HGVS_REFERENCE_SEQUENCE_TYPES: {
-  [type: HgvsReferenceSequenceType]: {parsedPostMappedHgvsField: keyof VariantPropertiesAddedByPreparingCodingVariants}
+  [type: HgvsReferenceSequenceType]: { parsedPostMappedHgvsField: keyof VariantPropertiesAddedByPreparingCodingVariants }
 } = {
   c: {
     parsedPostMappedHgvsField: 'parsedPostMappedHgvsC'
@@ -242,7 +242,7 @@ export function inferReferenceSequenceFromVariants(variants: Variant[], referenc
     return {
       referenceSequence: '',
       referenceSequenceResidueType: referenceType == 'p' ? 'aa' : 'nt',
-      referenceSequenceRange: {start: 0, length: 0}
+      referenceSequenceRange: { start: 0, length: 0 }
     }
   }
   const referenceSequenceRange = getReferenceRange(variants, referenceType)
@@ -306,7 +306,7 @@ export function inferReferenceSequenceFromVariants(variants: Variant[], referenc
  * @param variants The array of variants to translate.
  */
 export function translateSimpleCodingVariants(variants: Variant[]) {
-  const {referenceSequence: codingSequence, referenceSequenceRange: codingSequenceRange} =
+  const { referenceSequence: codingSequence, referenceSequenceRange: codingSequenceRange } =
     inferReferenceSequenceFromVariants(variants, 'c')
   if (codingSequence.length > 0) {
     for (const v of variants) {
@@ -372,4 +372,63 @@ function translateSimpleCodingHgvsCVariant(
     AMINO_ACIDS_WITH_TER.find((aa) => aa.codes.single == variantAaResidue)?.codes?.triple?.toLowerCase()
   )
   return `p.${originalAaTriple}${aaPosition}${variantAaTriple}`
+}
+
+
+
+/**
+ * Determines whether a given variant represents either a start-loss (loss of the initiator methionine)
+ * or a stop-loss (loss of a terminal stop/termination signal) event based on its protein-level HGVS notation.
+ *
+ * Detection logic:
+ * 1. Selects the first available, non-null / non-"NA" protein HGVS string from:
+ *    - variant.post_mapped_hgvs_p
+ *    - variant.hgvs_pro_inferred
+ *    - variant.hgvs_pro
+ * 2. Parses the HGVS protein string via parseSimpleProVariant (external utility).
+ * 3. Returns:
+ *    - true if the variant alters the initiator methionine at position 1 (original == 'Met') to a different residue.
+ *    - true if the variant alters a termination symbol at position 1 (original == 'Ter' or '*') to a non-stop residue.
+ * 4. Returns false if no suitable HGVS string is found, parsing fails, or the criteria above are not met.
+ *
+ * Notes:
+ * - The function currently infers start-loss strictly when position == 1 and original is 'Met'.
+ *
+ * Performance considerations:
+ * - A TODO in the source notes possible redundant parsing if the same HGVS string was already parsed earlier
+ *   (e.g., in prepareSimpleVariantInstances). Caching parsed results or passing a pre-parsed object could reduce overhead.
+ *
+ * Parameter requirements:
+ * - variant should be an object containing at least one of the HGVS protein fields listed above.
+ * - External helpers required: variantNotNullOrNA, parseSimpleProVariant.
+ *
+ * @param variant Arbitrary variant-like object holding HGVS protein annotations.
+ * @returns true if the variant is classified as start-loss or stop-loss; false (or undefined) otherwise.
+ */
+export function isStartOrStopLoss(variant: any) {
+  const hgvsP = [variant.post_mapped_hgvs_p, variant.hgvs_pro_inferred, variant.hgvs_pro].find((hgvs) =>
+    variantNotNullOrNA(hgvs)
+  )
+  if (!hgvsP) {
+    return false
+  }
+  // TODO We may be reparsing the same variant that was just parsed in prepareSimpleVariantInstances.
+  const parsedVariant = parseSimpleProVariant(hgvsP)
+  if (!parsedVariant) {
+    return false
+  }
+  if (parsedVariant.position == 1 && parsedVariant.original == 'Met' && parsedVariant.substitution != 'Met') {
+    // Start loss
+    return true
+  }
+  if (
+    (parsedVariant.original == 'Ter' || parsedVariant.original == '*') &&
+    parsedVariant.substitution != 'Ter' &&
+    parsedVariant.substitution != '*'
+  ) {
+    // Stop loss
+    return true
+  }
+
+  return false
 }

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -430,9 +430,6 @@ function translateSimpleCodingHgvsCVariant(
  * Notes:
  * - The function currently infers start-loss strictly when position == 1 and original is 'Met'.
  *
- * Performance considerations:
- * - A TODO in the source notes possible redundant parsing if the same HGVS string was already parsed earlier
- *   (e.g., in prepareSimpleVariantInstances). Caching parsed results or passing a pre-parsed object could reduce overhead.
  *
  * Parameter requirements:
  * - variant should be an object containing at least one of the HGVS protein fields listed above.
@@ -442,14 +439,7 @@ function translateSimpleCodingHgvsCVariant(
  * @returns true if the variant is classified as start-loss or stop-loss; false (or undefined) otherwise.
  */
 export function isStartOrStopLoss(variant: any) {
-  const hgvsP = [variant.post_mapped_hgvs_p, variant.hgvs_pro_inferred, variant.hgvs_pro].find((hgvs) =>
-    variantNotNullOrNA(hgvs)
-  )
-  if (!hgvsP) {
-    return false
-  }
-  // TODO We may be reparsing the same variant that was just parsed in prepareSimpleVariantInstances.
-  const parsedVariant = parseSimpleProVariant(hgvsP)
+  const parsedVariant = variant.parsedPostMappedHgvsP
   if (!parsedVariant) {
     return false
   }
@@ -469,25 +459,8 @@ export function isStartOrStopLoss(variant: any) {
   return false
 }
 
-function getHgvsProFromVariant(variant: Variant) {
-  if (variant.post_mapped_hgvs_p && variant.post_mapped_hgvs_p != 'NA') {
-    return variant.post_mapped_hgvs_p
-  }
-  if (variant.hgvs_pro_inferred && variant.hgvs_pro_inferred != 'NA') {
-    return variant.hgvs_pro_inferred
-  }
-  if (variant.hgvs_pro && variant.hgvs_pro != 'NA') {
-    return variant.hgvs_pro
-  }
-  return null
-}
-
 export function variantIsMissense(variant: Variant) {
-  const hgvsPro = getHgvsProFromVariant(variant)
-  if (!hgvsPro) {
-    return false
-  }
-  const parsedVariant = parseSimpleProVariant(hgvsPro)
+  const parsedVariant = variant.parsedPostMappedHgvsP
   if (!parsedVariant) {
     return false
   }
@@ -500,11 +473,7 @@ export function variantIsMissense(variant: Variant) {
 }
 
 export function variantIsSynonymous(variant: Variant) {
-  const hgvsPro = getHgvsProFromVariant(variant)
-  if (!hgvsPro) {
-    return false
-  }
-  const parsedVariant = parseSimpleProVariant(hgvsPro)
+  const parsedVariant = variant.parsedPostMappedHgvsP
   if (!parsedVariant) {
     return false
   }
@@ -515,11 +484,7 @@ export function variantIsSynonymous(variant: Variant) {
 }
 
 export function variantIsNonsense(variant: Variant) {
-  const hgvsPro = getHgvsProFromVariant(variant)
-  if (!hgvsPro) {
-    return false
-  }
-  const parsedVariant = parseSimpleProVariant(hgvsPro)
+  const parsedVariant = variant.parsedPostMappedHgvsP
   if (!parsedVariant) {
     return false
   }


### PR DESCRIPTION
This pull request introduces new filtering and visualization options for protein variant effects in the histogram component, refactors some variant effect logic for reusability, and improves the UI controls for clinical and protein effect views. The most important changes are grouped below:

**Variant Effect Filtering and Visualization:**

* Added support for filtering and visualizing histogram data by protein effect types (Missense, Synonymous, Nonsense, Start/Stop Loss, Other), including new UI controls for selecting these filters. This enables users to focus on specific protein variant effects in both clinical and protein effect views. [[1]](diffhunk://#diff-8c5baf0c0d572e0f90078fb085ef8b917eed7b7308edde7efd57e080754a2fc1R61-R78) [[2]](diffhunk://#diff-8c5baf0c0d572e0f90078fb085ef8b917eed7b7308edde7efd57e080754a2fc1R97-R118) [[3]](diffhunk://#diff-8c5baf0c0d572e0f90078fb085ef8b917eed7b7308edde7efd57e080754a2fc1R278-R282) [[4]](diffhunk://#diff-8c5baf0c0d572e0f90078fb085ef8b917eed7b7308edde7efd57e080754a2fc1R582-R595) [[5]](diffhunk://#diff-8c5baf0c0d572e0f90078fb085ef8b917eed7b7308edde7efd57e080754a2fc1R878-R920)
* Introduced a new "Protein Effect View" option in the histogram, allowing users to visualize variants grouped by protein effect. [[1]](diffhunk://#diff-8c5baf0c0d572e0f90078fb085ef8b917eed7b7308edde7efd57e080754a2fc1R485-R489) [[2]](diffhunk://#diff-8c5baf0c0d572e0f90078fb085ef8b917eed7b7308edde7efd57e080754a2fc1R320-R358)

**Refactoring and Code Reuse:**

* Moved the `isStartOrStopLoss` logic to a shared location (`@/lib/variants`) and updated both heatmap and histogram components to use the new function, reducing code duplication and improving maintainability. [[1]](diffhunk://#diff-88a85a0733e52b5dde74962201e24ba373a8ab7f04391fdf0bba714234df5364R78) [[2]](diffhunk://#diff-88a85a0733e52b5dde74962201e24ba373a8ab7f04391fdf0bba714234df5364L875-L901) [[3]](diffhunk://#diff-88a85a0733e52b5dde74962201e24ba373a8ab7f04391fdf0bba714234df5364L929-R903) [[4]](diffhunk://#diff-8c5baf0c0d572e0f90078fb085ef8b917eed7b7308edde7efd57e080754a2fc1R174) [[5]](diffhunk://#diff-8c5baf0c0d572e0f90078fb085ef8b917eed7b7308edde7efd57e080754a2fc1R320-R358)
<img width="1175" height="467" alt="Screenshot 2025-09-26 at 10 57 54 AM" src="https://github.com/user-attachments/assets/5b63cb0b-d8fe-4079-8e96-f05980285859" />

**Clinical Mode and Customization Improvements:**

* Added `clinicalModeActive` prop and logic to control which variant effect filters are available, ensuring that Start/Stop Loss variants are excluded in clinical mode where appropriate. [[1]](diffhunk://#diff-8c5baf0c0d572e0f90078fb085ef8b917eed7b7308edde7efd57e080754a2fc1R244-R247) [[2]](diffhunk://#diff-8c5baf0c0d572e0f90078fb085ef8b917eed7b7308edde7efd57e080754a2fc1R278-R282) [[3]](diffhunk://#diff-8c5baf0c0d572e0f90078fb085ef8b917eed7b7308edde7efd57e080754a2fc1R320-R358)
* Updated custom and clinical views to apply protein effect filters to control variants, allowing for more granular filtering of clinical significance series. [[1]](diffhunk://#diff-8c5baf0c0d572e0f90078fb085ef8b917eed7b7308edde7efd57e080754a2fc1L279-R367) [[2]](diffhunk://#diff-8c5baf0c0d572e0f90078fb085ef8b917eed7b7308edde7efd57e080754a2fc1L291-R379) [[3]](diffhunk://#diff-8c5baf0c0d572e0f90078fb085ef8b917eed7b7308edde7efd57e080754a2fc1L303-R391) [[4]](diffhunk://#diff-8c5baf0c0d572e0f90078fb085ef8b917eed7b7308edde7efd57e080754a2fc1L322-R410)

**User Interface Enhancements:**

* Improved UI controls by grouping options into fieldsets with clear legends, enhancing usability and organization of clinical and protein effect series options. [[1]](diffhunk://#diff-8c5baf0c0d572e0f90078fb085ef8b917eed7b7308edde7efd57e080754a2fc1R26-R27) [[2]](diffhunk://#diff-8c5baf0c0d572e0f90078fb085ef8b917eed7b7308edde7efd57e080754a2fc1R97-R118) [[3]](diffhunk://#diff-8c5baf0c0d572e0f90078fb085ef8b917eed7b7308edde7efd57e080754a2fc1R1128-R1137)
* Updated labels and layout for variant effect and clinical significance controls for clarity and consistency.
<img width="1171" height="741" alt="Screenshot 2025-09-26 at 10 58 21 AM" src="https://github.com/user-attachments/assets/cf0503f5-9b76-4b5f-ac20-a3747de66084" />

**Reactivity and State Management:**

* Added watchers for new filter properties and clinical mode to ensure the histogram updates automatically when options change, improving responsiveness and user experience. [[1]](diffhunk://#diff-8c5baf0c0d572e0f90078fb085ef8b917eed7b7308edde7efd57e080754a2fc1R767-R771) [[2]](diffhunk://#diff-8c5baf0c0d572e0f90078fb085ef8b917eed7b7308edde7efd57e080754a2fc1R791-R800)