### PR TITLE
fix: decimals were unsupported in calibration editor component range entries

### DIFF
--- a/src/components/CalibrationEditor.vue
+++ b/src/components/CalibrationEditor.vue
@@ -228,6 +228,10 @@
                 v-model="rangeObj.range[0]"
                 :aria-labelledby="scopedId(`input-investigatorProvidedRangeLower-${rangeIdx}`)"
                 :disabled="functionalRangeHelpers[rangeIdx].infiniteLower"
+                :max-fraction-digits="10"
+                :min-fraction-digits="0"
+                mode="decimal"
+                step="any"
               />
               <label :for="scopedId(`input-investigatorProvidedRangeLower-${rangeIdx}`)">{{
                 functionalRangeHelpers[rangeIdx].infiniteLower
@@ -243,6 +247,10 @@
                 v-model="rangeObj.range[1]"
                 :aria-labelledby="scopedId(`input-investigatorProvidedRangeUpper-${rangeIdx}`)"
                 :disabled="functionalRangeHelpers[rangeIdx].infiniteUpper"
+                :max-fraction-digits="10"
+                :min-fraction-digits="0"
+                mode="decimal"
+                step="any"
               />
               <label :for="scopedId(`input-investigatorProvidedRangeUpper-${rangeIdx}`)">{{
                 functionalRangeHelpers[rangeIdx].infiniteUpper


### PR DESCRIPTION
This pull request makes a small update to the numeric input fields in the `CalibrationEditor.vue` component to improve their precision and flexibility for decimal values.

- The numeric input fields for both the lower and upper range values now support up to 10 decimal places, allow any decimal step, and are explicitly set to decimal mode for more accurate data entry. [[1]](diffhunk://#diff-a6c7ff63cddf11370db09492c1b2562fb2062a0762bb2c524ed4734a0c9ab502R231-R234) [[2]](diffhunk://#diff-a6c7ff63cddf11370db09492c1b2562fb2062a0762bb2c524ed4734a0c9ab502R250-R253)