### PR TITLE
feat(variant-page): add synonymous nucleotide as a distinct measurement class

### DIFF
--- a/src/assets/app.css
+++ b/src/assets/app.css
@@ -121,12 +121,15 @@
   --color-ga4gh-light: #e3f0f9;
 
   /* ── Measurement Types (variant screen) ────────────────────── */
-  --color-nucleotide: var(--color-published);
-  --color-nucleotide-light: var(--color-published-light);
-  --color-nucleotide-border: var(--color-light-green);
-  --color-protein: var(--color-help);
-  --color-protein-light: var(--color-help-light);
-  --color-protein-border: var(--color-help-border);
+  --color-nucleotide: #2e7d32;
+  --color-nucleotide-light: #e8f5e9;
+  --color-nucleotide-border: #c8e4c6;
+  --color-protein: #7e5daf;
+  --color-protein-light: #f1ecf8;
+  --color-protein-border: #b5a0d0;
+  --color-synonymous-nucleotide: #8a5700;
+  --color-synonymous-nucleotide-light: #fef8e1;
+  --color-synonymous-nucleotide-border: #f5c97a;
 
   /* ── Role Badges ───────────────────────────────────────────── */
   --color-role-admin: #1a56a0;

--- a/src/components/screens/VariantScreen.vue
+++ b/src/components/screens/VariantScreen.vue
@@ -75,6 +75,15 @@
                 :count="lookup.proteinCount.value"
                 label="Protein level"
               />
+              <MvBadgeToggle
+                v-if="lookup.associatedNucleotideCount.value > 0"
+                v-model="lookup.showAssociatedNucleotide.value"
+                active-background="var(--color-synonymous-nucleotide-light)"
+                active-border="var(--color-synonymous-nucleotide-border)"
+                color="var(--color-synonymous-nucleotide)"
+                :count="lookup.associatedNucleotideCount.value"
+                label="Synonymous nucleotide"
+              />
             </div>
           </div>
           <!-- Desktop: horizontal scroll strip -->

--- a/src/composables/use-variant-lookup.ts
+++ b/src/composables/use-variant-lookup.ts
@@ -45,8 +45,10 @@ export interface UseVariantLookupReturn {
   // Filters
   showNucleotide: Ref<boolean>
   showProtein: Ref<boolean>
+  showAssociatedNucleotide: Ref<boolean>
   nucleotideCount: ComputedRef<number>
   proteinCount: ComputedRef<number>
+  associatedNucleotideCount: ComputedRef<number>
   filteredVariants: ComputedRef<VariantEntry[]>
 
   // Selection
@@ -115,19 +117,22 @@ export function useVariantLookup(
   const selectedVariantUrn = ref<string | null>(null)
   const showNucleotide = ref(true)
   const showProtein = ref(true)
+  const showAssociatedNucleotide = ref(true)
   const variantDetailCache = ref<Record<string, VariantEffectMeasurementWithScoreSet>>({})
   const scoresCache = shallowRef<Record<string, readonly ScoresOrCountsRow[]>>({})
   const selectedCalibration = ref<string | null>(null)
 
   // ── Filters ───────────────────────────────────────────────
-  const nucleotideCount = computed(
-    () => variants.value.filter((v) => v.type === 'nucleotide' || v.type === 'associatedNucleotide').length
-  )
+  const nucleotideCount = computed(() => variants.value.filter((v) => v.type === 'nucleotide').length)
   const proteinCount = computed(() => variants.value.filter((v) => v.type === 'protein').length)
+  const associatedNucleotideCount = computed(
+    () => variants.value.filter((v) => v.type === 'associatedNucleotide').length
+  )
   const filteredVariants = computed(() =>
     variants.value.filter((v) => {
-      if (v.type === 'nucleotide' || v.type === 'associatedNucleotide') return showNucleotide.value
+      if (v.type === 'nucleotide') return showNucleotide.value
       if (v.type === 'protein') return showProtein.value
+      if (v.type === 'associatedNucleotide') return showAssociatedNucleotide.value
       return true
     })
   )
@@ -383,8 +388,10 @@ export function useVariantLookup(
     fetchVariants,
     showNucleotide,
     showProtein,
+    showAssociatedNucleotide,
     nucleotideCount,
     proteinCount,
+    associatedNucleotideCount,
     filteredVariants,
     selectedVariantUrn,
     selectVariant,

--- a/src/lib/measurement-types.ts
+++ b/src/lib/measurement-types.ts
@@ -3,11 +3,11 @@ export type MeasurementType = 'nucleotide' | 'protein' | 'associatedNucleotide'
 export const MEASUREMENT_TYPE_LABELS: Record<MeasurementType, {full: string; short: string}> = {
   nucleotide: {full: 'Nucleotide level', short: 'Nucleotide'},
   protein: {full: 'Protein level', short: 'Protein'},
-  associatedNucleotide: {full: 'Associated nucleotide', short: 'Assoc. nucleotide'}
+  associatedNucleotide: {full: 'Synonymous nucleotide', short: 'Synonymous'}
 }
 
 export const MEASUREMENT_TYPE_CLASSES: Record<MeasurementType, string> = {
   nucleotide: 'bg-nucleotide-light text-nucleotide',
   protein: 'bg-protein-light text-protein',
-  associatedNucleotide: 'bg-nucleotide-light text-nucleotide'
+  associatedNucleotide: 'bg-synonymous-nucleotide-light text-synonymous-nucleotide'
 }


### PR DESCRIPTION
Previously, associated nucleotide measurements were grouped with direct nucleotide measurements: they shared the same filter toggle, count, and card badge styling, making them visually and behaviorally indistinguishable.

Changes:
- Add dedicated `--color-synonymous-nucleotide` / `-light` / `-border` design tokens in app.css using a dark amber palette (#8a5700 / #fef8e1 / #f5c97a).
- Rename the `associatedNucleotide` label from "Associated nucleotide" to "Synonymous nucleotide" / "Synonymous" (short) in measurement-types.ts and update its badge class to the new amber tokens.
- In use-variant-lookup: split the shared nucleotide count/filter into separate `nucleotideCount` / `associatedNucleotideCount` computeds and a dedicated `showAssociatedNucleotide` ref; each of the three classes is now filtered independently in `filteredVariants`.
- In VariantScreen.vue: add a third `MvBadgeToggle` for synonymous nucleotide (conditionally rendered when count > 0). The mobile dropdown derives its label from `MEASUREMENT_TYPE_LABELS[type].short` and automatically shows "Synonymous" with no further changes.