### PR TITLE
feat: Variant Search via VRS Digest

### DIFF
--- a/docs/content/mavemd/variant-search.md
+++ b/docs/content/mavemd/variant-search.md
@@ -12,12 +12,23 @@ You can search for variants using any of the following identifier types:
 | ClinVar Variation ID | `55367` | [ClinVar](https://www.ncbi.nlm.nih.gov/clinvar/) |
 | dbSNP RSID | `rs80357906` | [dbSNP](https://www.ncbi.nlm.nih.gov/snp/) |
 | ClinGen Allele ID (CAID) | `CA024716` | [ClinGen Allele Registry](https://reg.clinicalgenome.org/) |
+| GA4GH VRS identifier | `ga4gh:VA.n9ax-9x6gOC0OEt73VMYqCBfqfxG1XUH` | [GA4GH VRS](https://vrs.ga4gh.org/) |
 
 ## How search works
 
-MaveMD variant search is powered by the [ClinGen Allele Registry](https://reg.clinicalgenome.org/). When MaveDB [maps variants](../reference/variant-mapping.md) to human genomic coordinates, it registers them with the ClinGen Allele Registry and obtains ClinGen Allele IDs (CAIDs). These stable, universal identifiers allow MaveMD to match your search query — regardless of which identifier type you use — to the correct variant across all datasets.
+Most MaveMD searches are powered by the [ClinGen Allele Registry](https://reg.clinicalgenome.org/). When MaveDB [maps variants](../reference/variant-mapping.md) to human genomic coordinates, it registers them with the ClinGen Allele Registry and obtains ClinGen Allele IDs (CAIDs). These stable, universal identifiers allow MaveMD to match your search query — regardless of which identifier type you use — to the correct variant across all datasets.
 
 This means you can search using a ClinVar Variation ID from a clinical report and find the same variant in MAVE datasets that originally used HGVS notation on a different transcript, as long as both resolve to the same genomic variant.
+
+### VRS identifier search
+
+GA4GH VRS identifier search works differently from all other search types. Rather than routing through the ClinGen Allele Registry, it queries MaveDB directly using the [VRS digest](../reference/data-standards.md#vrs--variant-representation) assigned during variant mapping. This makes it useful in workflows where you already have a GA4GH-compatible identifier — for example, from a MaveDB data export, a GA4GH-compliant pipeline, or another VRS-enabled database.
+
+MaveDB assigns VRS identifiers to both the pre-mapped (target-relative) and post-mapped (reference-relative) forms of each variant, and the search matches against either.
+
+Both alleles (`ga4gh:VA.*`) and haplotypes (`ga4gh:VH.*`) are supported.
+
+If the matched variant has a ClinGen Allele ID, the standard results page is displayed. If the variant was mapped but not registered with ClinGen — which can occur for certain variant types — MaveMD will note this and provide a direct link to the source score set instead.
 
 ## Fuzzy search
 

--- a/docs/content/reference/data-standards.md
+++ b/docs/content/reference/data-standards.md
@@ -448,6 +448,8 @@ Each VRS object has a globally unique GA4GH identifier (e.g., `ga4gh:VA.2JOqpLMF
 !!! tip "Why GA4GH identifiers matter"
     HGVS strings that describe the same variant are often not identical — differences in reference sequence versions, notation style, or coordinate systems can produce different strings for the same biological change. This makes cross-referencing variants by HGVS alone unreliable. GA4GH identifiers solve this problem by being computed deterministically from the variant's properties, guaranteeing that the same variant always produces the same identifier regardless of how it was originally described.
 
+    GA4GH identifiers can also be used directly to search MaveMD. Paste a `ga4gh:VA.*` or `ga4gh:VH.*` identifier into the VRS search tab to retrieve matching functional measurements without going through the ClinGen Allele Registry. See [VRS identifier search](../mavemd/variant-search.md#vrs-identifier-search) for details.
+
 ### HGVS expressions
 
 VRS objects include HGVS expressions in the `expressions` array for human readability. MaveDB typically includes both pre-mapped (relative to the target sequence) and post-mapped (relative to a genomic reference) HGVS strings. The `syntax` field indicates the type — `hgvs.p` for protein, `hgvs.g` for genomic, or `hgvs.c` for coding DNA.

--- a/src/api/mavedb/variants.ts
+++ b/src/api/mavedb/variants.ts
@@ -6,6 +6,7 @@ import {components} from '@/schema/openapi'
 type ScoreSet = components['schemas']['ScoreSet']
 type VariantEffectMeasurementWithScoreSet = components['schemas']['VariantEffectMeasurementWithScoreSet']
 type ClingenAlleleIdVariantLookupResponse = components['schemas']['ClingenAlleleIdVariantLookupResponse']
+type MappedVariant = components['schemas']['MappedVariant']
 
 export async function lookupVariantsByClingenId(
   clingenAlleleIds: string[]
@@ -13,6 +14,14 @@ export async function lookupVariantsByClingenId(
   const response = await axios.post(`${config.apiBaseUrl}/variants/clingen-allele-id-lookups`, {
     clingenAlleleIds
   })
+  return response.data
+}
+
+export async function lookupVariantsByVrsDigest(identifier: string): Promise<MappedVariant[]> {
+  const response = await axios.get(
+    `${config.apiBaseUrl}/mapped-variants/vrs/${encodeURIComponent(identifier)}`,
+    {params: {only_current: true}}
+  )
   return response.data
 }
 

--- a/src/assets/app.css
+++ b/src/assets/app.css
@@ -117,6 +117,8 @@
   --color-dbsnp-light: #fdf3d7;
   --color-clinvar: #5aafa0;
   --color-clinvar-light: #c8ece5;
+  --color-ga4gh: #0f6ca4;
+  --color-ga4gh-light: #e3f0f9;
 
   /* ── Measurement Types (variant screen) ────────────────────── */
   --color-nucleotide: var(--color-published);

--- a/src/components/screens/HomeScreen.vue
+++ b/src/components/screens/HomeScreen.vue
@@ -71,7 +71,7 @@
               />
               <button
                 class="cursor-pointer border-none px-4 font-body text-sm font-semibold md:px-5.5"
-                :style="{background: activeSearchColor.accent, color: '#222'}"
+                :style="{background: activeSearchColor.accent, color: activeSearchColor.activeText || '#222'}"
                 type="submit"
               >
                 Search
@@ -82,8 +82,9 @@
             Find a variant with functional data via
             <router-link class="text-link" to="/mavemd?searchType=hgvs">HGVS</router-link>,
             <router-link class="text-link" to="/mavemd?searchType=clinGenAlleleId">ClinGen CAId</router-link>,
-            <router-link class="text-link" to="/mavemd?searchType=clinVarVariationId">ClinVar ID</router-link>, or
-            <router-link class="text-link" to="/mavemd?searchType=dbSnpRsId">dbSNP rsid</router-link>.
+            <router-link class="text-link" to="/mavemd?searchType=clinVarVariationId">ClinVar ID</router-link>,
+            <router-link class="text-link" to="/mavemd?searchType=dbSnpRsId">dbSNP rsid</router-link>, or
+            <router-link class="text-link" to="/mavemd?searchType=vrsDigest">VRS digest</router-link>.
           </p>
         </div>
       </section>
@@ -267,7 +268,7 @@ export default defineComponent({
   },
 
   computed: {
-    activeSearchColor(): {accent: string; bg: string} {
+    activeSearchColor(): {accent: string; bg: string; activeText?: string} {
       return SEARCH_COLORS[this.searchType] || SEARCH_COLORS.hgvs
     },
     activeSearchPlaceholder(): string {

--- a/src/components/screens/SearchVariantsScreen.vue
+++ b/src/components/screens/SearchVariantsScreen.vue
@@ -265,6 +265,13 @@
         <MvLoader text="Finding matching variants..." />
       </div>
 
+      <div v-else-if="alleles.length === 0" class="py-10 text-center">
+        <div class="text-base font-semibold text-gray-600">No variants found</div>
+        <div class="mt-1.5 text-sm text-gray-500">
+          No matching variants were found in MaveDB. Try a different identifier or search type.
+        </div>
+      </div>
+
       <article
         v-for="(allele, alleleIdx) in alleles"
         :key="allele.clingenAlleleId"

--- a/src/components/screens/SearchVariantsScreen.vue
+++ b/src/components/screens/SearchVariantsScreen.vue
@@ -60,8 +60,11 @@
               @keyup.enter="defaultSearch"
             />
             <button
-              class="cursor-pointer whitespace-nowrap border-none px-4 text-sm font-semibold text-dark transition-colors hover:brightness-85 md:px-7"
-              :style="{backgroundColor: currentSearchColor.accent}"
+              class="cursor-pointer whitespace-nowrap border-none px-4 text-sm font-semibold transition-colors hover:brightness-85 md:px-7"
+              :style="{
+                backgroundColor: currentSearchColor.accent,
+                color: currentSearchColor.activeText || 'var(--color-text-dark)'
+              }"
               @click="defaultSearch"
             >
               Search
@@ -274,13 +277,14 @@
 
       <article
         v-for="(allele, alleleIdx) in alleles"
-        :key="allele.clingenAlleleId"
+        :key="allele.clingenAlleleId || allele.variantUrn || alleleIdx"
         :aria-label="'Allele result: ' + allele.canonicalAlleleName"
         class="mb-5 overflow-hidden rounded-lg border border-gray-200 border-l-[3px] border-l-sage-light bg-white"
       >
         <!-- Card header -->
         <div class="border-b border-gray-100 px-5 pt-4 pb-3.5">
           <router-link
+            v-if="allele.clingenAlleleId"
             :aria-label="'View variant detail for ' + allele.canonicalAlleleName"
             class="group flex flex-col gap-2 no-underline sm:flex-row sm:items-start sm:justify-between sm:gap-4"
             :to="{name: 'variant', params: {clingenAlleleId: allele.clingenAlleleId}}"
@@ -310,6 +314,13 @@
               View variant &rarr;
             </span>
           </router-link>
+          <div v-else class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+            <div class="min-w-0">
+              <span class="font-mono text-base font-bold leading-snug text-dark sm:text-lg">
+                {{ allele.canonicalAlleleName }}
+              </span>
+            </div>
+          </div>
 
           <!-- MANE coordinates (collapsible) -->
           <MvCollapsible v-if="allele.maneCoordinates.length > 0" class="mt-3" :open="false" title="MANE transcripts">
@@ -479,7 +490,20 @@
         </div>
 
         <div v-else-if="allele.variantsStatus === 'Loaded'" class="px-5 py-4">
-          <Message> No score sets containing this variant were found in MaveDB. </Message>
+          <!-- VRS Digest based searches may not always resolve to variants with a ClinGen Allele ID -->
+          <template v-if="allele.variantUrn && !allele.clingenAlleleId">
+            <p class="mb-3 text-sm text-gray-600">
+              This variant was found in MaveDB but it is not linked to a ClinGen Allele ID.
+            </p>
+            <router-link
+              v-if="scoreSetUrnFromVariantUrn(allele.variantUrn)"
+              class="text-sm font-semibold text-link hover:underline"
+              :to="{name: 'scoreSet', params: {urn: scoreSetUrnFromVariantUrn(allele.variantUrn)}}"
+            >
+              View score set &rarr;
+            </router-link>
+          </template>
+          <Message v-else> No score sets containing this variant were found in MaveDB. </Message>
         </div>
 
         <div v-else-if="allele.variantsStatus === 'Error'" class="px-5 py-4">
@@ -641,6 +665,8 @@ import {
   clinGenAlleleIdRegex,
   clinVarVariationIdRegex,
   rsIdRegex,
+  vrsDigestRegex,
+  scoreSetUrnFromVariantUrn,
   extractIdFromUrl,
   createAlleleResult
 } from '@/lib/mavemd'
@@ -658,6 +684,7 @@ import {
 } from '@/data/mavemd'
 import {getAlleleByCaId, getAlleleByHgvs, getAlleleByDbSnp, getAlleleByClinVar, getGeneBySymbol} from '@/api/clingen'
 import {getCollection, getErrorResponse, lookupVariantsByClingenId} from '@/api/mavedb'
+import {lookupVariantsByVrsDigest} from '@/api/mavedb/variants'
 import {useEntityCache} from '@/composables/entity-cache'
 import MvLoader from '@/components/common/MvLoader.vue'
 
@@ -687,7 +714,7 @@ export default defineComponent({
     const router = useRouter()
     const toast = useToast()
     const {getEntity} = useEntityCache()
-    return {route, router, toast, getEntity, getScoreSetShortName}
+    return {route, router, toast, getEntity, getScoreSetShortName, scoreSetUrnFromVariantUrn}
   },
 
   data: function () {
@@ -759,7 +786,7 @@ export default defineComponent({
         this.inputAlternateAllele
       )
     },
-    currentSearchColor(): {accent: string; bg: string} {
+    currentSearchColor(): {accent: string; bg: string; activeText?: string} {
       return SEARCH_COLORS[this.searchType || 'hgvs'] || SEARCH_COLORS.hgvs
     },
     currentPlaceholder(): string {
@@ -1039,6 +1066,57 @@ export default defineComponent({
             return
           }
           responseData = await getAlleleByClinVar(searchStr)
+        } else if (searchType === 'vrsDigest') {
+          if (!vrsDigestRegex.test(searchStr)) {
+            this.toast.add({
+              severity: 'error',
+              summary: 'Invalid search',
+              detail: `Please provide a valid VRS digest (e.g. ${this.searchTypeOptions.find((o) => o.code === searchType)?.examples?.join(', ')})`,
+              life: 10000
+            })
+            return
+          }
+          let mappedVariants
+          try {
+            mappedVariants = await lookupVariantsByVrsDigest(searchStr)
+          } catch (error: unknown) {
+            const {status} = getErrorResponse(error)
+            if (status === 404) {
+              this.toast.add({
+                severity: 'warn',
+                summary: 'VRS identifier not found',
+                detail: 'No MaveDB variants match this identifier. Check that the digest is correct and try again.',
+                life: 10000
+              })
+              return
+            }
+            throw error
+          }
+          for (const mappedVariant of mappedVariants) {
+            if (mappedVariant.clingenAlleleId) {
+              const alleleData = await getAlleleByCaId(mappedVariant.clingenAlleleId)
+              this.alleles.push(createAlleleResult(alleleData, maneStatus))
+            } else {
+              this.alleles.push({
+                clingenAlleleUrl: undefined,
+                clingenAlleleId: undefined,
+                variantUrn: mappedVariant.variantUrn,
+                canonicalAlleleName: mappedVariant.variantUrn,
+                maneStatus: null,
+                genomicAlleles: [],
+                grch38Hgvs: null,
+                grch37Hgvs: null,
+                transcriptAlleles: [],
+                maneCoordinates: [],
+                variantsStatus: 'Loaded',
+                variants: {nucleotide: [], protein: [], associatedNucleotide: []}
+              })
+            }
+          }
+          if (this.alleles.length > 0) {
+            ;(this.$refs.searchResults as HTMLElement)?.scrollIntoView({behavior: 'smooth', block: 'start'})
+          }
+          return
         } else {
           if (!hgvsSearchStringRegex.test(searchStr)) {
             this.toast.add({
@@ -1233,7 +1311,11 @@ export default defineComponent({
       const colors = SEARCH_COLORS[code] || SEARCH_COLORS.hgvs
       switch (variant) {
         case 'active':
-          return {borderColor: colors.accent, backgroundColor: colors.accent, color: 'var(--color-text-dark)'}
+          return {
+            borderColor: colors.accent,
+            backgroundColor: colors.accent,
+            color: colors.activeText || 'var(--color-text-dark)'
+          }
         case 'inactive':
           return {borderColor: colors.accent, backgroundColor: 'var(--color-surface)', color: colors.accent}
         default:

--- a/src/data/mavemd.ts
+++ b/src/data/mavemd.ts
@@ -8,7 +8,8 @@ export const SEARCH_TYPE_OPTIONS = [
   {code: 'hgvs', name: 'HGVS', examples: ['ENST00000473961.6:c.-19-2A>T', 'NP_000242.1:p.Asn566Thr']},
   {code: 'clinGenAlleleId', name: 'ClinGen Allele ID', examples: ['CA10590195', 'PA2579983208']},
   {code: 'dbSnpRsId', name: 'dbSNP rsID', examples: ['rs900082291', '900082291']},
-  {code: 'clinVarVariationId', name: 'ClinVar Variation ID', examples: ['869058']}
+  {code: 'clinVarVariationId', name: 'ClinVar Variation ID', examples: ['869058']},
+  {code: 'vrsDigest', name: 'VRS Digest', examples: ['ga4gh:VA.-US8Ap1kUYvW3DzeFEYrNXgk3Xk9toKy']}
 ]
 
 /** Variant type options for guided search. */

--- a/src/data/search.ts
+++ b/src/data/search.ts
@@ -9,19 +9,22 @@ export const SEARCH_TYPES = [
   {value: 'hgvs', label: 'HGVS'},
   {value: 'dbSnpRsId', label: 'dbSNP'},
   {value: 'clinVarVariationId', label: 'ClinVar'},
-  {value: 'clinGenAlleleId', label: 'ClinGen'}
+  {value: 'clinGenAlleleId', label: 'ClinGen'},
+  {value: 'vrsDigest', label: 'VRS'}
 ]
 
-export const SEARCH_COLORS: Record<string, {accent: string; bg: string}> = {
+export const SEARCH_COLORS: Record<string, {accent: string; bg: string; activeText?: string}> = {
   hgvs: {accent: 'var(--color-sage)', bg: 'var(--color-sage-light)'},
   dbSnpRsId: {accent: 'var(--color-dbsnp)', bg: 'var(--color-dbsnp-light)'},
   clinVarVariationId: {accent: 'var(--color-clinvar)', bg: 'var(--color-clinvar-light)'},
-  clinGenAlleleId: {accent: 'var(--color-orange-cta)', bg: 'var(--color-orange-light)'}
+  clinGenAlleleId: {accent: 'var(--color-orange-cta)', bg: 'var(--color-orange-light)'},
+  vrsDigest: {accent: 'var(--color-ga4gh)', bg: 'var(--color-ga4gh-light)', activeText: '#ffffff'}
 }
 
 export const SEARCH_PLACEHOLDERS: Record<string, {full: string; short: string}> = {
   hgvs: {full: 'Search by HGVS, e.g. NM_007294.3:c.211A>G', short: 'Search by HGVS'},
   dbSnpRsId: {full: 'Search by dbSNP rsID, e.g. rs28897672', short: 'Search by dbSNP rsID'},
   clinVarVariationId: {full: 'Search by ClinVar Variation ID, e.g. 37610', short: 'Search by ClinVar ID'},
-  clinGenAlleleId: {full: 'Search by ClinGen Allele ID, e.g. CA003746', short: 'Search by ClinGen Allele ID'}
+  clinGenAlleleId: {full: 'Search by ClinGen Allele ID, e.g. CA003746', short: 'Search by ClinGen Allele ID'},
+  vrsDigest: {full: 'Search by VRS ID, e.g. ga4gh:VA.n9ax-9x6gOC0OEt73VMYqCBfqfxG1XUH', short: 'Search by VRS ID'}
 }

--- a/src/lib/mavemd.ts
+++ b/src/lib/mavemd.ts
@@ -9,6 +9,21 @@ type VariantMeasurement = components['schemas']['VariantEffectMeasurementWithSho
 export const clinGenAlleleIdRegex = /^(CA|PA)[0-9]+$/im
 
 /**
+ * Regular expression for GA4GH VRS identifiers: ga4gh:<type>.<32-char base64url digest>.
+ */
+export const vrsDigestRegex = /^ga4gh:[^.]+\.[0-9A-Za-z_-]{32}$/
+
+/**
+ * Extracts the score set URN from a MaveDB variant URN.
+ * Variant URNs follow the format urn:mavedb:XXXXXXXX-X-N-SUFFIX.
+ * The score set URN is the first three hyphenated segments.
+ */
+export function scoreSetUrnFromVariantUrn(variantUrn: string): string | null {
+  const match = variantUrn.match(/^(urn:mavedb:[^-]+-[^-]+-[^-]+)(?:-.+)?$/)
+  return match?.[1] ?? null
+}
+
+/**
  * Regular expression for valid ClinVar Variation IDs that can be used in ClinGen searches.
  */
 export const clinVarVariationIdRegex = /^[0-9]+$/m
@@ -42,6 +57,8 @@ export interface AlleleResult {
     protein: VariantMeasurement[]
     associatedNucleotide: VariantMeasurement[]
   }
+  /** MaveDB variant URN — present when a VRS digest search resolves to a variant without a ClinGen Allele ID. */
+  variantUrn?: string | null
 }
 
 /** Extract the trailing path segment from a URL (e.g. ClinGen allele ID from its URL). */


### PR DESCRIPTION
This pull request adds support for searching variants in MaveMD using GA4GH VRS identifiers (VRS digests), in addition to existing search types. It updates the UI, search logic, API integration, documentation, and visual styling to fully support and explain VRS-based searches. The most important changes are grouped below.

**VRS Digest Search Functionality:**

- Added support for searching by GA4GH VRS identifiers (`ga4gh:VA.*`, `ga4gh:VH.*`) throughout the app, including a new search option, backend API integration, and handling of results that may not have a ClinGen Allele ID. [[1]](diffhunk://#diff-ba49234bc3e78219a3d3f970f997580cb0858d3bd28ad585d20e3019e6886523R20-R27) [[2]](diffhunk://#diff-f588bed0e1f93a557eeb6be191d51dc5a16cde2a00d249de4bd32ddac158b585R1069-R1119) [[3]](diffhunk://#diff-e1db87265b479c6794570541f556d2be0702237a8882a520307adbbf9991921cL12-R29) [[4]](diffhunk://#diff-4017dcc279dca8f3cc109a0b2a81b5286b0f01f66fea2f8aef11233a8d4dbaa1L11-R12) [[5]](diffhunk://#diff-0ae6267efceb3bad36dc65bebcb0e4ae1d8c60129646742981bc79fb39a3c7d5R11-R25)

- Updated the search results UI to handle and display variants found via VRS digest, including cases where the variant is present in MaveDB but not linked to a ClinGen Allele ID, and providing direct links to the relevant score set when appropriate. [[1]](diffhunk://#diff-f588bed0e1f93a557eeb6be191d51dc5a16cde2a00d249de4bd32ddac158b585R271-R287) [[2]](diffhunk://#diff-f588bed0e1f93a557eeb6be191d51dc5a16cde2a00d249de4bd32ddac158b585R317-R323) [[3]](diffhunk://#diff-f588bed0e1f93a557eeb6be191d51dc5a16cde2a00d249de4bd32ddac158b585L475-R506) [[4]](diffhunk://#diff-f588bed0e1f93a557eeb6be191d51dc5a16cde2a00d249de4bd32ddac158b585L683-R717)

**UI and Styling Updates:**

- Added a new color scheme for VRS digest searches and ensured consistent button and highlight styling for the new search type across components. [[1]](diffhunk://#diff-5a38462f5aa0bc0e0b1c5c1e98dfdecd8fd8b0f8874c96eacb4715e736590ad5R120-R121) [[2]](diffhunk://#diff-e1db87265b479c6794570541f556d2be0702237a8882a520307adbbf9991921cL12-R29) [[3]](diffhunk://#diff-4038d17cf80b83a85e6759f9dfbd50c445cad55b83e21c96f28eaf1d8856fec4L74-R74) [[4]](diffhunk://#diff-4038d17cf80b83a85e6759f9dfbd50c445cad55b83e21c96f28eaf1d8856fec4L270-R271) [[5]](diffhunk://#diff-f588bed0e1f93a557eeb6be191d51dc5a16cde2a00d249de4bd32ddac158b585L63-R67) [[6]](diffhunk://#diff-f588bed0e1f93a557eeb6be191d51dc5a16cde2a00d249de4bd32ddac158b585L755-R789)

- Updated the home screen and search screen to include VRS digest as a visible and selectable search option, with appropriate placeholder text and example identifiers. [[1]](diffhunk://#diff-4038d17cf80b83a85e6759f9dfbd50c445cad55b83e21c96f28eaf1d8856fec4L85-R87) [[2]](diffhunk://#diff-4017dcc279dca8f3cc109a0b2a81b5286b0f01f66fea2f8aef11233a8d4dbaa1L11-R12) [[3]](diffhunk://#diff-e1db87265b479c6794570541f556d2be0702237a8882a520307adbbf9991921cL12-R29)

**Documentation Updates:**

- Expanded documentation to describe VRS digest search, including its workflow, use cases, and how it differs from other identifier searches. Added explanations in both the variant search and data standards documentation. [[1]](diffhunk://#diff-d0052607d6819da22ee9ce2aac8eaea6767b4b68d4934d4a0de0dd7c15098b20R15-R32) [[2]](diffhunk://#diff-43a2c9e5afc1306935bb99e45066ccd96a9652b101a88a426584555168954c3bR451-R452)

**Supporting Utilities and Validation:**

- Added a regular expression for validating VRS digests and a utility function to extract score set URNs from variant URNs, supporting correct linking and validation in the UI and logic. [[1]](diffhunk://#diff-0ae6267efceb3bad36dc65bebcb0e4ae1d8c60129646742981bc79fb39a3c7d5R11-R25) [[2]](diffhunk://#diff-f588bed0e1f93a557eeb6be191d51dc5a16cde2a00d249de4bd32ddac158b585R668-R669)

**API Integration:**

- Added a new API function `lookupVariantsByVrsDigest` to query mapped variants by VRS identifier, and updated type definitions to support the new search results. [[1]](diffhunk://#diff-ba49234bc3e78219a3d3f970f997580cb0858d3bd28ad585d20e3019e6886523R9) [[2]](diffhunk://#diff-ba49234bc3e78219a3d3f970f997580cb0858d3bd28ad585d20e3019e6886523R20-R27) [[3]](diffhunk://#diff-f588bed0e1f93a557eeb6be191d51dc5a16cde2a00d249de4bd32ddac158b585R687)

These changes together enable users to search for variants using GA4GH VRS identifiers, improving interoperability with GA4GH-compliant pipelines and databases.