### PR TITLE
Title improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,6 @@
     <link rel="icon" href="/mavedb-icon.png" type="image/png" />
     <link rel="icon" href="/mavedb-icon.ico" sizes="32x32" />
     <link rel="alternate icon" href="/favicon.png" />
-    <title>%VITE_SITE_TITLE%</title>
   </head>
   <body>
     <noscript>

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@fortawesome/free-regular-svg-icons": "^7.0.0",
         "@fortawesome/free-solid-svg-icons": "^7.0.0",
         "@fortawesome/vue-fontawesome": "^3.1.1",
+        "@unhead/vue": "^2.0.17",
         "axios": "^1.11.0",
         "chart.js": "^4.4.1",
         "d3": "^7.9.0",
@@ -1991,6 +1992,22 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
+    },
+    "node_modules/@unhead/vue": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-2.0.17.tgz",
+      "integrity": "sha512-jzmGZYeMAhETV6qfetmLbZzUjjx1TjdNvFSobeFZb73D7dwD9wl/nOAx36qq+TvjZsLJdF5PQWToz2oDGAUqCg==",
+      "license": "MIT",
+      "dependencies": {
+        "hookable": "^5.5.3",
+        "unhead": "2.0.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      },
+      "peerDependencies": {
+        "vue": ">=3.5.18"
+      }
     },
     "node_modules/@vitejs/plugin-basic-ssl": {
       "version": "1.2.0",
@@ -5303,6 +5320,12 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "license": "MIT"
     },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
@@ -9524,6 +9547,18 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
+    "node_modules/unhead": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.0.17.tgz",
+      "integrity": "sha512-xX3PCtxaE80khRZobyWCVxeFF88/Tg9eJDcJWY9us727nsTC7C449B8BUfVBmiF2+3LjPcmqeoB2iuMs0U4oJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hookable": "^5.5.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      }
     },
     "node_modules/unicode-properties": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@fortawesome/free-regular-svg-icons": "^7.0.0",
     "@fortawesome/free-solid-svg-icons": "^7.0.0",
     "@fortawesome/vue-fontawesome": "^3.1.1",
+    "@unhead/vue": "^2.0.17",
     "axios": "^1.11.0",
     "chart.js": "^4.4.1",
     "d3": "^7.9.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,7 +12,9 @@ import {mapActions, mapState} from 'vuex'
 
 export default {
   components: {ConfirmDialog, Toast},
+
   computed: mapState('toast', ['toasts']),
+
   watch: {
     toasts: {
       deep: true,
@@ -24,6 +26,7 @@ export default {
       }
     }
   },
+
   methods: mapActions('toast', ['removeDequeuedToasts'])
 }
 </script>

