### PR TITLE
fix: decimals were unsupported in calibration editor component range entries

### DIFF
--- a/src/components/CalibrationEditor.vue
+++ b/src/components/CalibrationEditor.vue
@@ -228,6 +228,10 @@
                 v-model="rangeObj.range[0]"
                 :aria-labelledby="scopedId(`input-investigatorProvidedRangeLower-${rangeIdx}`)"
                 :disabled="functionalRangeHelpers[rangeIdx].infiniteLower"
+                :max-fraction-digits="10"
+                :min-fraction-digits="0"
+                mode="decimal"
+                step="any"
               />
               <label :for="scopedId(`input-investigatorProvidedRangeLower-${rangeIdx}`)">{{
                 functionalRangeHelpers[rangeIdx].infiniteLower
@@ -243,6 +247,10 @@
                 v-model="rangeObj.range[1]"
                 :aria-labelledby="scopedId(`input-investigatorProvidedRangeUpper-${rangeIdx}`)"
                 :disabled="functionalRangeHelpers[rangeIdx].infiniteUpper"
+                :max-fraction-digits="10"
+                :min-fraction-digits="0"
+                mode="decimal"
+                step="any"
               />
               <label :for="scopedId(`input-investigatorProvidedRangeUpper-${rangeIdx}`)">{{
                 functionalRangeHelpers[rangeIdx].infiniteUpper


### PR DESCRIPTION
This pull request improves the numeric input fields in the `CalibrationEditor.vue` component to allow for more precise and flexible decimal input. The main changes ensure that users can enter decimal values with up to 10 digits after the decimal point and that the input fields are explicitly set to accept any decimal value.

Enhancements to numeric input fields:

* Updated both lower and upper range input fields to allow up to 10 decimal places, set the minimum fraction digits to 0, specify decimal mode, and allow any step size for more accurate and flexible data entry. [[1]](diffhunk://#diff-a6c7ff63cddf11370db09492c1b2562fb2062a0762bb2c524ed4734a0c9ab502R231-R234) [[2]](diffhunk://#diff-a6c7ff63cddf11370db09492c1b2562fb2062a0762bb2c524ed4734a0c9ab502R250-R253)