### PR TITLE
fixed: removing primary publication from publications list would freeze primary selection drop down

### DIFF
--- a/src/components/screens/ExperimentCreator.vue
+++ b/src/components/screens/ExperimentCreator.vue
@@ -249,6 +249,7 @@
                           :suggestions="publicationIdentifierSuggestionsList"
                           @complete="searchPublicationIdentifiers"
                           @item-select="acceptNewPublicationIdentifier"
+                          @item-unselect="removePublicationIdentifier"
                           @keyup.escape="clearPublicationIdentifierSearch"
                         >
                           <template #chip="slotProps">
@@ -981,6 +982,17 @@ export default {
           summary: `Identifier "${newIdentifier}" is already associated with this experiment`,
           life: 3000
         })
+      }
+    },
+
+    removePublicationIdentifier: function (event) {
+      // If we are removing a primary publication identifier, also remove it from that list.
+      const removedIdentifier = event.value.identifier
+      const primaryIdx = this.primaryPublicationIdentifiers.findIndex(
+        (pub) => pub.identifier == removedIdentifier
+      )
+      if (primaryIdx != -1) {
+        this.primaryPublicationIdentifiers.splice(primaryIdx, 1)
       }
     },
 

--- a/src/components/screens/ExperimentEditor.vue
+++ b/src/components/screens/ExperimentEditor.vue
@@ -101,6 +101,7 @@
                     :suggestions="publicationIdentifierSuggestionsList"
                     @complete="searchPublicationIdentifiers"
                     @item-select="acceptNewPublicationIdentifier"
+                    @item-unselect="removePublicationIdentifier"
                     @keyup.escape="clearPublicationIdentifierSearch"
                   >
                     <template #chip="slotProps">
@@ -757,6 +758,17 @@ export default {
           summary: `Identifier "${newIdentifier}" is already associated with this experiment`,
           life: 3000
         })
+      }
+    },
+
+    removePublicationIdentifier: function (event) {
+      // If we are removing a primary publication identifier, also remove it from that list.
+      const removedIdentifier = event.value.identifier
+      const primaryIdx = this.primaryPublicationIdentifiers.findIndex(
+        (pub) => pub.identifier == removedIdentifier
+      )
+      if (primaryIdx != -1) {
+        this.primaryPublicationIdentifiers.splice(primaryIdx, 1)
       }
     },
 

--- a/src/components/screens/ScoreSetCreator.vue
+++ b/src/components/screens/ScoreSetCreator.vue
@@ -541,6 +541,7 @@
                           :suggestions="publicationIdentifierSuggestionsList"
                           @complete="searchPublicationIdentifiers"
                           @item-select="acceptNewPublicationIdentifier"
+                          @item-unselect="removePublicationIdentifier"
                           @keyup.escape="clearPublicationIdentifierSearch"
                         >
                           <template #chip="slotProps">
@@ -2773,6 +2774,17 @@ export default {
           summary: `Identifier "${newIdentifier}" is already associated with this experiment`,
           life: 3000
         })
+      }
+    },
+
+    removePublicationIdentifier: function (event) {
+      // If we are removing a primary publication identifier, also remove it from that list.
+      const removedIdentifier = event.value.identifier
+      const primaryIdx = this.primaryPublicationIdentifiers.findIndex(
+        (pub) => pub.identifier == removedIdentifier
+      )
+      if (primaryIdx != -1) {
+        this.primaryPublicationIdentifiers.splice(primaryIdx, 1)
       }
     },
 

--- a/src/components/screens/ScoreSetEditor.vue
+++ b/src/components/screens/ScoreSetEditor.vue
@@ -251,6 +251,7 @@
                       :suggestions="publicationIdentifierSuggestionsList"
                       @complete="searchPublicationIdentifiers"
                       @item-select="acceptNewPublicationIdentifier"
+                      @item-unselect="removePublicationIdentifier"
                       @keyup.escape="clearPublicationIdentifierSearch"
                     >
                       <template #chip="slotProps">
@@ -1981,6 +1982,17 @@ export default {
           summary: `Identifier "${newIdentifier}" is already associated with this experiment`,
           life: 3000
         })
+      }
+    },
+
+    removePublicationIdentifier: function (event) {
+      // If we are removing a primary publication identifier, also remove it from that list.
+      const removedIdentifier = event.value.identifier
+      const primaryIdx = this.primaryPublicationIdentifiers.findIndex(
+        (pub) => pub.identifier == removedIdentifier
+      )
+      if (primaryIdx != -1) {
+        this.primaryPublicationIdentifiers.splice(primaryIdx, 1)
       }
     },
 


### PR DESCRIPTION
Adds the `@item-unselect` handler to the publication identifier autocomplete and links it to a new removePublicationIdentifier method in multiple components. The new method checks to see if the removed publication is in the list of primary publications and removes the primary publication if it is.