--- a/src/components/AssayFactSheet.vue
+++ b/src/components/AssayFactSheet.vue
@@ -133,7 +133,7 @@ export default defineComponent({
 
   computed: {
     firstAuthor: function () {
-      const firstAuthor = this.scoreSet.primaryPublicationIdentifiers[0]?.authors[0].name
+      const firstAuthor = this.scoreSet.primaryPublicationIdentifiers[0]?.authors.find((author) => author.primary)
       const firstAuthorLastName = _.isEmpty(firstAuthor) ? undefined : firstAuthor.split(',')[0]
       return firstAuthorLastName
     },

--- a/src/components/AssayFactSheet.vue
+++ b/src/components/AssayFactSheet.vue
@@ -119,6 +119,7 @@
 import _ from 'lodash'
 import {defineComponent, PropType} from 'vue'
 
+import {getScoreSetFirstAuthor} from '@/lib/score-sets'
 import type {components} from '@/schema/openapi'
 
 export default defineComponent({
@@ -133,9 +134,8 @@ export default defineComponent({
 
   computed: {
     firstAuthor: function () {
-      const firstAuthor = this.scoreSet.primaryPublicationIdentifiers[0]?.authors.find((author) => author.primary)
-      const firstAuthorLastName = _.isEmpty(firstAuthor) ? undefined : firstAuthor.split(',')[0]
-      return firstAuthorLastName
+      const firstAuthor = getScoreSetFirstAuthor(this.scoreSet)
+      return !firstAuthor || _.isEmpty(firstAuthor?.name) ? undefined : firstAuthor.name.split(',')[0]
     },
 
     numAuthors: function () {

--- a/src/components/AssayFactSheet.vue
+++ b/src/components/AssayFactSheet.vue
@@ -143,6 +143,7 @@ export default defineComponent({
     },
 
     geneAndYear: function () {
+      // TODO VariantEffect/mavedb-api#450
       const gene = this.scoreSet.targetGenes?.[0]?.name
       const year = this.scoreSet.primaryPublicationIdentifiers[0]?.publicationYear
       const parts = [gene, year?.toString()].filter((x) => x != null)

--- a/src/components/VariantMeasurementView.vue
+++ b/src/components/VariantMeasurementView.vue
@@ -121,6 +121,7 @@ import axios from 'axios'
 import Card from 'primevue/card'
 import {useRestResource} from 'rest-client-vue'
 import {defineComponent, watch} from 'vue'
+import {useHead} from '@unhead/vue'
 
 import AssayFactSheet from '@/components/AssayFactSheet.vue'
 import ScoreSetHistogram from '@/components/ScoreSetHistogram.vue'
@@ -144,6 +145,7 @@ export default defineComponent({
   },
 
   setup: (props) => {
+    const head = useHead()
     const {data: scoresData, setDataUrl: setScoresDataUrl, ensureDataLoaded: ensureScoresDataLoaded} = useRemoteData()
 
     const {
@@ -172,6 +174,7 @@ export default defineComponent({
     )
 
     return {
+      head,
       ...useFormatters(),
 
       config: config,
@@ -310,6 +313,11 @@ export default defineComponent({
         }
       },
       immediate: true
+    },
+    variantName: {
+      handler: function (newValue) {
+        this.head.patch({title: newValue ? `Variant ${newValue}` : 'Variant'})
+      }
     }
   },
 

--- a/src/components/screens/CollectionView.vue
+++ b/src/components/screens/CollectionView.vue
@@ -235,6 +235,7 @@ import Dialog from 'primevue/dialog'
 import Inplace from 'primevue/inplace'
 import InputText from 'primevue/inputtext'
 import Textarea from 'primevue/textarea'
+import {useHead} from '@unhead/vue'
 
 import EntityLink from '@/components/common/EntityLink'
 import CollectionBadge from '@/components/CollectionBadge'
@@ -274,8 +275,10 @@ export default {
   },
 
   setup: () => {
+    const head = useHead({title: 'Collection'})
     const {userIsAuthenticated} = useAuth()
     return {
+      head,
       config: config,
       userIsAuthenticated,
 
@@ -300,6 +303,12 @@ export default {
   }),
 
   watch: {
+    item: {
+      handler: function (newValue) {
+        this.head.patch({title: newValue?.name || 'Collection'})
+      }
+    },
+
     itemId: {
       handler: function (newValue, oldValue) {
         if (newValue != oldValue) {

--- a/src/components/screens/CollectionsView.vue
+++ b/src/components/screens/CollectionsView.vue
@@ -71,6 +71,7 @@ import Button from 'primevue/button'
 import Column from 'primevue/column'
 import DataTable from 'primevue/datatable'
 import Dialog from 'primevue/dialog'
+import {useHead} from '@unhead/vue'
 
 import CollectionCreator from '@/components/CollectionCreator'
 import DefaultLayout from '@/components/layout/DefaultLayout'
@@ -83,7 +84,10 @@ export default {
 
   components: {Button, CollectionCreator, Column, DataTable, DefaultLayout, Dialog, PageLoading},
 
-  setup: useFormatters,
+  setup: () => {
+    useHead({title: 'My saved collections'})
+    return useFormatters()
+  },
 
   data: () => ({
     collections: [],

--- a/src/components/screens/DashboardView.vue
+++ b/src/components/screens/DashboardView.vue
@@ -30,18 +30,22 @@
 <script>
 import axios from 'axios'
 import InputText from 'primevue/inputtext'
+import TabPanel from 'primevue/tabpanel'
+import TabView from 'primevue/tabview'
+import {useHead} from '@unhead/vue'
 
 import config from '@/config'
 import ScoreSetTable from '@/components/ScoreSetTable.vue'
 import DefaultLayout from '@/components/layout/DefaultLayout'
 
-import TabView from 'primevue/tabview'
-import TabPanel from 'primevue/tabpanel'
-
 export default {
   name: 'HomeView',
 
   components: {DefaultLayout, ScoreSetTable, InputText, TabView, TabPanel},
+
+  setup: () => {
+    useHead({title: 'My dashboard'})
+  },
 
   data: function () {
     return {

--- a/src/components/screens/DocumentationView.vue
+++ b/src/components/screens/DocumentationView.vue
@@ -24,13 +24,20 @@
 
 <script lang="ts">
 import {defineComponent} from 'vue'
+import {useHead} from '@unhead/vue'
 
 import DefaultLayout from '@/components/layout/DefaultLayout.vue'
 import config from '@/config'
 
 export default defineComponent({
   name: 'DocumentationView',
+
   components: {DefaultLayout},
+
+  setup: () => {
+    useHead({title: 'Documentation'})
+  },
+
   computed: {
     apiDocumentationUrl: function () {
       return new URL('/docs', config.apiBaseUrl)

--- a/src/components/screens/ExperimentCreator.vue
+++ b/src/components/screens/ExperimentCreator.vue
@@ -518,6 +518,7 @@ import StepperPanel from 'primevue/stepperpanel'
 import TabPanel from 'primevue/tabpanel'
 import TabView from 'primevue/tabview'
 import Textarea from 'primevue/textarea'
+import {useHead} from '@unhead/vue'
 
 import DefaultLayout from '@/components/layout/DefaultLayout'
 import EmailPrompt from '@/components/common/EmailPrompt'
@@ -642,6 +643,8 @@ export default {
   },
 
   setup: () => {
+    useHead({title: 'New experiment'})
+
     const {userProfile} = useAuth()
 
     const variantLibraryKeywordOptions = useItems({itemTypeName: `controlled-keywords-variant-search`})

--- a/src/components/screens/ExperimentEditor.vue
+++ b/src/components/screens/ExperimentEditor.vue
@@ -362,6 +362,7 @@ import ProgressSpinner from 'primevue/progressspinner'
 import TabPanel from 'primevue/tabpanel'
 import TabView from 'primevue/tabview'
 import Textarea from 'primevue/textarea'
+import {useHead} from '@unhead/vue'
 
 import DefaultLayout from '@/components/layout/DefaultLayout'
 import EmailPrompt from '@/components/common/EmailPrompt'
@@ -485,6 +486,8 @@ export default {
   },
 
   setup: () => {
+    useHead({title: 'Edit experiment'})
+
     const {userProfile} = useAuth()
 
     const variantLibraryKeywordOptions = useItems({itemTypeName: `controlled-keywords-variant-search`})

--- a/src/components/screens/ExperimentSetView.vue
+++ b/src/components/screens/ExperimentSetView.vue
@@ -46,7 +46,7 @@ import _ from 'lodash'
 import axios from 'axios'
 import {marked} from 'marked'
 import Button from 'primevue/button'
-import config from '@/config'
+import {useHead} from '@unhead/vue'
 
 import DefaultLayout from '@/components/layout/DefaultLayout'
 import ItemNotFound from '@/components/common/ItemNotFound'
@@ -54,6 +54,7 @@ import PageLoading from '@/components/common/PageLoading'
 import useAuth from '@/composition/auth'
 import useItem from '@/composition/item'
 import useFormatters from '@/composition/formatters'
+import config from '@/config'
 
 export default {
   name: 'ExperimentSetView',
@@ -68,6 +69,7 @@ export default {
   },
 
   setup: () => {
+    useHead({title: 'Experiment set'})
     const {userIsAuthenticated} = useAuth()
 
     return {

--- a/src/components/screens/ExperimentView.vue
+++ b/src/components/screens/ExperimentView.vue
@@ -288,6 +288,7 @@ import {marked} from 'marked'
 import 'primeicons/primeicons.css'
 import Button from 'primevue/button'
 import Dialog from 'primevue/dialog'
+import {useHead} from '@unhead/vue'
 
 import CollectionAdder from '@/components/CollectionAdder'
 import CollectionBadge from '@/components/CollectionBadge'
@@ -312,8 +313,10 @@ export default {
   },
 
   setup: () => {
+    const head = useHead()
     const {userIsAuthenticated} = useAuth()
     return {
+      head,
       config: config,
 
       ...useFormatters(),
@@ -345,6 +348,12 @@ export default {
   },
 
   watch: {
+    item: {
+      handler: function (newValue) {
+        this.head.patch({title: newValue?.title ?? 'Untitled experiment'})
+      }
+    },
+
     itemId: {
       handler: function (newValue, oldValue) {
         if (newValue != oldValue) {

--- a/src/components/screens/HelpScreen.vue
+++ b/src/components/screens/HelpScreen.vue
@@ -43,12 +43,18 @@
 
 <script lang="ts">
 import {defineComponent} from 'vue'
+import {useHead} from '@unhead/vue'
 
 import DefaultLayout from '@/components/layout/DefaultLayout.vue'
 
 export default defineComponent({
   name: 'HelpScreen',
-  components: {DefaultLayout}
+
+  components: {DefaultLayout},
+
+  setup: () => {
+    useHead({title: 'Help'})
+  }
 })
 </script>
 

--- a/src/components/screens/PublicationIdentifierView.vue
+++ b/src/components/screens/PublicationIdentifierView.vue
@@ -42,6 +42,7 @@
 <script>
 import _ from 'lodash'
 import {marked} from 'marked'
+import {useHead} from '@unhead/vue'
 
 import DefaultLayout from '@/components/layout/DefaultLayout'
 import ScoreSetTable from '@/components/ScoreSetTable'
@@ -72,7 +73,8 @@ export default {
   },
 
   setup: (props) => {
-    console.log(props)
+    useHead({title: 'Publication details'})
+
     return {
       ...useFormatters(),
       ...useItem({itemTypeName: props.name})

--- a/src/components/screens/ScoreSetCreator.vue
+++ b/src/components/screens/ScoreSetCreator.vue
@@ -1880,6 +1880,7 @@ import TabPanel from 'primevue/tabpanel'
 import TabView from 'primevue/tabview'
 import Textarea from 'primevue/textarea'
 import {ref} from 'vue'
+import {useHead} from '@unhead/vue'
 
 import EntityLink from '@/components/common/EntityLink'
 import EmailPrompt from '@/components/common/EmailPrompt'
@@ -1984,6 +1985,8 @@ export default {
   },
 
   setup: () => {
+    useHead({title: 'New score set'})
+
     const publicationIdentifierSuggestions = useItems({itemTypeName: 'publication-identifier-search'})
     const externalPublicationIdentifierSuggestions = useItems({itemTypeName: 'external-publication-identifier-search'})
 

--- a/src/components/screens/ScoreSetEditor.vue
+++ b/src/components/screens/ScoreSetEditor.vue
@@ -1285,6 +1285,7 @@ import TabPanel from 'primevue/tabpanel'
 import TabView from 'primevue/tabview'
 import Textarea from 'primevue/textarea'
 import {ref} from 'vue'
+import {useHead} from '@unhead/vue'
 
 import EmailPrompt from '@/components/common/EmailPrompt'
 import EntityLink from '@/components/common/EntityLink'
@@ -1378,6 +1379,8 @@ export default {
   },
 
   setup: () => {
+    useHead({title: 'Edit score set'})
+
     const publicationIdentifierSuggestions = useItems({itemTypeName: 'publication-identifier-search'})
     const externalPublicationIdentifierSuggestions = useItems({itemTypeName: 'external-publication-identifier-search'})
     const targetGeneIdentifierSuggestions = {}

--- a/src/components/screens/ScoreSetView.vue
+++ b/src/components/screens/ScoreSetView.vue
@@ -468,7 +468,7 @@ export default {
     item: {
       handler: function (newValue) {
         this.head.patch({
-          title: getScoreSetShortName(newValue)
+          title: newValue ? getScoreSetShortName(newValue) : undefined
         })
       }
     },

--- a/src/components/screens/ScoreSetView.vue
+++ b/src/components/screens/ScoreSetView.vue
@@ -296,6 +296,7 @@ import Sidebar from 'primevue/sidebar'
 import SplitButton from 'primevue/splitbutton'
 import {ref} from 'vue'
 import {mapState} from 'vuex'
+import {useHead} from '@unhead/vue'
 
 import AssayFactSheet from '@/components/AssayFactSheet'
 import CollectionAdder from '@/components/CollectionAdder'
@@ -316,6 +317,7 @@ import useItem from '@/composition/item'
 import useRemoteData from '@/composition/remote-data'
 import config from '@/config'
 import {preferredVariantLabel, variantNotNullOrNA} from '@/lib/mave-hgvs'
+import {getScoreSetShortName} from '@/lib/score-sets'
 import {parseScoresOrCounts} from '@/lib/scores'
 import {parseSimpleCodingVariants, translateSimpleCodingVariants} from '@/lib/variants'
 
@@ -354,11 +356,14 @@ export default {
   },
 
   setup: () => {
+    const head = useHead()
+
     const {userIsAuthenticated} = useAuth()
     const scoresRemoteData = useRemoteData()
     const variantSearchSuggestions = ref([])
 
     return {
+      head,
       config: config,
       userIsAuthenticated,
 
@@ -460,6 +465,13 @@ export default {
   },
 
   watch: {
+    item: {
+      handler: function (newValue) {
+        this.head.patch({
+          title: getScoreSetShortName(newValue)
+        })
+      }
+    },
     itemId: {
       handler: function (newValue, oldValue) {
         if (newValue != oldValue) {

--- a/src/components/screens/SearchVariantsScreen.vue
+++ b/src/components/screens/SearchVariantsScreen.vue
@@ -527,6 +527,7 @@ import Message from 'primevue/message'
 import {defineComponent} from 'vue'
 import {useRoute, useRouter} from 'vue-router'
 import {useToast} from 'primevue/usetoast'
+import {useHead} from '@unhead/vue'
 
 import config from '@/config'
 import EntityLink from '@/components/common/EntityLink.vue'
@@ -552,6 +553,8 @@ export default defineComponent({
   },
 
   setup() {
+    useHead({title: 'MaveMD variant search'})
+
     const route = useRoute()
     const router = useRouter()
     const toast = useToast()

--- a/src/components/screens/SearchView.vue
+++ b/src/components/screens/SearchView.vue
@@ -97,11 +97,12 @@ import TabPanel from 'primevue/tabpanel'
 import TabView from 'primevue/tabview'
 import {debounce} from 'vue-debounce'
 import {defineComponent} from 'vue'
-import {paths, components} from '@/schema/openapi'
+import {useHead} from '@unhead/vue'
 
 import type {LocationQueryValue} from 'vue-router'
 import {textForTargetGeneCategory} from '@/lib/target-genes'
 import {routeToVariantSearchIfVariantIsSearchable} from '@/lib/search'
+import {paths, components} from '@/schema/openapi'
 
 type ShortScoreSet = components['schemas']['ShortScoreSet']
 type ShortTargetGene = components['schemas']['ShortTargetGene']
@@ -165,6 +166,10 @@ export default defineComponent({
   name: 'SearchView',
 
   components: {DefaultLayout, ScoreSetTable, IconField, InputIcon, InputText, SelectList, TabView, TabPanel, Button},
+
+  setup: () => {
+    useHead({title: 'Search data sets'})
+  },
 
   data: function () {
     return {

--- a/src/components/screens/SettingsScreen.vue
+++ b/src/components/screens/SettingsScreen.vue
@@ -131,21 +131,24 @@ import Button from 'primevue/button'
 import Card from 'primevue/card'
 import Checkbox from 'primevue/checkbox'
 import InputText from 'primevue/inputtext'
+import {useHead} from '@unhead/vue'
 
-import config from '@/config'
 import DefaultLayout from '@/components/layout/DefaultLayout'
 import useScopedId from '@/composables/scoped-id'
+import useAuth from '@/composition/auth'
 import useClipboard from '@/composition/clipboard'
 import useItem from '@/composition/item'
 import useItems from '@/composition/items'
-
-import useAuth from '@/composition/auth'
+import config from '@/config'
 
 export default {
   name: 'HomeView',
+
   components: {Button, Card, DefaultLayout, InputText, Checkbox},
 
   setup: () => {
+    useHead({title: 'Settings'})
+
     const {item: user, setItemId: setUserId, saveItem: saveUser} = useItem({itemTypeName: 'me'})
     const {items: accessKeys, invalidateItems: invalidateAccessKeys} = useItems({itemTypeName: 'my-access-key'})
     const {activeRoles, updateActiveRoles} = useAuth()

--- a/src/components/screens/StatisticsView.vue
+++ b/src/components/screens/StatisticsView.vue
@@ -148,6 +148,7 @@ import DefaultLayout from '../layout/DefaultLayout.vue'
 import SelectButton from 'primevue/selectbutton'
 import PageLoading from '../common/PageLoading.vue'
 import TimeSeriesLineChart from '../TimeSeriesLineChart.vue'
+import {useHead} from '@unhead/vue'
 
 import useItem from '@/composition/item'
 import config from '@/config'
@@ -155,6 +156,10 @@ import config from '@/config'
 export default {
   name: 'StatisticsView',
   components: {Carousel, Card, Column, Chart, DataTable, DefaultLayout, SelectButton, PageLoading, TimeSeriesLineChart},
+
+  setup: () => {
+   useHead({title: 'Database statistics'})
+  },
 
   data() {
     const aggregationLevels = [

--- a/src/components/screens/UsersView.vue
+++ b/src/components/screens/UsersView.vue
@@ -6,12 +6,18 @@
 
 <script lang="ts">
 import {defineComponent} from 'vue'
+import {useHead} from '@unhead/vue'
 
 import ItemsView from '@/components/common/ItemsView.vue'
 import DefaultLayout from '@/components/layout/DefaultLayout.vue'
 
 export default defineComponent({
   name: 'HomeView',
-  components: {DefaultLayout, ItemsView}
+
+  components: {DefaultLayout, ItemsView},
+
+  setup: () => {
+    useHead({title: 'User administration'})
+  }
 })
 </script>

--- a/src/components/screens/VariantMeasurementScreen.vue
+++ b/src/components/screens/VariantMeasurementScreen.vue
@@ -6,6 +6,7 @@
 
 <script lang="ts">
 import {defineComponent} from 'vue'
+import {useHead} from '@unhead/vue'
 
 import DefaultLayout from '@/components/layout/DefaultLayout.vue'
 import VariantMeasurementView from '@/components/VariantMeasurementView.vue'
@@ -19,6 +20,10 @@ export default defineComponent({
       type: String,
       required: true
     }
+  },
+
+  setup: () => {
+    useHead({title: 'Variant'})
   }
 })
 </script>

--- a/src/components/screens/VariantScreen.vue
+++ b/src/components/screens/VariantScreen.vue
@@ -56,6 +56,7 @@ import Message from 'primevue/message'
 import TabPanel from 'primevue/tabpanel'
 import TabView from 'primevue/tabview'
 import {defineComponent} from 'vue'
+import {useHead} from '@unhead/vue'
 
 import ErrorView from '@/components/common/ErrorView.vue'
 import PageLoading from '@/components/common/PageLoading.vue'
@@ -73,6 +74,10 @@ export default defineComponent({
       required: true
     }
   },
+
+  setup: () => ({
+    head: useHead({title: 'Variant search results'})
+  }),
 
   data: () => ({
     activeVariantIndex: 0,
@@ -114,6 +119,13 @@ export default defineComponent({
         }
       },
       immediate: true
+    },
+    clingenAlleleName: {
+      handler: async function (newValue) {
+        this.head.patch({
+          title: newValue ? `Variant ${newValue}` : 'Variant'
+        })
+      }
     }
   },
 

--- a/src/components/screens/WizardCompletionView.vue
+++ b/src/components/screens/WizardCompletionView.vue
@@ -45,6 +45,7 @@ import DefaultLayout from '@/components/layout/DefaultLayout'
 import ItemNotFound from '@/components/common/ItemNotFound'
 import useAuth from '@/composition/auth'
 import useItem from '@/composition/item'
+import {useHead} from '@unhead/vue'
 
 export default {
   name: 'WizardCompletionView',
@@ -59,6 +60,8 @@ export default {
   },
 
   setup: () => {
+    useHead({title: 'Score set saved!'})
+
     const {userIsAuthenticated} = useAuth()
 
     return {

--- a/src/lib/score-sets.ts
+++ b/src/lib/score-sets.ts
@@ -1,0 +1,42 @@
+import _ from 'lodash'
+
+import type {components} from '@/schema/openapi'
+
+type ScoreSet = components['schemas']['ScoreSet']
+
+/**
+ * Get a short name for a score set. If the score set has primary publication information or a gene name, this will have
+ * the form "FirstAuthorLastName [et al.] GeneName PublicationYear" where "et al." is present only if there are multiple
+ * authors.
+ *
+ * If there is no primary publication but there is a gene name, the gene name is used as the score set's short name.
+ *
+ * If neither primary publication nor gene name is present, the score set's title (or, failing that, short description)
+ * is used.
+ *
+ * The short name is not unique, and it is especially ambiguous when no primary publication information exists. But even
+ * then it is suitable as a browser tab title.
+ *
+ * Notice that the short name matches the assay fact sheet's heading, except that the latter includes a publication name
+ * and italic formatting.
+ *
+ * @param scoreSet A score set.
+ * @returns A suitable short name for the score set.
+ */
+export function getScoreSetShortName(scoreSet: ScoreSet | undefined | null) {
+  if (!scoreSet) {
+    return undefined
+  }
+  const firstAuthor = scoreSet.primaryPublicationIdentifiers[0]?.authors[0].name
+  const firstAuthorLastName = _.isEmpty(firstAuthor) ? undefined : firstAuthor.split(',')[0]
+  const numAuthors = scoreSet.primaryPublicationIdentifiers[0]?.authors.length ?? 0
+  const authors = firstAuthorLastName
+    ? numAuthors > 1
+      ? `${firstAuthorLastName} et al.`
+      : firstAuthorLastName
+    : undefined
+  const gene = scoreSet.targetGenes?.[0]?.name
+  const year = scoreSet.primaryPublicationIdentifiers[0]?.publicationYear
+  const parts = [authors, gene, year?.toString()].filter((x) => x != null)
+  return parts.length > 0 ? parts.join(' ') : (scoreSet.title ?? scoreSet.shortDescription ?? 'Score set')
+}

--- a/src/lib/score-sets.ts
+++ b/src/lib/score-sets.ts
@@ -3,6 +3,19 @@ import _ from 'lodash'
 import type {components} from '@/schema/openapi'
 
 type ScoreSet = components['schemas']['ScoreSet']
+type Author = components["schemas"]["PublicationAuthors"]
+
+/**
+ * Get the first author of a score set.
+ *
+ * In ScoreSet.authors, the first author is identified by its primary attribute being set to true.
+ *
+ * @param scoreSet A score set.
+ * @returns The first author, or undefined if there is none.
+ */
+export function getScoreSetFirstAuthor(scoreSet: ScoreSet): Author | undefined {
+  return scoreSet.primaryPublicationIdentifiers[0]?.authors.find((author) => author.primary)
+}
 
 /**
  * Get a short name for a score set. If the score set has primary publication information or a gene name, this will have
@@ -23,18 +36,16 @@ type ScoreSet = components['schemas']['ScoreSet']
  * @param scoreSet A score set.
  * @returns A suitable short name for the score set.
  */
-export function getScoreSetShortName(scoreSet: ScoreSet | undefined | null) {
-  if (!scoreSet) {
-    return undefined
-  }
-  const firstAuthor = scoreSet.primaryPublicationIdentifiers[0]?.authors[0].name
-  const firstAuthorLastName = _.isEmpty(firstAuthor) ? undefined : firstAuthor.split(',')[0]
+export function getScoreSetShortName(scoreSet: ScoreSet): string {
+  const firstAuthorName = getScoreSetFirstAuthor(scoreSet)?.name
+  const firstAuthorLastName = !firstAuthorName || _.isEmpty(firstAuthorName) ? undefined : firstAuthorName.split(',')[0]
   const numAuthors = scoreSet.primaryPublicationIdentifiers[0]?.authors.length ?? 0
   const authors = firstAuthorLastName
     ? numAuthors > 1
       ? `${firstAuthorLastName} et al.`
       : firstAuthorLastName
     : undefined
+  // TODO VariantEffect/mavedb-api#450
   const gene = scoreSet.targetGenes?.[0]?.name
   const year = scoreSet.primaryPublicationIdentifiers[0]?.publicationYear
   const parts = [authors, gene, year?.toString()].filter((x) => x != null)

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,8 @@ import ToastService from 'primevue/toastservice'
 import Tooltip from 'primevue/tooltip'
 import {initRestClient} from 'rest-client-vue'
 import {createApp} from 'vue'
+import {createHead} from '@unhead/vue/client'
+import {TemplateParamsPlugin} from 'unhead/plugins'
 
 import App from '@/App.vue'
 import config from '@/config'
@@ -43,10 +45,24 @@ router.beforeEach((to) => {
   }
 })
 
+const head = createHead({
+  plugins: [TemplateParamsPlugin],
+  init: [
+    {
+      titleTemplate: '%siteName %separator %s',
+      templateParams: {
+        separator: '|',
+        siteName: import.meta.env.VITE_SITE_TITLE
+      }
+    }
+  ]
+})
+
 createApp(App)
   .use(router)
   .use(store)
   .use(createPinia())
+  .use(head)
   .use(PrimeVue)
   .use(ConfirmationService)
   .use(ToastService)

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -47,29 +47,20 @@ const routes: RouteRecordRaw[] = [
   {
     path: '/search',
     name: 'search',
-    component: SearchView,
-    meta: {
-      title: import.meta.env.VITE_SITE_TITLE + ' | Search'
-    }
+    component: SearchView
   },
   ...(config.CLINICAL_FEATURES_ENABLED
     ? [
         {
           path: '/mavemd',
           name: 'mavemd',
-          component: SearchVariantsScreen,
-          meta: {
-            title: import.meta.env.VITE_SITE_TITLE + ' | MaveMD variant search'
-          }
+          component: SearchVariantsScreen
         }
       ]
     : []),
   {
     path: '/docs',
-    component: DocumentationView,
-    meta: {
-      title: import.meta.env.VITE_SITE_TITLE + ' | Documentation'
-    }
+    component: DocumentationView
   },
   {
     path: '/help',
@@ -90,10 +81,7 @@ const routes: RouteRecordRaw[] = [
   {
     path: '/statistics', // Add the new route
     name: 'statistics',
-    component: StatisticsView,
-    meta: {
-      title: import.meta.env.VITE_SITE_TITLE + ' | Statistics'
-    }
+    component: StatisticsView
   },
   {
     path: '/experiments/:urn',
@@ -231,59 +219,59 @@ const router = createRouter({
   routes
 })
 
-router.beforeEach((to, from, next) => {
-  // This goes through the matched routes from last to first, finding the closest route with a title.
-  // e.g., if we have `/some/deep/nested/route` and `/some`, `/deep`, and `/nested` have titles,
-  // `/nested`'s will be chosen.
-  const nearestWithTitle = to.matched
-    .slice()
-    .reverse()
-    .find((r) => r.meta && r.meta.title)
+// router.beforeEach((to, from, next) => {
+//   // This goes through the matched routes from last to first, finding the closest route with a title.
+//   // e.g., if we have `/some/deep/nested/route` and `/some`, `/deep`, and `/nested` have titles,
+//   // `/nested`'s will be chosen.
+//   const nearestWithTitle = to.matched
+//     .slice()
+//     .reverse()
+//     .find((r) => r.meta && r.meta.title)
 
-  // Find the nearest route element with meta tags.
-  const nearestWithMeta = to.matched
-    .slice()
-    .reverse()
-    .find((r) => r.meta && r.meta.metaTags)
+//   // Find the nearest route element with meta tags.
+//   const nearestWithMeta = to.matched
+//     .slice()
+//     .reverse()
+//     .find((r) => r.meta && r.meta.metaTags)
 
-  const previousNearestWithMeta = from.matched
-    .slice()
-    .reverse()
-    .find((r) => r.meta && r.meta.metaTags)
+//   const previousNearestWithMeta = from.matched
+//     .slice()
+//     .reverse()
+//     .find((r) => r.meta && r.meta.metaTags)
 
-  // If a route with a title was found, set the document (page) title to that value.
-  if (nearestWithTitle) {
-    document.title = nearestWithTitle.meta.title
-  } else if (previousNearestWithMeta) {
-    document.title = previousNearestWithMeta.meta.title
-  }
+//   // If a route with a title was found, set the document (page) title to that value.
+//   if (nearestWithTitle) {
+//     document.title = nearestWithTitle.meta.title
+//   } else if (previousNearestWithMeta) {
+//     document.title = previousNearestWithMeta.meta.title
+//   }
 
   // Remove any stale meta tags from the document using the key attribute we set below.
-  Array.from(document.querySelectorAll('[data-vue-router-controlled]')).map((el) => el.parentNode.removeChild(el))
+  // Array.from(document.querySelectorAll('[data-vue-router-controlled]')).map((el) => el.parentNode.removeChild(el))
 
   // Skip rendering meta tags if there are none.
-  if (!nearestWithMeta) {
-    return next()
-  }
+  // if (!nearestWithMeta) {
+  //   return next()
+  // }
 
   // Turn the meta tag definitions into actual elements in the head.
-  nearestWithMeta.meta.metaTags
-    .map((tagDef) => {
-      const tag = document.createElement('meta')
+  // nearestWithMeta.meta.metaTags
+  //   .map((tagDef) => {
+  //     const tag = document.createElement('meta')
 
-      Object.keys(tagDef).forEach((key) => {
-        tag.setAttribute(key, tagDef[key])
-      })
+  //     Object.keys(tagDef).forEach((key) => {
+  //       tag.setAttribute(key, tagDef[key])
+  //     })
 
-      // We use this to track which meta tags we create so we don't interfere with other ones.
-      tag.setAttribute('data-vue-router-controlled', '')
+  //     // We use this to track which meta tags we create so we don't interfere with other ones.
+  //     tag.setAttribute('data-vue-router-controlled', '')
 
-      return tag
-    })
-    // Add the meta tags to the document head.
-    .forEach((tag) => document.head.appendChild(tag))
+  //     return tag
+  //   })
+  //   // Add the meta tags to the document head.
+  //   .forEach((tag) => document.head.appendChild(tag))
 
-  next()
-})
+//   next()
+// })
 
 export default router

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -79,7 +79,7 @@ const routes: RouteRecordRaw[] = [
     component: UsersView
   },
   {
-    path: '/statistics', // Add the new route
+    path: '/statistics',
     name: 'statistics',
     component: StatisticsView
   },
@@ -218,60 +218,5 @@ const router = createRouter({
   history: createWebHistory(),
   routes
 })
-
-// router.beforeEach((to, from, next) => {
-//   // This goes through the matched routes from last to first, finding the closest route with a title.
-//   // e.g., if we have `/some/deep/nested/route` and `/some`, `/deep`, and `/nested` have titles,
-//   // `/nested`'s will be chosen.
-//   const nearestWithTitle = to.matched
-//     .slice()
-//     .reverse()
-//     .find((r) => r.meta && r.meta.title)
-
-//   // Find the nearest route element with meta tags.
-//   const nearestWithMeta = to.matched
-//     .slice()
-//     .reverse()
-//     .find((r) => r.meta && r.meta.metaTags)
-
-//   const previousNearestWithMeta = from.matched
-//     .slice()
-//     .reverse()
-//     .find((r) => r.meta && r.meta.metaTags)
-
-//   // If a route with a title was found, set the document (page) title to that value.
-//   if (nearestWithTitle) {
-//     document.title = nearestWithTitle.meta.title
-//   } else if (previousNearestWithMeta) {
-//     document.title = previousNearestWithMeta.meta.title
-//   }
-
-  // Remove any stale meta tags from the document using the key attribute we set below.
-  // Array.from(document.querySelectorAll('[data-vue-router-controlled]')).map((el) => el.parentNode.removeChild(el))
-
-  // Skip rendering meta tags if there are none.
-  // if (!nearestWithMeta) {
-  //   return next()
-  // }
-
-  // Turn the meta tag definitions into actual elements in the head.
-  // nearestWithMeta.meta.metaTags
-  //   .map((tagDef) => {
-  //     const tag = document.createElement('meta')
-
-  //     Object.keys(tagDef).forEach((key) => {
-  //       tag.setAttribute(key, tagDef[key])
-  //     })
-
-  //     // We use this to track which meta tags we create so we don't interfere with other ones.
-  //     tag.setAttribute('data-vue-router-controlled', '')
-
-  //     return tag
-  //   })
-  //   // Add the meta tags to the document head.
-  //   .forEach((tag) => document.head.appendChild(tag))
-
-//   next()
-// })
 
 export default router


### PR DESCRIPTION
- Improved assay facts sheet title
  - Removed first name and initials from the first author's name.
  - Use "et al." only when there are multiple authors.
  - Add the journal name.
  - Use italics.
- Better page titles
  - Use the unhead package to manage page titles.
  - Include score set name in the score set page title.
  - Replaced Vue router-based meta tag handling with [unhead](https://unhead.unjs.io).

Unhead should now be used for any HTML header modification, including titles, meta tags, and dynamically loaded CSS and scripts.