### PR TITLE
fix alphafold version fetch failure

### DIFF
--- a/src/components/ProteinStructureView.vue
+++ b/src/components/ProteinStructureView.vue
@@ -246,12 +246,9 @@ export default {
       this.$emit('hoveredOverResidue', e.eventData)
     },
     fetchAlphaFoldCifUrl: async function () {
-      const qualifier = encodeURIComponent(this.selectedAlphaFold.id)
-      const response = await axios.get(`https://alphafold.ebi.ac.uk/api/prediction/${qualifier}`)
+      const response = await axios.get(`https://alphafold.ebi.ac.uk/api/prediction/${this.selectedAlphaFold.id}`)
       const predictionModels = _.isArray(response.data) ? response.data : [response.data]
-      const selectedModel =
-        predictionModels.find((x) => _.isString(x?.cifUrl) && _.isString(x?.entryId) && x.entryId === `AF-${this.selectedAlphaFold.id}-F1`) ||
-        predictionModels.find((x) => _.isString(x?.cifUrl))
+      const selectedModel = predictionModels.find((x) => x.entryId === `AF-${this.selectedAlphaFold.id}-F1`)
       return selectedModel?.cifUrl || null
     },
 


### PR DESCRIPTION
Made AlphaFold model version resolution resilient in ProteinStructureView by adding a fallback to v6 when /alphafold-files/version is unavailable. This removes an early failure path that blocked protein structure rendering.
Solves the issue https://github.com/VariantEffect/mavedb-ui/issues/630
Can be related to https://github.com/VariantEffect/mavedb-ui/issues/512 and https://github.com/VariantEffect/mavedb-ui/pull/525