### PR TITLE
feat(ScoreSet): add Clingen allele link to variant details in heatmap and histogram

### DIFF
--- a/src/components/score-set/ScoreSetHeatmap.vue
+++ b/src/components/score-set/ScoreSetHeatmap.vue
@@ -1132,6 +1132,11 @@ export default defineComponent({
         parts.push(`Score stdev: ${v.scoreStdev}`)
       }
 
+      const clingenAlleleId = v.instance?.clingen?.clingen_allele_id
+      if (clingenAlleleId) {
+        parts.push(`<a href="/variants/${clingenAlleleId}" target="_blank" class="text-link">View variant details</a>`)
+      }
+
       return parts.length > 0 ? parts.join('<br />') : null
     },
 

--- a/src/components/score-set/ScoreSetHistogram.vue
+++ b/src/components/score-set/ScoreSetHistogram.vue
@@ -852,6 +852,13 @@ export default defineComponent({
             parts.push(clinVarLinkOut)
           }
 
+          const clingenAlleleId = variant.clingen?.clingen_allele_id
+          if (clingenAlleleId) {
+            parts.push(
+              `<a href="/variants/${clingenAlleleId}" target="_blank" class="text-link">View variant details</a>`
+            )
+          }
+
           // Line 3: Score and classification
           if (variant.scores.score) {
             let binClassificationLabel = null
@@ -1570,7 +1577,6 @@ export default defineComponent({
   gap: 0.5rem 1rem;
   align-items: center;
 }
-
 </style>
 
 <style>

--- a/src/components/screens/ScoreSetView.vue
+++ b/src/components/screens/ScoreSetView.vue
@@ -678,7 +678,7 @@ export default {
           this.setItemId(newValue)
           let scoresUrl = null
           if (this.itemType?.restCollectionName && this.itemId) {
-            scoresUrl = `${config.apiBaseUrl}/${this.itemType.restCollectionName}/${this.itemId}/variants/data?include_post_mapped_hgvs=true&namespaces=vep&namespaces=scores`
+            scoresUrl = `${config.apiBaseUrl}/${this.itemType.restCollectionName}/${this.itemId}/variants/data?include_post_mapped_hgvs=true&namespaces=vep&namespaces=scores&namespaces=clingen`
           }
           this.setScoresDataUrl(scoresUrl)
           this.ensureScoresDataLoaded()

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -42,6 +42,9 @@ export interface RawVariant {
   vep?: {
     vep_functional_consequence?: string
   }
+  clingen?: {
+    clingen_allele_id?: string
+  }
 
   control?: ClinicalControlVariant
   mavedb_label?: string
@@ -399,7 +402,10 @@ function translateSimpleCodingHgvsCVariant(
  */
 export function isStartOrStopLoss(variant: any) {
   if (variant.vep && variant.vep.vep_functional_consequence && variant.vep.vep_functional_consequence != 'NA') {
-    if (variant.vep.vep_functional_consequence == 'start_lost' || variant.vep.vep_functional_consequence == 'stop_lost') {
+    if (
+      variant.vep.vep_functional_consequence == 'start_lost' ||
+      variant.vep.vep_functional_consequence == 'stop_lost'
+    ) {
       return true
     } else {
       return false


### PR DESCRIPTION
This pull request strengthens our linkage of score set and variant pages, adding a link to variant detail pages directly from score set variant tooltips. Previously, users had to search with the HGVS string to reach variant pages.

**ClinGen allele support and UI enhancements:**

* Added a `clingen` object with an optional `clingen_allele_id` field to the `RawVariant` interface in `src/lib/variants.ts`, enabling storage of ClinGen allele IDs.
* Updated the API request in `ScoreSetView.vue` to include the `clingen` namespace, ensuring ClinGen data is fetched for each variant.

**User interface improvements:**

* In both `ScoreSetHeatmap.vue` and `ScoreSetHistogram.vue`, added a "View variant details" link for variants with a ClinGen allele ID, allowing users to quickly access detailed variant pages. [[1]](diffhunk://#diff-fa7ebed80f24ff35af164889721bc9bb0184aaf83581b1a0f3634dd4b0dd8eb1R1135-R1139) [[2]](diffhunk://#diff-0c3434979eb02cc2f825a0a53fcd65301a4262bb886137829345a2dd22665e61R855-R861)