### PR TITLE
feat: migrate class variants to lazy endpoints and update class-view handling

### DIFF
--- a/src/components/CalibrationTable.vue
+++ b/src/components/CalibrationTable.vue
@@ -144,9 +144,7 @@
                 }
               ]"
             >
-              <span>
-                {{ range.variants ? range.variants.length : 0 }}
-              </span>
+              <span> {{ range.variantCount ?? 0 }} variants </span>
             </div>
           </template>
 

--- a/src/lib/calibrations.ts
+++ b/src/lib/calibrations.ts
@@ -1,5 +1,11 @@
+import axios from 'axios'
+
+import config from '@/config'
 import {HistogramBin, HistogramShader} from '@/lib/histogram'
 import {components} from '@/schema/openapi'
+
+export type FunctionalClassificationVariants = components['schemas']['FunctionalClassificationVariants']
+export type FunctionalClassificationVariant = components['schemas']['VariantEffectMeasurement']
 
 export const NORMAL_RANGE_DEFAULT_COLOR = '#4444ff'
 export const ABNORMAL_RANGE_DEFAULT_COLOR = '#ff4444'
@@ -214,4 +220,42 @@ export function functionalClassificationContainsVariant(
     max === null ? true : functionalClassification.inclusiveUpperBound ? variantScore <= max : variantScore < max
 
   return lowerOk && upperOk
+}
+
+/**
+ * Fetches the full list of variants for a single functional classification in a score calibration.
+ *
+ * Uses the dedicated calibration variants endpoint introduced to replace embedded
+ * `variants` payloads in calibration responses.
+ *
+ * @param calibrationUrn The score calibration URN.
+ * @param classificationId The database ID of the functional classification.
+ * @returns The classification ID and associated variant list.
+ */
+export async function fetchScoreCalibrationFunctionalClassificationVariants(
+  calibrationUrn: string,
+  classificationId: number
+): Promise<FunctionalClassificationVariants> {
+  const response = await axios.get(
+    `${config.apiBaseUrl}/score-calibrations/${encodeURIComponent(calibrationUrn)}/functional-classifications/${classificationId}/variants`
+  )
+  return response.data
+}
+
+/**
+ * Fetches variant lists for all functional classifications in a score calibration.
+ *
+ * This is intended for views that need class membership across the full calibration
+ * (for example, class-based histogram series generation).
+ *
+ * @param calibrationUrn The score calibration URN.
+ * @returns An array of per-classification variant payloads.
+ */
+export async function fetchScoreCalibrationVariants(
+  calibrationUrn: string
+): Promise<FunctionalClassificationVariants[]> {
+  const response = await axios.get(
+    `${config.apiBaseUrl}/score-calibrations/${encodeURIComponent(calibrationUrn)}/variants`
+  )
+  return response.data
 }

--- a/src/lib/histogram.ts
+++ b/src/lib/histogram.ts
@@ -3,7 +3,6 @@ import $ from 'jquery'
 import _ from 'lodash'
 import {v4 as uuidv4} from 'uuid'
 import {HeatmapDatum} from './heatmap'
-import { style } from 'd3'
 
 type FieldGetter<T> = ((d: HistogramDatum) => T) | string
 type Getter<T> = () => T
@@ -12,18 +11,18 @@ type Accessor<T, Self> = (value?: T) => T | Self
 export const DEFAULT_SHADER_COLOR = '#333333'
 export const DEFAULT_SERIES_COLOR = '#333333'
 export const CATEGORICAL_SERIES_COLORS = [
-  '#1f77b4', // blue
-  '#ff7f0e', // orange
-  '#2ca02c', // green
-  '#d62728', // red
-  '#9467bd', // purple
-  '#8c564b', // brown
-  '#e377c2', // pink
-  '#7f7f7f', // gray
-  '#bcbd22', // olive
-  '#17becf', // cyan
-  '#aec7e8', // light blue
-  '#ffbb78' // light orange
+  '#FFD700', // Gold (yellow)
+  '#32CD32', // Lime (green)
+  '#FF00FF', // Magenta (purple-pink)
+  '#00CED1', // Cyan (blue-green)
+  '#FF8C00', // Orange
+  '#9370DB', // Purple
+  '#7FFF00', // Chartreuse (yellow-green)
+  '#FF6347', // Tomato (orange-red)
+  '#8B00FF', // Violet (deep purple)
+  '#20B2AA', // Teal (darker cyan)
+  '#DA70D6', // Orchid (light purple)
+  '#FFBF00' // Amber (darker yellow)
 ]
 const LABEL_SIZE = 10
 
