### PR TITLE
Use mapped HGNC name for assay facts gene text when available

### DIFF
--- a/src/components/AssayFactSheet.vue
+++ b/src/components/AssayFactSheet.vue
@@ -14,7 +14,9 @@
     <div class="mavedb-assay-facts-section mavedb-assay-facts-bottom-separator">
       <div class="mavedb-assay-facts-row">
         <div class="mavedb-assay-facts-label">Gene (HGNC symbol)</div>
-        <div class="mavedb-assay-facts-value">{{ scoreSet.targetGenes[0]?.name }}</div>
+        <div class="mavedb-assay-facts-value">
+          {{ geneTextForScoreSet ? geneTextForScoreSet : 'Not specified' }}
+        </div>
       </div>
     </div>
     <div class="mavedb-assay-facts-section">
@@ -238,8 +240,7 @@ export default defineComponent({
     },
 
     geneAndYear: function () {
-      // TODO VariantEffect/mavedb-api#450
-      const gene = this.scoreSet.targetGenes?.[0]?.name
+      const gene = this.geneTextForScoreSet
       const year = this.scoreSet.primaryPublicationIdentifiers[0]?.publicationYear
       const parts = [gene, year?.toString()].filter((x) => x != null)
       return parts.length > 0 ? parts.join(' ') : undefined
@@ -251,6 +252,20 @@ export default defineComponent({
 
     journal: function () {
       return this.scoreSet.primaryPublicationIdentifiers[0]?.publicationJournal
+    },
+
+    distinctGenesForTargets: function () {
+      // empty when no target genes have mappedHgncName
+      const geneNames = this.scoreSet.targetGenes?.map((tg) => tg.mappedHgncName) || []
+      return _.uniq(geneNames.filter((name) => !_.isEmpty(name))) as string[]
+    },
+
+    geneTextForScoreSet: function () {
+      if (this.distinctGenesForTargets.length == 0) {
+        return this.scoreSet.targetGenes[0]?.name || null
+      }
+
+      return this.distinctGenesForTargets.length == 1 ? this.distinctGenesForTargets[0] : 'Multiple genes'
     },
 
     detectsNmd: function () {

--- a/src/schema/openapi.d.ts
+++ b/src/schema/openapi.d.ts
@@ -667,7 +667,7 @@ export interface paths {
      *     The index to start from. If None, starts from the beginning.
      * limit : Optional[int]
      *     The maximum number of variants to return. If None, returns all variants.
-     * namespaces: List[Literal["scores", "counts", "vep", "gnomad"]]
+     * namespaces: List[Literal["scores", "counts", "vep", "gnomad", "clingen"]]
      *     The namespaces of all columns except for accession, hgvs_nt, hgvs_pro, and hgvs_splice.
      *     We may add ClinVar in the future.
      * drop_na_columns : bool, optional
@@ -2708,7 +2708,7 @@ export interface components {
       /** Processingstate */
       processingState?: string | null;
       /** Officialcollections */
-      officialCollections: components["schemas"]["mavedb__view_models__score_set__OfficialCollection"][];
+      officialCollections: components["schemas"]["OfficialCollection"][];
     };
     /**
      * ExperimentControlledKeyword
@@ -3542,6 +3542,15 @@ export interface components {
       /** Privatekey */
       privateKey: string;
     };
+    /** OfficialCollection */
+    OfficialCollection: {
+      /** Badgename */
+      badgeName: string;
+      /** Name */
+      name: string;
+      /** Urn */
+      urn: string;
+    };
     /** OrcidUser */
     OrcidUser: {
       /** Recordtype */
@@ -4092,11 +4101,11 @@ export interface components {
       /** Functionalclassifications */
       functionalClassifications?: components["schemas"]["mavedb__view_models__score_calibration__FunctionalClassification"][] | null;
       /** Thresholdsources */
-      thresholdSources?: components["schemas"]["PublicationIdentifier"][] | null;
+      thresholdSources: components["schemas"]["PublicationIdentifier"][];
       /** Classificationsources */
-      classificationSources?: components["schemas"]["PublicationIdentifier"][] | null;
+      classificationSources: components["schemas"]["PublicationIdentifier"][];
       /** Methodsources */
-      methodSources?: components["schemas"]["PublicationIdentifier"][] | null;
+      methodSources: components["schemas"]["PublicationIdentifier"][];
       /** Calibrationmetadata */
       calibrationMetadata?: Record<string, never> | null;
       /** Recordtype */
@@ -4153,11 +4162,11 @@ export interface components {
       /** Functionalclassifications */
       functionalClassifications?: components["schemas"]["FunctionalClassificationCreate"][] | null;
       /** Thresholdsources */
-      thresholdSources?: components["schemas"]["PublicationIdentifierCreate"][] | null;
+      thresholdSources: components["schemas"]["PublicationIdentifierCreate"][];
       /** Classificationsources */
-      classificationSources?: components["schemas"]["PublicationIdentifierCreate"][] | null;
+      classificationSources: components["schemas"]["PublicationIdentifierCreate"][];
       /** Methodsources */
-      methodSources?: components["schemas"]["PublicationIdentifierCreate"][] | null;
+      methodSources: components["schemas"]["PublicationIdentifierCreate"][];
       /** Calibrationmetadata */
       calibrationMetadata?: Record<string, never> | null;
       /** Scoreseturn */
@@ -4184,11 +4193,11 @@ export interface components {
       /** Functionalclassifications */
       functionalClassifications?: components["schemas"]["SavedFunctionalClassification"][] | null;
       /** Thresholdsources */
-      thresholdSources?: components["schemas"]["SavedPublicationIdentifier"][] | null;
+      thresholdSources: components["schemas"]["SavedPublicationIdentifier"][];
       /** Classificationsources */
-      classificationSources?: components["schemas"]["SavedPublicationIdentifier"][] | null;
+      classificationSources: components["schemas"]["SavedPublicationIdentifier"][];
       /** Methodsources */
-      methodSources?: components["schemas"]["SavedPublicationIdentifier"][] | null;
+      methodSources: components["schemas"]["SavedPublicationIdentifier"][];
       /** Calibrationmetadata */
       calibrationMetadata?: Record<string, never> | null;
       /** Recordtype */
@@ -4289,7 +4298,7 @@ export interface components {
       scoreCalibrations?: components["schemas"]["ScoreCalibration"][] | null;
       experiment: components["schemas"]["Experiment"];
       /** Officialcollections */
-      officialCollections: components["schemas"]["mavedb__view_models__score_set__OfficialCollection"][];
+      officialCollections: components["schemas"]["OfficialCollection"][];
       /** Private */
       private: boolean;
       processingState?: components["schemas"]["ProcessingState"] | null;
@@ -4714,6 +4723,8 @@ export interface components {
       recordType?: string;
       targetSequence?: components["schemas"]["SavedTargetSequence"] | null;
       targetAccession?: components["schemas"]["SavedTargetAccession"] | null;
+      /** Mappedhgncname */
+      mappedHgncName?: string | null;
       /** Uniprotidfrommappedmetadata */
       uniprotIdFromMappedMetadata?: string | null;
     };
@@ -4920,6 +4931,8 @@ export interface components {
       recordType?: string;
       targetSequence?: components["schemas"]["TargetSequence"] | null;
       targetAccession?: components["schemas"]["TargetAccession"] | null;
+      /** Mappedhgncname */
+      mappedHgncName?: string | null;
       /** Uniprotidfrommappedmetadata */
       uniprotIdFromMappedMetadata?: string | null;
     };
@@ -4952,6 +4965,8 @@ export interface components {
       recordType?: string;
       targetSequence?: components["schemas"]["TargetSequence"] | null;
       targetAccession?: components["schemas"]["TargetAccession"] | null;
+      /** Mappedhgncname */
+      mappedHgncName?: string | null;
       /** Uniprotidfrommappedmetadata */
       uniprotIdFromMappedMetadata?: string | null;
       /** Scoreseturn */
@@ -5755,15 +5770,6 @@ export interface components {
        * @default []
        */
       variants?: components["schemas"]["VariantEffectMeasurement"][];
-    };
-    /** OfficialCollection */
-    mavedb__view_models__score_set__OfficialCollection: {
-      /** Badgename */
-      badgeName: string;
-      /** Name */
-      name: string;
-      /** Urn */
-      urn: string;
     };
     /**
      * sequenceString
@@ -8685,6 +8691,11 @@ export interface operations {
   };
   /** Get Filter Options For Search */
   get_filter_options_for_search_api_v1_score_sets_search_filter_options_post: {
+    parameters: {
+      header?: {
+        "x-active-roles"?: string | null;
+      };
+    };
     requestBody: {
       content: {
         "application/json": components["schemas"]["ScoreSetsSearch"];
@@ -8983,7 +8994,7 @@ export interface operations {
    *     The index to start from. If None, starts from the beginning.
    * limit : Optional[int]
    *     The maximum number of variants to return. If None, returns all variants.
-   * namespaces: List[Literal["scores", "counts", "vep", "gnomad"]]
+   * namespaces: List[Literal["scores", "counts", "vep", "gnomad", "clingen"]]
    *     The namespaces of all columns except for accession, hgvs_nt, hgvs_pro, and hgvs_splice.
    *     We may add ClinVar in the future.
    * drop_na_columns : bool, optional
@@ -9005,8 +9016,8 @@ export interface operations {
         start?: number;
         /** @description Maximum number of variants to return */
         limit?: number;
-        /** @description One or more data types to include: scores, counts, clinVar, gnomAD, VEP */
-        namespaces?: ("scores" | "counts" | "vep" | "gnomad")[];
+        /** @description One or more data types to include: scores, counts, ClinGen, gnomAD, VEP */
+        namespaces?: ("scores" | "counts" | "vep" | "gnomad" | "clingen")[];
         drop_na_columns?: boolean | null;
         include_custom_columns?: boolean | null;
         include_post_mapped_hgvs?: boolean | null;
@@ -9068,6 +9079,7 @@ export interface operations {
         urn: string;
       };
     };
+    /** @description Score files, to be uploaded as multipart form data. The `scores_file` is required, while the `counts_file`, `score_columns_metadata`, and `count_columns_metadata` are optional. */
     requestBody?: {
       content: {
         "multipart/form-data": components["schemas"]["Body_upload_score_set_variant_data_api_v1_score_sets__urn__variants_data_post"];
@@ -9604,6 +9616,7 @@ export interface operations {
         urn: string;
       };
     };
+    /** @description Score set properties and score files, to be uploaded as multipart form data. All fields here are optional, and only those provided will be updated. */
     requestBody?: {
       content: {
         "multipart/form-data": components["schemas"]["Body_update_score_set_with_variants_api_v1_score_sets_with_variants__urn__patch"];


### PR DESCRIPTION
This pull request improves how gene information is displayed in the `AssayFactSheet.vue` component. The main focus is to show a clearer and more accurate gene label, handling cases where multiple genes are present or a gene is not specified. This display will now also pull first from the `mappedHgncName` property, which is based on a more robust HGNC selection strategy as described in https://github.com/VariantEffect/dcd_mapping2/pull/67.

Gene display improvements:

* Added a new computed property, `distinctGenesForTargets`, to extract unique mapped HGNC gene names from `targetGenes`, filtering out empty values.
* Introduced `geneTextForScoreSet`, which uses `distinctGenesForTargets` to determine the gene text: if no mapped gene names are available, it falls back to the original gene name; if there is one unique gene, it displays that; if there are multiple, it displays "Multiple genes".
* Updated the gene display in the template to use `geneTextForScoreSet`, defaulting to "Not specified" if no gene is available.

Related code updates:

* Modified the `geneAndYear` computed property to use `geneTextForScoreSet` for consistency in gene name display.