### PR TITLE
chore: remove home link from toolbar

### DIFF
--- a/src/components/layout/Toolbar.vue
+++ b/src/components/layout/Toolbar.vue
@@ -18,25 +18,23 @@
           <img v-if="config.PREVIEW_SITE" alt="MaveDB Beta Site" src="@/assets/logo-mavedb-beta.png" />
           <img v-else alt="MaveDB" src="@/assets/logo-mavedb.png" />
         </router-link>
-        <div style="display: inline-block; margin-left: 40px">
-          <div class="p-inputgroup" style="max-width: 300px; width: 300px; display: flex; align-items: stretch">
-            <InputText
-              ref="searchTextInput"
-              v-model="searchText"
-              class="rounded-r-none! w-full"
-              placeholder="Search"
-              size="small"
-              type="search"
-              @keyup.enter="search"
-            />
-            <Button
-              class="rounded-l-none!"
-              :enabled="searchText && searchText.length > 0"
-              icon="pi pi-search"
-              size="small"
-              @click="search"
-            />
-          </div>
+        <div class="flex w-[300px] ml-10">
+          <InputText
+            ref="searchTextInput"
+            v-model="searchText"
+            class="rounded-r-none! w-full"
+            placeholder="Search"
+            size="small"
+            type="search"
+            @keyup.enter="search"
+          />
+          <Button
+            class="rounded-l-none!"
+            :enabled="searchText && searchText.length > 0"
+            icon="pi pi-search"
+            size="small"
+            @click="search"
+          />
         </div>
       </template>
       <template #item="{item, props, hasSubmenu}">


### PR DESCRIPTION
This pull request removes the "Home" navigation button from the `Toolbar.vue` component. Some minor automatic styling changes are also included.

**Navigation updates:**
 - Removed the "Home" button from the toolbar navigation menu.