### PR TITLE
Add AlphaFold citations to docs and ProteinStructureView component

### DIFF
--- a/docs/content/finding-data/visualizations.md
+++ b/docs/content/finding-data/visualizations.md
@@ -87,6 +87,12 @@ The viewer displays a side-by-side heatmap and 3D structure sourced from the [Al
   <figcaption>Protein structure viewer from <a href="https://mavedb.org/score-sets/urn:mavedb:00000050-a-1">urn:mavedb:00000050-a-1</a>, showing mean variant effect scores mapped onto the MSH2 3D structure.</figcaption>
 </figure>
 
+References:
+<ul class="list-disc text-xs italic text-gray-400 ml-5 px-2 py-1">
+  <li>Jumper, J et al. Highly accurate protein structure prediction with AlphaFold. <em>Nature</em> (2021)</li>
+  <li>Fleming J. et al. AlphaFold Protein Structure Database and 3D-Beacons: New Data and Capabilities. <em>Journal of Molecular Biology</em> (2025)</li>
+</ul>
+
 ## See also
 
 - [Score calibrations](../reference/score-calibrations.md) -- learn how calibration data drives classification overlays in histograms and heatmaps.

--- a/src/components/score-set/ProteinStructureView.vue
+++ b/src/components/score-set/ProteinStructureView.vue
@@ -10,6 +10,10 @@
     </div>
     <div v-show="selectedAlphaFold" id="pdbe-molstar-viewer-container" class="flex-1 relative z-5000"></div>
     <div v-if="!selectedAlphaFold" class="m-auto">No AlphaFold entry found</div>
+    <ul class="list-disc text-xs italic text-gray-400 ml-5 px-2 py-1">
+      <li>Jumper, J et al. Highly accurate protein structure prediction with AlphaFold. <em>Nature</em> (2021)</li>
+      <li>Fleming J. et al. AlphaFold Protein Structure Database and 3D-Beacons: New Data and Capabilities. <em>Journal of Molecular Biology</em> (2025)</li>
+    </ul>
   </div>
 </template>
 


### PR DESCRIPTION
This pull request adds reference citations for AlphaFold and related resources to both the documentation and the `ProteinStructureView` component. This helps provide proper attribution and context for users viewing the protein structure visualizations.

Documentation and attribution improvements:

* Added a references section citing key AlphaFold publications to the protein structure viewer documentation (`docs/content/finding-data/visualizations.md`).
* Added the same references as a citation list below the 3D structure viewer in the `ProteinStructureView.vue` component, ensuring users see attribution directly in the UI.