### PR TITLE
ProteinStructureView: dynamic AlphaFold model file version

### DIFF
--- a/src/components/ProteinStructureView.vue
+++ b/src/components/ProteinStructureView.vue
@@ -245,19 +245,32 @@ export default {
 
     render: async function () {
       if (this.selectedAlphaFold) {
-        let alphafoldFilesVersion
+        let alphafoldCifUrl
         try {
           const response = await axios.get(`${config.apiBaseUrl}/alphafold-files/version`)
-          alphafoldFilesVersion = response.data.version
+          const alphafoldFilesVersion = response.data.version
+          alphafoldCifUrl = `https://alphafold.ebi.ac.uk/files/AF-${this.selectedAlphaFold.id}-F1-model_${alphafoldFilesVersion}.cif`
         } catch (error) {
-          console.error('Error fetching AlphaFold files version:', error)
+          this.$toast.add({severity: 'error', summary: 'Error', detail: 'Failed to fetch AlphaFold version'})
+          return
+        }
+
+        // verify that the alphafoldCifUrl exists by verifying 200 or 304 status
+        try {
+          const response = await fetch(alphafoldCifUrl, { method: 'HEAD' })
+          if (response.status !== 200 && response.status !== 304) {
+            this.$toast.add({severity: 'error', summary: 'Error', detail: 'Failed to fetch AlphaFold structure'})
+            return
+          }
+        } catch (error) {
+          this.$toast.add({severity: 'error', summary: 'Error', detail: 'Failed to fetch AlphaFold structure'})
           return
         }
 
         const viewerInstance = new PDBeMolstarPlugin()
         const options = {
           customData: {
-            url: `https://alphafold.ebi.ac.uk/files/AF-${this.selectedAlphaFold.id}-F1-model_${alphafoldFilesVersion}.cif`,
+            url: alphafoldCifUrl,
             format: 'cif'
           },
           /** This applies AlphaFold confidence score colouring theme for AlphaFold model */


### PR DESCRIPTION
Retrieves AlphaFold model version from API to be included in CIF file URL, rather than hardcoding, to prevent 404s when old file versions are purged by AlphaFold.

Goes with [#VariantEffect/mavedb-api/davereinhart/alphafold-files-version-proxy](https://github.com/VariantEffect/mavedb-api/pull/547/commits/590844e34c9b38527523ecca98a5df7c10fabc52)