### PR TITLE
Add message for missing OddsPath calculations, update AccordionTab header

### DIFF
--- a/src/components/CalibrationTable.vue
+++ b/src/components/CalibrationTable.vue
@@ -190,6 +190,9 @@
       </tr>
     </tbody>
   </table>
+  <div v-else style="text-align: center; margin-top: 1em; font-style: italic; font-size: 0.9em;">
+    No OddsPath calculations have been provided for these score ranges.
+  </div>
 </template>
 
 <script lang="ts">

--- a/src/components/ScoreSetHistogram.vue
+++ b/src/components/ScoreSetHistogram.vue
@@ -116,7 +116,7 @@
    to create the histogram before the component is mounted when it doesn't have access to `this.$refs`. As a workaround, only render this child component once the histogram is ready. -->
   <div v-if="showCalibrations && activeCalibration && activeCalibration.value" class="mave-range-table-container">
     <Accordion :active-index="0" collapse-icon="pi pi-minus" expand-icon="pi pi-plus">
-      <AccordionTab class="mave-range-table-tab" header="Score Range Details">
+      <AccordionTab class="mave-range-table-tab" header="Score Ranges and Clinical Evidence Strength">
         <CalibrationTable
           :score-calibration="activeCalibration.value"
           :score-calibration-name="activeCalibration.label"


### PR DESCRIPTION
- Adds a message that OddsPath calculations are missing to the accordion tab if they are not available
- Adds `Clinical Evidence Strength` to the accordion tab header to better represent its contents