### PR TITLE
Use stored VEP consequence for protein effect histogram filtering

### DIFF
--- a/src/components/screens/ScoreSetView.vue
+++ b/src/components/screens/ScoreSetView.vue
@@ -660,7 +660,7 @@ export default {
 
           let scoresUrl = null
           if (this.itemType && this.itemType.restCollectionName && this.itemId) {
-            scoresUrl = `${config.apiBaseUrl}/${this.itemType.restCollectionName}/${this.itemId}/variants/data?include_post_mapped_hgvs=true`
+            scoresUrl = `${config.apiBaseUrl}/${this.itemType.restCollectionName}/${this.itemId}/variants/data?include_post_mapped_hgvs=true&namespaces=vep&namespaces=scores`
           }
           this.setScoresDataUrl(scoresUrl)
           this.ensureScoresDataLoaded()

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -39,6 +39,9 @@ export interface RawVariant {
     post_mapped_hgvs_p?: string
     post_mapped_vrs_digest?: string
   }
+  vep?: {
+    vep_functional_consequence?: string
+  }
 
   control?: ClinicalControlVariant
   mavedb_label?: string
@@ -395,6 +398,13 @@ function translateSimpleCodingHgvsCVariant(
  * @returns true if the variant is classified as start-loss or stop-loss; false (or undefined) otherwise.
  */
 export function isStartOrStopLoss(variant: any) {
+  if (variant.vep && variant.vep.vep_functional_consequence && variant.vep.vep_functional_consequence != 'NA') {
+    if (variant.vep.vep_functional_consequence == 'start_lost' || variant.vep.vep_functional_consequence == 'stop_lost') {
+      return true
+    } else {
+      return false
+    }
+  }
   const parsedVariant = variant.parsedPostMappedHgvsP
   if (!parsedVariant) {
     return false
@@ -416,6 +426,13 @@ export function isStartOrStopLoss(variant: any) {
 }
 
 export function variantIsMissense(variant: Variant) {
+  if (variant.vep && variant.vep.vep_functional_consequence && variant.vep.vep_functional_consequence != 'NA') {
+    if (variant.vep.vep_functional_consequence == 'missense_variant') {
+      return true
+    } else {
+      return false
+    }
+  }
   const parsedVariant = variant.parsedPostMappedHgvsP
   if (!parsedVariant) {
     return false
@@ -429,6 +446,13 @@ export function variantIsMissense(variant: Variant) {
 }
 
 export function variantIsSynonymous(variant: Variant) {
+  if (variant.vep && variant.vep.vep_functional_consequence && variant.vep.vep_functional_consequence != 'NA') {
+    if (variant.vep.vep_functional_consequence == 'synonymous_variant') {
+      return true
+    } else {
+      return false
+    }
+  }
   const parsedVariant = variant.parsedPostMappedHgvsP
   if (!parsedVariant) {
     return false
@@ -440,6 +464,13 @@ export function variantIsSynonymous(variant: Variant) {
 }
 
 export function variantIsNonsense(variant: Variant) {
+  if (variant.vep && variant.vep.vep_functional_consequence && variant.vep.vep_functional_consequence != 'NA') {
+    if (variant.vep.vep_functional_consequence == 'stop_gained') {
+      return true
+    } else {
+      return false
+    }
+  }
   const parsedVariant = variant.parsedPostMappedHgvsP
   if (!parsedVariant) {
     return false
@@ -471,6 +502,7 @@ export function variantIsOther(variant: Variant) {
 export function allCodingVariantsHaveProteinConsequence(variants: Variant[]) {
   return variants.every(
     (v) =>
+      (v.vep && v.vep.vep_functional_consequence && v.vep.vep_functional_consequence != 'NA') ||
       v.parsedPostMappedHgvsP != null ||
       (v.parsedPostMappedHgvsC?.referenceType == 'c' && v.parsedPostMappedHgvsC?.position == null)
   )


### PR DESCRIPTION
Note that this change still includes the ability to translate coding variants and calculate protein effect in the absence of HGVS p. strings and/or VEP consequence information. The intention is to eventually get rid of that fallback code once HGVS and VEP information has been fully generated for everything in the database and automated.
When testing, note that every coding variant in the score set must have either VEP information or an HGVS p. string available in order to show the protein effect options. Currently, the VEP script/job fails to fill out the functional consequence for no-change nucleotide variants. Incoming changes in the api will handle this, but for now you can manually add "no change" to your local database for these variants to view protein effect histograms for more score sets (e.g. urn:mavedb:00000013-a-1 requires one variant's VEP to be manually filled out to "no change" to work).