### PR TITLE
fix(VariantScreen): use mapped coordinate mode for histogram

### DIFF
--- a/src/api/mavedb/score-sets.ts
+++ b/src/api/mavedb/score-sets.ts
@@ -7,6 +7,30 @@ type ScoreSetSearch = components['schemas']['ScoreSetsSearch']
 type ScoreSetsSearchResponse = components['schemas']['ScoreSetsSearchResponse']
 export type ScoreSetsSearchFilterOptionsResponse = components['schemas']['ScoreSetsSearchFilterOptionsResponse']
 
+const HISTOGRAM_VARIANT_DATA_NAMESPACES = ['vep', 'scores', 'clingen']
+
+function scoreSetVariantDataParams(
+  options: {includePostMappedHgvs?: boolean; namespaces?: string[]} = {}
+): URLSearchParams {
+  const params = new URLSearchParams()
+  if (options.includePostMappedHgvs) params.append('include_post_mapped_hgvs', 'true')
+  for (const namespace of options.namespaces ?? []) params.append('namespaces', namespace)
+  return params
+}
+
+function scoreSetVariantDataUrl(urn: string, params: URLSearchParams = new URLSearchParams()): string {
+  const query = params.toString()
+  const baseUrl = `${config.apiBaseUrl}/score-sets/${encodeURIComponent(urn)}/variants/data`
+  return query ? `${baseUrl}?${query}` : baseUrl
+}
+
+export function histogramScoreSetVariantDataUrl(urn: string): string {
+  return scoreSetVariantDataUrl(
+    urn,
+    scoreSetVariantDataParams({includePostMappedHgvs: true, namespaces: HISTOGRAM_VARIANT_DATA_NAMESPACES})
+  )
+}
+
 // ---------------------------------------------------------------------------
 // Search
 // ---------------------------------------------------------------------------
@@ -91,9 +115,7 @@ export async function downloadScoreSetFile(urn: string, type: 'scores' | 'counts
 }
 
 export async function downloadScoreSetVariantData(urn: string, params: URLSearchParams): Promise<string> {
-  const response = await axios.get(
-    `${config.apiBaseUrl}/score-sets/${encodeURIComponent(urn)}/variants/data?${params.toString()}`
-  )
+  const response = await axios.get(scoreSetVariantDataUrl(urn, params))
   return response.data
 }
 

--- a/src/api/mavedb/variants.ts
+++ b/src/api/mavedb/variants.ts
@@ -1,6 +1,7 @@
 import axios from 'axios'
 
 import config from '@/config'
+import {histogramScoreSetVariantDataUrl} from '@/api/mavedb/score-sets'
 import {components} from '@/schema/openapi'
 
 type ScoreSet = components['schemas']['ScoreSet']
@@ -18,10 +19,9 @@ export async function lookupVariantsByClingenId(
 }
 
 export async function lookupVariantsByVrsDigest(identifier: string): Promise<MappedVariant[]> {
-  const response = await axios.get(
-    `${config.apiBaseUrl}/mapped-variants/vrs/${encodeURIComponent(identifier)}`,
-    {params: {only_current: true}}
-  )
+  const response = await axios.get(`${config.apiBaseUrl}/mapped-variants/vrs/${encodeURIComponent(identifier)}`, {
+    params: {only_current: true}
+  })
   return response.data
 }
 
@@ -30,8 +30,8 @@ export async function getVariantDetail(urn: string): Promise<VariantEffectMeasur
   return response.data
 }
 
