### PR TITLE
feat(ScoreSetHistogram): add note clarifying clinical controls vs calibration controls

### DIFF
--- a/docs/content/finding-data/visualizations.md
+++ b/docs/content/finding-data/visualizations.md
@@ -26,6 +26,9 @@ The default view shows the overall score distribution for all variants in the sc
 
 Available when a score set has been linked to [ClinVar annotations](external-integrations.md#clinvar). This view overlays the distribution of scores for variants classified as `Pathogenic` or `Likely pathogenic` and `Benign` or `Likely benign` in ClinVar, allowing users to assess how well the assay segregates known clinical variants. The ClinVar version used is always shown in the histogram legend.
 
+!!! info "Clinical controls are not calibration controls"
+    The clinical controls displayed in the histogram are ClinVar entries linked to mapped variants in the score set. They are **not** necessarily the same controls used to derive a [score calibration](../reference/score-calibrations.md). A calibration may use a different set of reference variants, classification criteria, or ClinVar version than what is shown in the histogram. Treat the clinical view as an independent overlay of ClinVar annotations, not as a representation of a calibration's input data.
+
 <figure markdown="span">
   ![Clinical view of the histogram visualization from a MaveDB score set page](../images/bard1_clinical_histogram.png)
   <figcaption>Clinical view of the histogram from <a href="https://mavedb.org/score-sets/urn:mavedb:00001250-a-1">urn:mavedb:00001250-a-1</a>, showing ClinVar pathogenic and benign variant distributions.</figcaption>

--- a/src/components/score-set/ScoreSetHistogram.vue
+++ b/src/components/score-set/ScoreSetHistogram.vue
@@ -145,6 +145,14 @@
     Loading calibration class variants.
   </div>
   <div ref="histogramContainer" class="mavedb-histogram-container" />
+  <span
+    v-if="vizOptions[activeViz]?.clinicalControlLegendNoteEnabled && refreshedClinicalControls"
+    class="mt-1 block text-center text-xs italic leading-tight"
+  >
+    Note: The ClinVar annotations shown above are matched to variants in this score set and may not correspond to the
+    control variants used to derive the displayed calibration. For details on which variants were used, refer to the
+    sources associated with each calibration.
+  </span>
   <span v-if="selectedCalibrationIsClassBased" class="mavedb-class-based-calibration-note">
     *Class-based calibrations may not be visualized as thresholds. To view the distribution of variants within each
     class, select the
@@ -1570,7 +1578,6 @@ export default defineComponent({
   gap: 0.5rem 1rem;
   align-items: center;
 }
-
 </style>
 
 <style>


### PR DESCRIPTION
This pull request improves the clarity of how clinical controls (ClinVar annotations) are presented in the score set histogram visualization, ensuring users understand the distinction between clinical controls and calibration controls. The changes add both user-facing documentation and interface notes to prevent confusion.

Enhancements to user guidance and documentation:

* Added an info box to the documentation (`visualizations.md`) clarifying that clinical controls shown in the histogram are ClinVar entries mapped to the score set, and may differ from the controls used for score calibration. The note emphasizes that the clinical overlay is independent of calibration input data.

User interface improvements:

* Added a conditional note to the `ScoreSetHistogram.vue` component, displayed when appropriate, informing users that ClinVar annotations in the histogram may not correspond to the calibration control variants, and directing them to calibration sources for details.