### PR TITLE
fix: correct hash-to-history redirect guard to check full path prefix

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -32,15 +32,17 @@ initializeOrcidAuthentication()
 // Provide a smooth migration path from vue-router's hash navigation mode to its history navigation mode. If the user
 // arrived via an old bookmark that uses the URL fragment (hash) for routing, redirect to the corresponding current URL.
 router.beforeEach((to) => {
-  const redirectPathAndQuery = to.hash.split('#')[1]
-  if (redirectPathAndQuery) {
-    const [redirectPath, redirectQueryStr] = redirectPathAndQuery.split('?', 2)
-    const redirectQuery = redirectQueryStr ? Object.fromEntries(new URLSearchParams(redirectQueryStr)) : undefined
+  if (to.fullPath.startsWith('/#/')) {
+    const redirectPathAndQuery = to.fullPath.replace('/#/', '/')
+    if (redirectPathAndQuery) {
+      const [redirectPath, redirectQueryStr] = redirectPathAndQuery.split('?', 2)
+      const redirectQuery = redirectQueryStr ? Object.fromEntries(new URLSearchParams(redirectQueryStr)) : undefined
 
-    // Attempt to resolve the path using vue-router. If the router finds a matching named route, then the path
-    // represents a valid screen, and we should redirect the user to that screen's current URL.
-    if (router.resolve({path: redirectPath})?.name) {
-      return {path: redirectPath, query: redirectQuery}
+      // Attempt to resolve the path using vue-router. If the router finds a matching named route, then the path
+      // represents a valid screen, and we should redirect the user to that screen's current URL.
+      if (router.resolve({path: redirectPath})?.name) {
+        return {path: redirectPath, query: redirectQuery}
+      }
     }
   }
 })


### PR DESCRIPTION
The router `beforeEach` guard was inspecting `to.hash` to detect legacy hash-based URLs, but `to.hash` only contains the fragment after the `#` and would not reliably identify paths starting with `/#/`. Switch to checking `to.fullPath.startsWith('/#/')` and removing `/#` so the redirect logic fires only for true hash-router URLs and not for anchors within the current page.