-export async function getVariantScores(scoreSetUrn: string): Promise<string> {
-  const response = await axios.get(`${config.apiBaseUrl}/score-sets/${encodeURIComponent(scoreSetUrn)}/variants/data`)
+export async function getHistogramVariantData(scoreSetUrn: string): Promise<string> {
+  const response = await axios.get(histogramScoreSetVariantDataUrl(scoreSetUrn))
   return response.data
 }
 

--- a/src/components/screens/ScoreSetView.vue
+++ b/src/components/screens/ScoreSetView.vue
@@ -502,9 +502,13 @@ import config from '@/config'
 import {hasPathogenicityCalibrations, hasFunctionalCalibrations} from '@/lib/calibrations'
 import {variantNotNullOrNA} from '@/lib/mave-hgvs'
 import {getScoreSetShortName} from '@/lib/score-sets'
-import {parseScoresOrCounts} from '@/lib/scores'
-import {parseSimpleCodingVariants, translateSimpleCodingVariants, type Variant} from '@/lib/variants'
-import {deleteScoreSet, publishScoreSet, getScoreSetClinicalControlOptions} from '@/api/mavedb'
+import {parseScoreSetVariantData, type Variant} from '@/lib/variants'
+import {
+  deleteScoreSet,
+  publishScoreSet,
+  getScoreSetClinicalControlOptions,
+  histogramScoreSetVariantDataUrl
+} from '@/api/mavedb'
 import {components} from '@/schema/openapi'
 import MvLoader from '@/components/common/MvLoader.vue'
 import MvEmptyState from '@/components/common/MvEmptyState.vue'
@@ -714,7 +718,7 @@ export default {
           this.setItemId(newValue)
           let scoresUrl = null
           if (this.itemType?.restCollectionName && this.itemId) {
-            scoresUrl = `${config.apiBaseUrl}/${this.itemType.restCollectionName}/${this.itemId}/variants/data?include_post_mapped_hgvs=true&namespaces=vep&namespaces=scores&namespaces=clingen`
+            scoresUrl = histogramScoreSetVariantDataUrl(this.itemId)
           }
           this.setScoresDataUrl(scoresUrl)
           this.ensureScoresDataLoaded()
@@ -723,11 +727,7 @@ export default {
       immediate: true
     },
     scoresData(newValue: unknown) {
-      const parsed = newValue ? parseScoresOrCounts(newValue as string, true) : null
-      if (parsed) {
-        parseSimpleCodingVariants(parsed as Variant[])
-        translateSimpleCodingVariants(parsed as Variant[])
-      }
+      const parsed = newValue ? parseScoreSetVariantData(newValue as string) : null
       this.variants = parsed ? (Object.freeze(parsed) as Variant[]) : null
       this.applyUrlState()
     },

--- a/src/components/screens/VariantScreen.vue
+++ b/src/components/screens/VariantScreen.vue
@@ -228,11 +228,12 @@
               <ScoreSetHistogram
                 :key="lookup.selectedScoreSetUrn.value || ''"
                 ref="histogram"
+                :coordinates="'mapped'"
                 :external-selection="lookup.variantScoreRow.value"
                 :lock-selection="true"
                 :score-set="lookup.selectedScoreSet.value"
                 :selected-calibration="lookup.selectedCalibration.value || undefined"
-                :variants="lookup.scores.value as any"
+                :variants="lookup.scores.value"
                 @calibration-changed="lookup.selectedCalibration.value = $event"
                 @selection-changed="() => {}"
               />

--- a/src/composables/use-variant-lookup.ts
+++ b/src/composables/use-variant-lookup.ts
@@ -4,7 +4,7 @@ import {computed, ref, shallowRef, watch, type ComputedRef, type Ref} from 'vue'
 import {
   getVariantAnnotation,
   getVariantDetail,
-  getVariantScores,
+  getHistogramVariantData,
   lookupVariantsByClingenId
 } from '@/api/mavedb/variants'
 import {useCalibrationResolution, type UseCalibrationResolutionReturn} from '@/composables/use-calibration-resolution'
@@ -18,7 +18,7 @@ import {
 } from '@/lib/calibrations'
 import {triggerDownload} from '@/lib/downloads'
 import {getExperimentKeyword} from '@/lib/experiments'
-import {parseScoresOrCounts, type ScoresOrCountsRow} from '@/lib/scores'
+import {parseScoreSetVariantData, type Variant} from '@/lib/variants'
 import type {MeasurementType} from '@/lib/measurement-types'
 import type {components} from '@/schema/openapi'
 
@@ -60,8 +60,8 @@ export interface UseVariantLookupReturn {
   // Scores
   selectedScoreSet: ComputedRef<ScoreSet | null>
   selectedScoreSetUrn: ComputedRef<string | null>
-  scores: ComputedRef<readonly ScoresOrCountsRow[] | null>
-  variantScoreRow: ComputedRef<ScoresOrCountsRow | undefined>
+  scores: ComputedRef<Variant[] | null>
+  variantScoreRow: ComputedRef<Variant | undefined>
   selectedVariantScore: ComputedRef<number | string | null>
 
   // Calibration
@@ -116,7 +116,7 @@ export function useVariantLookup(
   const showNucleotide = ref(true)
   const showProtein = ref(true)
   const variantDetailCache = ref<Record<string, VariantEffectMeasurementWithScoreSet>>({})
-  const scoresCache = shallowRef<Record<string, readonly ScoresOrCountsRow[]>>({})
+  const scoresCache = shallowRef<Record<string, Variant[]>>({})
   const selectedCalibration = ref<string | null>(null)
 
   // ── Filters ───────────────────────────────────────────────
@@ -212,10 +212,10 @@ export function useVariantLookup(
   async function fetchScores(scoreSetUrn: string) {
     if (scoresCache.value[scoreSetUrn]) return
     try {
-      const data = await getVariantScores(scoreSetUrn)
+      const data = await getHistogramVariantData(scoreSetUrn)
       scoresCache.value = {
         ...scoresCache.value,
-        [scoreSetUrn]: Object.freeze(parseScoresOrCounts(data, true))
+        [scoreSetUrn]: parseScoreSetVariantData(data)
       }
     } catch (error) {
       console.error(`Error fetching scores for score set "${scoreSetUrn}"`, error)

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -4,10 +4,8 @@ import {AMINO_ACIDS, AMINO_ACIDS_WITH_TER, singleLetterAminoAcidOrHgvsCode} from
 import {DEFAULT_CLNREVSTAT_FIELD, DEFAULT_CLNSIG_FIELD} from '@/lib/clinical-controls'
 import geneticCodes from '@/lib/genetic-codes'
 import {parseSimpleNtVariant, parseSimpleProVariant} from '@/lib/mave-hgvs'
+import {parseScoresOrCounts} from '@/lib/scores'
 import type {SimpleDnaVariation, SimpleProteinVariation} from '@/lib/mave-hgvs'
-import {components} from '@/schema/openapi'
-
-type ScoreSet = components['schemas']['ScoreSet']
 
 export type HgvsReferenceSequenceType = 'c' | 'p' // | 'n'
 
@@ -19,6 +17,16 @@ export interface SequenceRange {
 export interface ClinicalControlVariant {
   [DEFAULT_CLNSIG_FIELD]: string
   [DEFAULT_CLNREVSTAT_FIELD]: string
+}
+
+type ParsedSimpleDnaVariation = SimpleDnaVariation & {
+  residueType?: 'nt'
+  origin?: 'mapped' | 'unmapped'
+}
+
+type ParsedSimpleProteinVariation = SimpleProteinVariation & {
+  residueType?: 'aa'
+  origin?: 'mapped' | 'unmapped'
 }
 
 export interface RawVariant {
@@ -51,9 +59,9 @@ export interface RawVariant {
 }
 
 export interface VariantPropertiesAddedByPreparingCodingVariants {
-  // Added by prepareSimpleCodingVariants.
-  parsedPostMappedHgvsC?: SimpleDnaVariation
-  parsedPostMappedHgvsP?: SimpleProteinVariation
+  // Added by parseSimpleCodingVariants.
+  parsedPostMappedHgvsC?: ParsedSimpleDnaVariation
+  parsedPostMappedHgvsP?: ParsedSimpleProteinVariation
 }
 
 export interface Variant extends RawVariant, VariantPropertiesAddedByPreparingCodingVariants {
@@ -61,9 +69,10 @@ export interface Variant extends RawVariant, VariantPropertiesAddedByPreparingCo
   translated_hgvs_p?: string
 }
 
-export const HGVS_REFERENCE_SEQUENCE_TYPES: {
-  [type: HgvsReferenceSequenceType]: {parsedPostMappedHgvsField: keyof VariantPropertiesAddedByPreparingCodingVariants}
-} = {
+export const HGVS_REFERENCE_SEQUENCE_TYPES: Record<
+  HgvsReferenceSequenceType,
+  {parsedPostMappedHgvsField: keyof VariantPropertiesAddedByPreparingCodingVariants}
+> = {
   c: {
     parsedPostMappedHgvsField: 'parsedPostMappedHgvsC'
   },
@@ -106,6 +115,17 @@ export const VARIANT_EFFECT_TYPE_OPTIONS = [
 
 export const DEFAULT_VARIANT_EFFECT_TYPES = ['Missense', 'Nonsense', 'Synonymous', 'Other']
 
+export function parseScoreSetVariantData(csvData: string): Variant[] {
+  const variants = parseScoresOrCounts(csvData, true) as Variant[]
+  prepareScoreSetVariantData(variants)
+  return variants
+}
+
+function prepareScoreSetVariantData(variants: Variant[]) {
+  parseSimpleCodingVariants(variants)
+  translateSimpleCodingVariants(variants)
+}
+
 export const PARSED_POST_MAPPED_VARIANT_PROPERTIES: ParsedPostMappedVariantProperties = {
   c: 'parsedPostMappedHgvsC',
   g: 'parsedPostMappedHgvsC',
@@ -128,7 +148,7 @@ function getParsedPostMappedHgvs(variant: Variant, type: HgvsReferenceSequenceTy
  *
  * @param variants The variants to modify.
  */
-export function parseSimpleCodingVariants(variants: Variant[]) {
+function parseSimpleCodingVariants(variants: Variant[]) {
   for (const v of variants) {
     // Create the mavedb namespace if it doesn't exist.
     if (!v.mavedb) v.mavedb = {}
@@ -302,7 +322,7 @@ export function inferReferenceSequenceFromVariants(variants: Variant[], referenc
  *
  * @param variants The array of variants to translate.
  */
-export function translateSimpleCodingVariants(variants: Variant[]) {
+function translateSimpleCodingVariants(variants: Variant[]) {
   const {referenceSequence: codingSequence, referenceSequenceRange: codingSequenceRange} =
     inferReferenceSequenceFromVariants(variants, 'c')
   if (codingSequence.length > 0) {


### PR DESCRIPTION
The Variant view histogram fell back to raw-mode tooltip labels because three things lined up: the `coordinates` prop defaulted to `'raw'`, the variant cache only ran `parseScoresOrCounts` (so `parsedPostMappedHgvs*` and `translated_hgvs_p` were never populated), and the fetch omitted `include_post_mapped_hgvs` plus the `vep`/`clingen` namespaces — so even a mapped-mode tooltip would have had nothing to render. Pass `coordinates="mapped"` on VariantScreen and route the fetch + parse through the same pipeline ScoreSetView uses.

Along the way, consolidate the variant-data plumbing that had drifted between the two screens:

- Extract `histogramScoreSetVariantDataUrl` and a small params/URL builder in `api/mavedb/score-sets.ts`; ScoreSetView and the histogram fetch now share one definition of the endpoint and namespace set.
- Add `parseScoreSetVariantData` in `lib/variants.ts` as the single entrypoint for the `parseScoresOrCounts` → `parseSimpleCodingVariants` → `translateSimpleCodingVariants` chain; the latter two are now internal.
- Rename `getVariantScores` → `getHistogramVariantData` to reflect that it returns full variant rows, not just scores.
- Type `useVariantLookup`'s `scores`/`variantScoreRow` as `Variant` instead of `ScoresOrCountsRow`, removing the `as any` cast at the histogram `:variants` binding.
- Introduce `ParsedSimpleDnaVariation`/`ParsedSimpleProteinVariation` aliases so the `residueType`/`origin` fields added by `parseSimpleCodingVariants` are reflected in the type.