@@ -616,7 +615,10 @@ export default function makeHistogram(): Histogram {
 
       // Clamp vertically to keep tooltip inside container bounds
       selectionTooltip
-        .style('top', `clamp(${-(_container.clientHeight - bufferPx)}px, ${anchorTop - bufferPx}px, ${-(tooltipHeight + bufferPx)}px)`)
+        .style(
+          'top',
+          `clamp(${-(_container.clientHeight - bufferPx)}px, ${anchorTop - bufferPx}px, ${-(tooltipHeight + bufferPx)}px)`
+        )
         // Prevent the relatively positioned div from affecting layout flow
         .style('margin-bottom', `${-height - topBorderWidth * 2}px`)
 
@@ -661,7 +663,7 @@ export default function makeHistogram(): Histogram {
       return 0
     }
     // Highlight selected and hovered bins.
-    return ((hoverBin && d == hoverBin) || d == selectedBin) ? 1 : 0
+    return (hoverBin && d == hoverBin) || d == selectedBin ? 1 : 0
   }
 
   const hoverStrokeWidth = (d: HistogramBin) => {
@@ -671,7 +673,8 @@ export default function makeHistogram(): Histogram {
 
   const refreshHighlighting = () => {
     if (svg) {
-      svg.selectAll('.histogram-hover-highlight')
+      svg
+        .selectAll('.histogram-hover-highlight')
         .style('opacity', (d) => hoverOpacity(d as HistogramBin))
         .style('stroke-width', (d) => hoverStrokeWidth(d as HistogramBin))
     }

--- a/src/schema/openapi.d.ts
+++ b/src/schema/openapi.d.ts
@@ -596,6 +596,29 @@ export interface paths {
      */
     post: operations["publish_score_calibration_route_api_v1_score_calibrations__urn__publish_post"];
   };
+  "/api/v1/score-calibrations/{urn}/functional-classifications/{classification_id}/variants": {
+    /**
+     * Get Functional Classification Variants
+     * @description Retrieve variants for a specific functional classification within a score calibration.
+     *
+     * Returns the list of variants whose scores fall within the functional classification's
+     * defined range or class. Use this endpoint when you need the full variant data for a
+     * specific classification — the main score set and calibration endpoints return only
+     * a `variant_count` summary for performance.
+     */
+    get: operations["get_functional_classification_variants_api_v1_score_calibrations__urn__functional_classifications__classification_id__variants_get"];
+  };
+  "/api/v1/score-calibrations/{urn}/variants": {
+    /**
+     * Get Calibration All Variants
+     * @description Retrieve all variants across all functional classifications for a score calibration.
+     *
+     * Returns a list of variant sets, one per functional classification. Use this endpoint
+     * when you need the full variant data for an entire calibration — the main score set and
+     * calibration endpoints return only a `variant_count` summary for performance.
+     */
+    get: operations["get_calibration_all_variants_api_v1_score_calibrations__urn__variants_get"];
+  };
   "/api/v1/score-sets/search": {
     /**
      * Search score sets
@@ -3149,6 +3172,19 @@ export interface components {
       positiveLikelihoodRatio?: number | null;
     };
     /**
+     * FunctionalClassificationVariants
+     * @description Response model for functional classification variant endpoints.
+     */
+    FunctionalClassificationVariants: {
+      /** Functionalclassificationid */
+      functionalClassificationId: number;
+      /**
+       * Variants
+       * @default []
+       */
+      variants?: components["schemas"]["VariantEffectMeasurement"][];
+    };
+    /**
      * GnomADVariantWithMappedVariants
      * @description GnomAD variant view model with mapped variants for non-admin clients.
      */
@@ -3940,13 +3976,15 @@ export interface components {
       oddspathsRatio?: number | null;
       /** Positivelikelihoodratio */
       positiveLikelihoodRatio?: number | null;
+      /** Id */
+      id: number;
       /** Recordtype */
       recordType?: string;
       /**
-       * Variants
-       * @default []
+       * Variantcount
+       * @default 0
        */
-      variants?: components["schemas"]["SavedVariantEffectMeasurement"][];
+      variantCount?: number;
     };
     /** SavedPublicationIdentifier */
     SavedPublicationIdentifier: {
@@ -4045,38 +4083,6 @@ export interface components {
       firstName?: string | null;
       /** Lastname */
       lastName?: string | null;
-      /** Recordtype */
-      recordType?: string;
-    };
-    /**
-     * SavedVariantEffectMeasurement
-     * @description Base class for variant effect measurement view models handling saved variant effect measurements
-     */
-    SavedVariantEffectMeasurement: {
-      /** Urn */
-      urn?: string | null;
-      /** Data */
-      data: unknown;
-      /** Scoresetid */
-      scoreSetId: number;
-      /** Hgvsnt */
-      hgvsNt?: string | null;
-      /** Hgvspro */
-      hgvsPro?: string | null;
-      /** Hgvssplice */
-      hgvsSplice?: string | null;
-      /**
-       * Creationdate
-       * Format: date
-       */
-      creationDate: string;
-      /**
-       * Modificationdate
-       * Format: date
-       */
-      modificationDate: string;
-      /** Id */
-      id: number;
       /** Recordtype */
       recordType?: string;
     };
@@ -5763,13 +5769,15 @@ export interface components {
       oddspathsRatio?: number | null;
       /** Positivelikelihoodratio */
       positiveLikelihoodRatio?: number | null;
+      /** Id */
+      id: number;
       /** Recordtype */
       recordType?: string;
       /**
-       * Variants
-       * @default []
+       * Variantcount
+       * @default 0
        */
-      variants?: components["schemas"]["VariantEffectMeasurement"][];
+      variantCount?: number;
     };
     /**
      * sequenceString
@@ -8629,6 +8637,80 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["ScoreCalibrationWithScoreSetUrn"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: never;
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Get Functional Classification Variants
+   * @description Retrieve variants for a specific functional classification within a score calibration.
+   *
+   * Returns the list of variants whose scores fall within the functional classification's
+   * defined range or class. Use this endpoint when you need the full variant data for a
+   * specific classification — the main score set and calibration endpoints return only
+   * a `variant_count` summary for performance.
+   */
+  get_functional_classification_variants_api_v1_score_calibrations__urn__functional_classifications__classification_id__variants_get: {
+    parameters: {
+      header?: {
+        "x-active-roles"?: string | null;
+      };
+      path: {
+        urn: string;
+        classification_id: number;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["FunctionalClassificationVariants"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: never;
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Get Calibration All Variants
+   * @description Retrieve all variants across all functional classifications for a score calibration.
+   *
+   * Returns a list of variant sets, one per functional classification. Use this endpoint
+   * when you need the full variant data for an entire calibration — the main score set and
+   * calibration endpoints return only a `variant_count` summary for performance.
+   */
+  get_calibration_all_variants_api_v1_score_calibrations__urn__variants_get: {
+    parameters: {
+      header?: {
+        "x-active-roles"?: string | null;
+      };
+      path: {
+        urn: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["FunctionalClassificationVariants"][];
         };
       };
       /** @description Not Found */


### PR DESCRIPTION
- consume new calibration variant endpoints via API helpers
- switch functional classification usage to id/variantCount model
- replace embedded variant counts in calibration table with variantCount
- lazily load class-based calibration variants in histogram view with loading state and cache
- fix class-view empty state by gating series on loaded class map and triggering refresh on load
- add TODO#622 note for future large-dataset performance optimizations