### PR TITLE
Enhance ScoreSetHistogram tooltip and relationship handling

### DIFF
--- a/src/components/score-set/ScoreSetHistogram.vue
+++ b/src/components/score-set/ScoreSetHistogram.vue
@@ -873,8 +873,8 @@ export default defineComponent({
                 if (variantsByClassificationId) {
                   matchedClassification =
                     classifications.find((fc) =>
-                    variantsByClassificationId[fc.id]?.some((v) => v.urn === variant.accession)
-                  ) ?? null
+                      variantsByClassificationId[fc.id]?.some((v) => v.urn === variant.accession)
+                    ) ?? null
                 }
               }
 
@@ -1247,7 +1247,7 @@ export default defineComponent({
       this.$emit('selection-changed', payload)
     },
     conditionallyLoadCalibrationClassVariants: async function () {
-      if (!this.isCalibrationClassViewActive || !this.selectedCalibrationIsClassBased) {
+      if (!this.selectedCalibrationIsClassBased) {
         return
       }
 

--- a/src/components/score-set/ScoreSetHistogram.vue
+++ b/src/components/score-set/ScoreSetHistogram.vue
@@ -208,7 +208,8 @@ import {getScoreCalibrationVariants} from '@/api/mavedb'
 import {
   prepareCalibrationsForHistogram,
   shaderOverlapsBin,
-  functionalClassificationContainsVariant
+  functionalClassificationContainsVariant,
+  getClassificationColor
 } from '@/lib/calibrations'
 import type {FunctionalClassificationVariant} from '@/lib/calibrations'
 import {variantNotNullOrNA} from '@/lib/mave-hgvs'
@@ -862,14 +863,24 @@ export default defineComponent({
             if (this.activeCalibration.value?.urn && this.activeCalibration.value?.functionalClassifications) {
               // TODO#491: Refactor this calculation into the creation of variant objects so we may just access the property of the variant which tells us its classification.
               const classifications = this.activeCalibration.value.functionalClassifications
-              const shaders = this.histogramShaders[this.activeCalibration.value.urn]
-              const matchIndex = classifications.findIndex((fc) =>
-                functionalClassificationContainsVariant(fc, variant.scores.score)
-              )
-              const matchingShader = matchIndex >= 0 && shaders ? shaders[matchIndex] : null
 
-              if (matchingShader) {
-                binClassificationLabel = `<span class="mavedb-range-classification-badge" style="margin-left: 6px; background-color:${matchingShader.color}; color:white;">${matchingShader.title}</span>`
+              // Try range-based match first, then fall back to class-based membership lookup.
+              let matchedClassification =
+                classifications.find((fc) => functionalClassificationContainsVariant(fc, variant.scores.score)) ?? null
+
+              if (!matchedClassification && this.selectedCalibrationIsClassBased) {
+                const variantsByClassificationId = this.calibrationClassVariantsByUrn[this.activeCalibration.value.urn]
+                if (variantsByClassificationId) {
+                  matchedClassification =
+                    classifications.find((fc) =>
+                    variantsByClassificationId[fc.id]?.some((v) => v.urn === variant.accession)
+                  ) ?? null
+                }
+              }
+
+              if (matchedClassification) {
+                const color = getClassificationColor(matchedClassification)
+                binClassificationLabel = `<span class="mavedb-range-classification-badge" style="margin-left: 6px; background-color:${color}; color:white;">${matchedClassification.label}</span>`
               }
             }
 

--- a/src/components/score-set/ScoreSetHistogram.vue
+++ b/src/components/score-set/ScoreSetHistogram.vue
@@ -205,7 +205,11 @@ import makeHistogram, {
   CATEGORICAL_SERIES_COLORS
 } from '@/lib/histogram'
 import {getScoreCalibrationVariants} from '@/api/mavedb'
-import {prepareCalibrationsForHistogram, shaderOverlapsBin} from '@/lib/calibrations'
+import {
+  prepareCalibrationsForHistogram,
+  shaderOverlapsBin,
+  functionalClassificationContainsVariant
+} from '@/lib/calibrations'
 import type {FunctionalClassificationVariant} from '@/lib/calibrations'
 import {variantNotNullOrNA} from '@/lib/mave-hgvs'
 import {
@@ -848,21 +852,24 @@ export default defineComponent({
             parts.push(variantDescriptionParts.join(' '))
           }
           if (variantHasClinicalSignificance && variantHasReviewStatus) {
-            const clinVarLinkOut = `<a href="http://www.ncbi.nlm.nih.gov/clinvar/?term=${variant.control.dbIdentifier}[alleleid]" target="_blank">View in ClinVar</a>`
+            const clinVarLinkOut = `<a href="http://www.ncbi.nlm.nih.gov/clinvar/?term=${variant.control.dbIdentifier}[alleleid]" target="_blank" class="text-link">View in ClinVar</a>`
             parts.push(clinVarLinkOut)
           }
 
           // Line 3: Score and classification
-          if (variant.scores.score) {
+          if (variant.scores.score && variant.scores.score != 'NA') {
             let binClassificationLabel = null
-            if (bin && this.activeCalibration.value?.urn) {
+            if (this.activeCalibration.value?.urn && this.activeCalibration.value?.functionalClassifications) {
               // TODO#491: Refactor this calculation into the creation of variant objects so we may just access the property of the variant which tells us its classification.
-              const binClassification = this.histogramShaders[this.activeCalibration.value.urn]?.find(
-                (calibration: HistogramShader) => shaderOverlapsBin(calibration, bin)
+              const classifications = this.activeCalibration.value.functionalClassifications
+              const shaders = this.histogramShaders[this.activeCalibration.value.urn]
+              const matchIndex = classifications.findIndex((fc) =>
+                functionalClassificationContainsVariant(fc, variant.scores.score)
               )
+              const matchingShader = matchIndex >= 0 && shaders ? shaders[matchIndex] : null
 
-              if (binClassification) {
-                binClassificationLabel = `<span class="mavedb-range-classification-badge" style="margin-left: 6px; background-color:${binClassification.color}; color:white;">${binClassification.title}</span>`
+              if (matchingShader) {
+                binClassificationLabel = `<span class="mavedb-range-classification-badge" style="margin-left: 6px; background-color:${matchingShader.color}; color:white;">${matchingShader.title}</span>`
               }
             }
 
@@ -1570,7 +1577,6 @@ export default defineComponent({
   gap: 0.5rem 1rem;
   align-items: center;
 }
-
 </style>
 
 <style>

--- a/src/lib/calibrations.ts
+++ b/src/lib/calibrations.ts
@@ -98,8 +98,8 @@ export function prepareCalibrationsForHistogram(
       max: classification.range[1],
       title: classification.label,
       align: 'center',
-      color: getRangeColor(classification),
-      thresholdColor: getRangeColor(classification),
+      color: getClassificationColor(classification),
+      thresholdColor: getClassificationColor(classification),
       startOpacity: 0.15,
       stopOpacity: 0.05,
       gradientUUID: undefined
@@ -129,7 +129,7 @@ export function prepareCalibrationsForHistogram(
  * const color = getRangeColor({ classification: 'normal' }); // e.g. '#3BAA5C'
  * @remarks If new classifications are introduced, extend this function to handle them explicitly.
  */
-function getRangeColor(
+export function getClassificationColor(
   range: components['schemas']['mavedb__view_models__score_calibration__FunctionalClassification']
 ): string {
   if (range.functionalClassification === 'normal') {


### PR DESCRIPTION
This pull request fixes a bug in how score range labels were displayed in tooltips within the `ScoreSetHistogram.vue` component in addition to expanding this logic for class based calibrations, along with related code cleanup and enhancements.

**Variant classification badge rendering:**

* Fixed a bug that was causing the incorrect functional class label to be shown for variants which were within a histogram bin that was not fully contained within a functional classification range.
* Improved the logic for displaying classification badges in variant tooltips by matching variants to classifications using both range-based and class-based lookups, and applying the correct color via `getClassificationColor` (`src/components/score-set/ScoreSetHistogram.vue`).

**UI and UX improvements:**

* Added a `text-link` class to the ClinVar link for better styling and ensured the score is not `'NA'` before rendering.
* Adjusted the condition in `conditionallyLoadCalibrationClassVariants` to only check for class-based calibrations, simplifying the logic.