### PR TITLE
Fixes undefined query parameter value when clicking on segments of St…

### DIFF
--- a/src/components/screens/StatisticsView.vue
+++ b/src/components/screens/StatisticsView.vue
@@ -440,12 +440,19 @@ export default {
         if (!model) {
           model = 'search'
         }
-
-        if (element.text == 'Others') {
-          return
+        let organismName
+        if (Array.isArray(element) && element.length == 1) {
+          const elementIndex = element[0].index
+          organismName = data.labels[elementIndex]
+        } else {
+          organismName = element.text
         }
 
-        window.open(`${config.appBaseUrl}/#/search?${model}=${element.text}`)
+        if (!organismName || organismName == 'Others') {
+          return
+        }
+        window.open(`${config.appBaseUrl}/#/search?${model}=${organismName}`)
+
       }
 
       return {


### PR DESCRIPTION
…atisticsScreen organism chart

The text value needed for query parameter is found in element.text when clicking on the legend items, but when clicking on the doughnut chart segments it needs to be retreived from the chart's data labels using the index from the element clicked. This change handles that discrepancy by checking if the element is an array of length one, which is the case when a segment of the chart is clicked, then retreiving the correct value from the charts data labels array based on the element index property value.