### PR TITLE
Histogram Color Palette Cleanup

### DIFF
--- a/src/components/ScoreSetHistogram.vue
+++ b/src/components/ScoreSetHistogram.vue
@@ -305,35 +305,35 @@ export default defineComponent({
             {
               classifier: (d: HistogramDatum) => variantIsMissense(d),
               options: {
-                color: '#a36e4e',
+                color: '#ffcd3a',
                 title: 'Missense'
               }
             },
             {
               classifier: (d: HistogramDatum) => variantIsSynonymous(d),
               options: {
-                color: '#59a34e',
+                color: '#6aa84f',
                 title: 'Synonymous'
               }
             },
             {
               classifier: (d: HistogramDatum) => variantIsNonsense(d),
               options: {
-                color: '#a3984e',
+                color: '#681a1a',
                 title: 'Nonsense'
               }
             },
             ...(this.hideStartAndStopLossByDefault ? [] : [{
               classifier: (d: HistogramDatum) => isStartOrStopLoss(d),
               options: {
-              color: '#6d4ea3',
+              color: '#cd3aff',
               title: 'Start/Stop Loss'
               }
             }]),
             {
               classifier: (d: HistogramDatum) => variantIsOther(d),
               options: {
-                color: '#709090',
+                color: '#3affcd',
                 title: 'Other'
               }
             }
@@ -404,7 +404,7 @@ export default defineComponent({
             series.push({
               classifier: (d: HistogramDatum) => variantIsMissense(d),
               options: {
-                color: '#a36e4e',
+                color: '#ffcd3a',
                 title: 'Missense'
               }
             })
@@ -414,7 +414,7 @@ export default defineComponent({
             series.push({
               classifier: (d: HistogramDatum) => variantIsSynonymous(d),
               options: {
-                color: '#59a34e',
+                color: '#6aa84f',
                 title: 'Synonymous'
               }
             })
@@ -424,7 +424,7 @@ export default defineComponent({
             series.push({
               classifier: (d: HistogramDatum) => variantIsNonsense(d),
               options: {
-                color: '#a3984e',
+                color: '#681a1a',
                 title: 'Nonsense'
               }
             })
@@ -434,7 +434,7 @@ export default defineComponent({
             series.push({
               classifier: (d: HistogramDatum) => isStartOrStopLoss(d),
               options: {
-                color: '#6d4ea3',
+                color: '#cd3aff',
                 title: 'Start/Stop Loss'
               }
             })
@@ -444,7 +444,7 @@ export default defineComponent({
             series.push({
               classifier: (d: HistogramDatum) => variantIsOther(d),
               options: {
-                color: '#709090',
+                color: '#3affcd',
                 title: 'Other'
               }
             })

--- a/src/components/ScoreSetHistogram.vue
+++ b/src/components/ScoreSetHistogram.vue
@@ -459,20 +459,20 @@ export default defineComponent({
     },
 
     vizOptions: function () {
-      const options = [{label: 'Overall Distribution', view: 'distribution'}]
+      const options = [{label: 'Overall Distribution', view: 'distribution', clinicalControlLegendNoteEnabled: false}]
 
       if (this.someVariantsHaveClinicalSignificance) {
-        options.push({label: 'Clinical View', view: 'clinical'})
+        options.push({label: 'Clinical View', view: 'clinical', clinicalControlLegendNoteEnabled: true})
       }
 
       // crude to be based on clinical significance. may be a better option for viz control
       if (this.someVariantsHaveClinicalSignificance) {
-        options.push({label: 'Protein Effect View', view: 'effect'})
+        options.push({label: 'Protein Effect View', view: 'effect', clinicalControlLegendNoteEnabled: false})
       }
 
       // custom view should always come last
       if (this.someVariantsHaveClinicalSignificance) {
-        options.push({label: 'Custom', view: 'custom'})
+        options.push({label: 'Custom', view: 'custom', clinicalControlLegendNoteEnabled: true})
       }
       return options
     },
@@ -900,9 +900,9 @@ export default defineComponent({
         .seriesClassifier(seriesClassifier)
         .title('Distribution of Functional Scores')
         .legendNote(
-          this.activeViz == 0 || !this.refreshedClinicalControls
-            ? null
-            : `${this.controlDb?.dbName} data from version ${this.controlVersion}`
+          this.vizOptions[this.activeViz]?.clinicalControlLegendNoteEnabled && this.refreshedClinicalControls
+            ? `${this.controlDb?.dbName} data from version ${this.controlVersion}`
+            : null
         )
         .shaders(this.histogramShaders)
 

--- a/src/lib/ranges.ts
+++ b/src/lib/ranges.ts
@@ -2,7 +2,7 @@ import { HistogramShader } from '@/lib/histogram'
 
 export const NORMAL_RANGE_DEFAULT_COLOR = '#4444ff'
 export const ABNORMAL_RANGE_DEFAULT_COLOR = '#ff4444'
-export const NOT_SPECIFIED_RANGE_DEFAULT_COLOR = '#a6a600'
+export const NOT_SPECIFIED_RANGE_DEFAULT_COLOR = '#646464'
 
 export const INDETERMINATE_RANGE_EVIDENCE = ['INDETERMINATE'] as const
 export const NORMAL_RANGE_EVIDENCE = ['BS3_STRONG', 'BS3_MODERATE', 'BS3_SUPPORTING'] as const


### PR DESCRIPTION
This pull request updates the color scheme for variant categories in the `ScoreSetHistogram.vue` component and refines how legend notes are displayed for different visualization options. Additionally, it adjusts the default color for unspecified ranges in `ranges.ts`. These changes improve visual clarity and user experience in the histogram and related visualizations.

### Visual and UI improvements

* Updated the color palette for all variant categories (`Missense`, `Synonymous`, `Nonsense`, `Start/Stop Loss`, and `Other`) in both direct initialization and dynamic series creation within `ScoreSetHistogram.vue` for improved distinction and accessibility. [[1]](diffhunk://#diff-8c5baf0c0d572e0f90078fb085ef8b917eed7b7308edde7efd57e080754a2fc1L308-R336) [[2]](diffhunk://#diff-8c5baf0c0d572e0f90078fb085ef8b917eed7b7308edde7efd57e080754a2fc1L407-R407) [[3]](diffhunk://#diff-8c5baf0c0d572e0f90078fb085ef8b917eed7b7308edde7efd57e080754a2fc1L417-R417) [[4]](diffhunk://#diff-8c5baf0c0d572e0f90078fb085ef8b917eed7b7308edde7efd57e080754a2fc1L427-R427) [[5]](diffhunk://#diff-8c5baf0c0d572e0f90078fb085ef8b917eed7b7308edde7efd57e080754a2fc1L437-R437) [[6]](diffhunk://#diff-8c5baf0c0d572e0f90078fb085ef8b917eed7b7308edde7efd57e080754a2fc1L447-R447)
* Added a new `clinicalControlLegendNoteEnabled` flag to each visualization option in the `vizOptions` method, allowing conditional display of clinical control legend notes based on the selected view.
* Refined logic for displaying the legend note in the histogram visualization, now using the new flag to determine when to show clinical control data version information.

### Code and configuration updates

* Changed the default color for unspecified ranges in `src/lib/ranges.ts` from yellow (`#a6a600`) to gray (`#646464`) for better contrast with overlaid colors.

<img width="1176" height="462" alt="Screenshot 2025-09-29 at 9 44 38 PM" src="https://github.com/user-attachments/assets/dd09dd25-9b92-489e-b245-31872c2c8c80" />
