### PR TITLE
ProteinStructureView improvements

### DIFF
--- a/src/components/score-set/ProteinStructureView.vue
+++ b/src/components/score-set/ProteinStructureView.vue
@@ -1,8 +1,20 @@
 <template>
   <div class="flex flex-col h-full">
-    <div class="flex">
+    <div class="flex items-center flex-wrap">
       <span class="ml-2">Color by:</span>
-      <SelectButton v-model="colorBy" class="ml-2" option-label="name" option-value="value" :options="colorByOptions" />
+      <SelectButton v-model="colorBy" class="ml-2 mb-2" option-label="name" option-value="value" :options="colorByOptions" />
+      <span v-if="showStructureSelector">
+        <span class="ml-4">Segment:</span>
+        <PSelect
+          v-model="selectedModelId"
+          class="ml-2"
+          option-label="label"
+          option-value="id"
+          :options="structureModels"
+          :pt="{listContainer: {style: {overscrollBehavior: 'contain'}}}"
+          @change="onModelChange"
+        />
+      </span>
     </div>
     <div id="pdbe-molstar-viewer-container" class="flex-1 relative z-5000"></div>
     <ul class="list-disc text-xs italic text-gray-400 ml-5 px-2 py-1">
@@ -14,6 +26,7 @@
 
 <script>
 import axios from 'axios'
+import PSelect from 'primevue/select'
 import SelectButton from 'primevue/selectbutton'
 import {PDBeMolstarPlugin} from 'pdbe-molstar/lib/viewer'
 import 'pdbe-molstar/build/pdbe-molstar-light.css'
@@ -25,7 +38,7 @@ import useScopedId from '@/composables/scoped-id'
 export default {
   name: 'ProteinStructureView',
 
-  components: {SelectButton},
+  components: {PSelect, SelectButton},
 
   props: {
     uniprotId: {
@@ -89,6 +102,9 @@ export default {
 
   data: () => ({
     viewerInstance: null,
+    allStructureModels: [],
+    selectedModelId: null,
+    userPickedModel: false,
   }),
 
   computed: {
@@ -112,6 +128,48 @@ export default {
         color: _.get(x, this.colorBy, '#ffffff')
       }))
     },
+    selectedModel: function () {
+      return _.find(this.structureModels, {id: this.selectedModelId}) || null
+    },
+    // Score entries carry canonical UniProt residue numbers, remapped to how the selected structure
+    // is addressed by molstar (see mapSelectionToModel).
+    mappedSelectionData: function () {
+      return this.mapSelectionToModel(this.selectionDataWithSelectedColorBy)
+    },
+    // Canonical UniProt residue span covered by the heatmap (the assayed positions), or null when
+    // scores haven't loaded yet.
+    scoredResidueRange: function () {
+      const scored = this.selectionData || []
+      if (!scored.length) {
+        return null
+      }
+      return {
+        low: _.min(_.map(scored, 'start_residue_number')),
+        high: _.max(_.map(scored, 'end_residue_number'))
+      }
+    },
+    // Structures offered in the viewer: only those overlapping the heatmapped residues, since a
+    // structure covering an un-assayed region would render blank here. Before scores load (no range
+    // yet), show everything fetched.
+    structureModels: function () {
+      const range = this.scoredResidueRange
+      if (!range) {
+        return this.allStructureModels
+      }
+      return _.filter(
+        this.allStructureModels,
+        (m) => Math.max(0, Math.min(m.end, range.high) - Math.max(m.start, range.low)) > 0
+      )
+    },
+    // Show the structure selector whenever we're displaying a fragment of the protein — even a single
+    // one, so the displayed region is clear. A single full-length model (AlphaFold) needs no selector.
+    showStructureSelector: function () {
+      const models = this.structureModels
+      if (!models.length) {
+        return false
+      }
+      return models.length > 1 || !models[0].fullLength
+    },
   },
 
   watch: {
@@ -119,7 +177,7 @@ export default {
       handler: function () {
         if (this.viewerInstance)
           this.viewerInstance.visual.select({
-            data: this.selectionDataWithSelectedColorBy,
+            data: this.mappedSelectionData,
             nonSelectedColor: this.nonSelectedColor
           })
       }
@@ -127,14 +185,16 @@ export default {
     selectedResidueRanges: {
       handler: function (newValue) {
         if (this.viewerInstance) {
-          const selectedRanges = newValue.map((x) => ({
-            start_residue_number: x.start,
-            end_residue_number: x.end,
-            color: null,
-            focus: true
-          }))
+          const selectedRanges = this.mapSelectionToModel(
+            newValue.map((x) => ({
+              start_residue_number: x.start,
+              end_residue_number: x.end,
+              color: null,
+              focus: true
+            }))
+          )
           this.viewerInstance.visual.select({
-            data: [...this.selectionDataWithSelectedColorBy, ...selectedRanges],
+            data: [...this.mappedSelectionData, ...selectedRanges],
             nonSelectedColor: this.nonSelectedColor
           })
           this.viewerInstance.visual.highlight({
@@ -144,9 +204,19 @@ export default {
       },
       deep: true
     },
+    selectionData: {
+      handler: function () {
+        // Score data can arrive (or change) after the structures are fetched. Re-sync so the offered
+        // structures re-filter to those covering the scored residues and the selection stays valid.
+        if (this.allStructureModels.length) {
+          this.syncSelectedStructure(false)
+        }
+      },
+      deep: true
+    },
     uniprotId: {
       handler: async function () {
-        this.render()
+        this.loadStructures()
       },
       immediate: true
     }
@@ -158,24 +228,162 @@ export default {
 
   methods: {
     clickedResidue: function (e) {
-      this.$emit('clickedResidue', e.eventData)
+      this.$emit('clickedResidue', this.toCanonicalResidueEvent(e.eventData))
     },
     hoveredOverResidue: function (e) {
-      this.$emit('hoveredOverResidue', e.eventData)
+      this.$emit('hoveredOverResidue', this.toCanonicalResidueEvent(e.eventData))
     },
-    fetchAlphaFoldCifUrl: async function () {
-      const response = await axios.get(`https://alphafold.ebi.ac.uk/api/prediction/${this.uniprotId}`)
-      const predictionModels = _.isArray(response.data) ? response.data : [response.data]
+    toCanonicalResidueEvent: function (eventData) {
+      // The parent matches the heatmap by canonical UniProt position. For SIFTS-mapped structures
+      // (PDBe) the clicked loci reports the structure's own residue number in `residueNumber`, so
+      // substitute the UniProt residue number (unp_seq_id) when molstar resolved one for this entry.
+      if (eventData && eventData.unp_accession === this.uniprotId && eventData.unp_seq_id != null) {
+        return {...eventData, residueNumber: eventData.unp_seq_id}
+      }
+      return eventData
+    },
+    mapSelectionToModel: function (ranges) {
+      // Score positions are canonical UniProt residue numbers. AlphaFold and SWISS-MODEL models are
+      // numbered by canonical position, so they're used directly. PDBe experimental structures use
+      // author numbering, but their _updated.cif carries the SIFTS UniProt mapping, so we select by
+      // uniprot_accession + UniProt residue number and molstar resolves it to the right residues.
+      if (this.selectedModel?.provider === 'PDBe' && this.uniprotId) {
+        return _.map(ranges, (r) => ({
+          ..._.omit(r, ['start_residue_number', 'end_residue_number']),
+          uniprot_accession: this.uniprotId,
+          start_uniprot_residue_number: r.start_residue_number,
+          end_uniprot_residue_number: r.end_residue_number
+        }))
+      }
+      return ranges
+    },
+    fetchStructureModels: async function () {
+      // Prefer the canonical AlphaFold model when one exists (normal-length proteins).
+      try {
+        const {data} = await axios.get(`https://alphafold.ebi.ac.uk/api/prediction/${this.uniprotId}`)
+        const predictions = _.isArray(data) ? data : [data]
+        const canonical = predictions.find((x) => x.entryId === `AF-${this.uniprotId}-F1`)
+        if (canonical) {
+          return [
+            {
+              id: canonical.entryId,
+              url: canonical.cifUrl,
+              format: 'cif',
+              provider: 'AlphaFold DB',
+              start: canonical.uniprotStart,
+              end: canonical.uniprotEnd,
+              fullLength: true,
+              label: `AlphaFold · ${canonical.uniprotStart}–${canonical.uniprotEnd}`
+            }
+          ]
+        }
+      } catch {
+        // AlphaFold has no single model for large canonical proteins (404); fall back below.
+      }
 
-      // response may contain multiple entries (e.g. UniProt ID: P42167), we want to select the one with entryId = AF-<uniprotId>-F1
-      const selectedModel = predictionModels.find((x) => x.entryId === `AF-${this.uniprotId}-F1`)
-      return selectedModel?.cifUrl || null
+      // Large canonical proteins: no single AlphaFold model exists. Gather experimental (PDBe) and
+      // template (SWISS-MODEL) structures from 3D-Beacons; coverage is reported in canonical UniProt
+      // coordinates, and each covers a segment of the protein. Score colouring maps onto all of them
+      // (SWISS-MODEL by canonical numbering, PDBe via its SIFTS mapping — see mapSelectionToModel).
+      const cifFormats = {MMCIF: 'cif', PDB: 'pdb', BCIF: 'bcif'}
+      try {
+        const {data} = await axios.get(
+          `https://www.ebi.ac.uk/pdbe/pdbe-kb/3dbeacons/api/uniprot/summary/${this.uniprotId}.json`
+        )
+        return _.chain(data.structures)
+          .map('summary')
+          .filter((s) => s?.model_url && ['PDBe', 'SWISS-MODEL'].includes(s.provider))
+          .map((s) => ({
+            id: s.model_identifier,
+            url: s.model_url,
+            format: cifFormats[s.model_format] || 'cif',
+            provider: s.provider,
+            start: s.uniprot_start,
+            end: s.uniprot_end,
+            fullLength: false,
+            label:
+              `${s.provider} · ${s.uniprot_start}–${s.uniprot_end}` +
+              (s.resolution ? ` · ${s.resolution.toFixed(1)}Å` : '')
+          }))
+          .sortBy('start')
+          .value()
+      } catch {
+        return []
+      }
+    },
+
+    pickDefaultModel: function (models) {
+      // Among the offered (already overlap-filtered) structures, show the one that best covers the
+      // scored residues first; fall back to the widest coverage when scores haven't loaded yet.
+      const range = this.scoredResidueRange
+      if (range) {
+        const overlap = (m) => Math.max(0, Math.min(m.end, range.high) - Math.max(m.start, range.low))
+        const best = _.maxBy(models, overlap)
+        if (best && overlap(best) > 0) {
+          return best
+        }
+      }
+      return _.maxBy(models, (m) => m.end - m.start)
+    },
+
+    loadStructures: async function () {
+      this.destroyViewer()
+      this.allStructureModels = []
+      this.selectedModelId = null
+      this.userPickedModel = false
+
+      if (!this.uniprotId) {
+        return
+      }
+
+      const models = await this.fetchStructureModels()
+      if (!models.length) {
+        this.$toast.add({
+          severity: 'error',
+          summary: 'Error',
+          detail: 'No protein structure is available for this UniProt entry'
+        })
+        return
+      }
+
+      this.allStructureModels = models
+      this.syncSelectedStructure(true)
+    },
+
+    syncSelectedStructure: function (announceIfNone) {
+      // Keep the selected structure valid for the current (overlap-filtered) options, then render.
+      const models = this.structureModels
+      if (!models.length) {
+        // Structures were fetched, but none overlap the heatmapped residues.
+        this.selectedModelId = null
+        this.destroyViewer()
+        if (announceIfNone) {
+          this.$toast.add({
+            severity: 'error',
+            summary: 'Error',
+            detail: 'No protein structure covers the variants in this score set'
+          })
+        }
+        return
+      }
+      if (!this.userPickedModel || !_.some(models, {id: this.selectedModelId})) {
+        this.selectedModelId = this.pickDefaultModel(models).id
+      }
+      this.render()
+    },
+
+    onModelChange: function () {
+      // Mark that the user chose a structure so late-arriving score data doesn't override it.
+      this.userPickedModel = true
+      this.render()
     },
 
     destroyViewer: function () {
       if (this.viewerInstance) {
         document.removeEventListener('PDB.molstar.click', this.clickedResidue)
         document.removeEventListener('PDB.molstar.mouseover', this.hoveredOverResidue)
+        // Fully tear down the previous molstar plugin so switching structures doesn't stack viewers.
+        this.viewerInstance.plugin?.dispose?.()
         this.viewerInstance = null
       }
     },
@@ -183,60 +391,45 @@ export default {
     render: async function () {
       this.destroyViewer()
 
-      if (this.uniprotId) {
-        let alphafoldCifUrl
-        try {
-          alphafoldCifUrl = await this.fetchAlphaFoldCifUrl()
-          if (!alphafoldCifUrl) {
-            throw new Error('AlphaFold cifUrl not found')
-          }
-        } catch (error) {
-          this.$toast.add({severity: 'error', summary: 'Error', detail: 'Failed to fetch AlphaFold structure metadata'})
-          return
-        }
-
-        const viewerInstance = new PDBeMolstarPlugin()
-        const options = {
-          customData: {
-            url: alphafoldCifUrl,
-            format: 'cif'
-          },
-          /** This applies AlphaFold confidence score colouring theme for AlphaFold model */
-          // alphafoldView: true,
-          hideControls: true,
-          bgColor: {r: 255, g: 255, b: 255},
-          // hideCanvasControls: [
-          //   'selection',
-          //   'animation',
-          //   'controlToggle',
-          //   'controlInfo',
-          // ],
-          // sequencePanel: true,
-          landscape: true,
-          highlightColor: '#ffffff',
-          selection: {
-            data: this.selectionDataWithSelectedColorBy,
-            nonSelectedColor: this.nonSelectedColor
-          },
-          selectInteraction: false
-        }
-        const viewerContainer = document.getElementById('pdbe-molstar-viewer-container')
-        viewerInstance.render(viewerContainer, options)
-        viewerInstance.events.loadComplete.subscribe(() => {
-          // if structureRefMap is empty, it means AlphaFold structure failed to load
-          if (!_.size(viewerInstance.structureRefMap)) {
-            this.$toast.add({severity: 'error', summary: 'Error', detail: 'Failed to load AlphaFold structure'})
-          } else {
-            viewerInstance.plugin.layout.context.canvas3d.camera.state.fog = 0
-            viewerInstance.plugin.layout.context.canvas3d.camera.state.clipFar = false
-            viewerInstance.visual.tooltips({data: this.residueTooltips})
-          }
-        })
-
-        document.addEventListener('PDB.molstar.click', this.clickedResidue)
-        document.addEventListener('PDB.molstar.mouseover', this.hoveredOverResidue)
-        this.viewerInstance = viewerInstance
+      if (!this.selectedModel) {
+        return
       }
+
+      const viewerInstance = new PDBeMolstarPlugin()
+      const options = {
+        customData: {
+          url: this.selectedModel.url,
+          format: this.selectedModel.format
+        },
+        hideControls: true,
+        bgColor: {r: 255, g: 255, b: 255},
+        landscape: true,
+        highlightColor: '#ffffff',
+        // Apply score colouring for every structure. mappedSelectionData carries canonical UniProt
+        // positions remapped to the selected structure's addressing; nonSelectedColor paints the
+        // rest a neutral colour so the viewer never falls back to molstar's per-chain default.
+        selection: {
+          data: this.mappedSelectionData,
+          nonSelectedColor: this.nonSelectedColor
+        },
+        selectInteraction: false
+      }
+      const viewerContainer = document.getElementById('pdbe-molstar-viewer-container')
+      viewerInstance.render(viewerContainer, options)
+      viewerInstance.events.loadComplete.subscribe(() => {
+        // if structureRefMap is empty, it means the structure failed to load
+        if (!_.size(viewerInstance.structureRefMap)) {
+          this.$toast.add({severity: 'error', summary: 'Error', detail: 'Failed to load protein structure'})
+        } else {
+          viewerInstance.plugin.layout.context.canvas3d.camera.state.fog = 0
+          viewerInstance.plugin.layout.context.canvas3d.camera.state.clipFar = false
+          viewerInstance.visual.tooltips({data: this.mapSelectionToModel(this.residueTooltips)})
+        }
+      })
+
+      document.addEventListener('PDB.molstar.click', this.clickedResidue)
+      document.addEventListener('PDB.molstar.mouseover', this.hoveredOverResidue)
+      this.viewerInstance = viewerInstance
     }
   }
 }

--- a/src/components/score-set/ProteinStructureView.vue
+++ b/src/components/score-set/ProteinStructureView.vue
@@ -1,15 +1,10 @@
 <template>
   <div class="flex flex-col h-full">
-    <FloatLabel v-if="alphaFoldData?.length > 1" class="m-2" variant="on">
-      <Select :id="scopedId('alphafold-id')" v-model="selectedAlphaFold" option-label="id" :options="alphaFoldData" />
-      <label :for="scopedId('alphafold-id')">AlphaFold ID</label>
-    </FloatLabel>
     <div class="flex">
       <span class="ml-2">Color by:</span>
       <SelectButton v-model="colorBy" class="ml-2" option-label="name" option-value="value" :options="colorByOptions" />
     </div>
-    <div v-show="selectedAlphaFold" id="pdbe-molstar-viewer-container" class="flex-1 relative z-5000"></div>
-    <div v-if="!selectedAlphaFold" class="m-auto">No AlphaFold entry found</div>
+    <div id="pdbe-molstar-viewer-container" class="flex-1 relative z-5000"></div>
     <ul class="list-disc text-xs italic text-gray-400 ml-5 px-2 py-1">
       <li>Jumper, J et al. Highly accurate protein structure prediction with AlphaFold. <em>Nature</em> (2021)</li>
       <li>Fleming J. et al. AlphaFold Protein Structure Database and 3D-Beacons: New Data and Capabilities. <em>Journal of Molecular Biology</em> (2025)</li>
@@ -19,9 +14,6 @@
 
 <script>
 import axios from 'axios'
-import $ from 'jquery'
-import FloatLabel from 'primevue/floatlabel'
-import Select from 'primevue/select'
 import SelectButton from 'primevue/selectbutton'
 import {PDBeMolstarPlugin} from 'pdbe-molstar/lib/viewer'
 import 'pdbe-molstar/build/pdbe-molstar-light.css'
@@ -33,7 +25,7 @@ import useScopedId from '@/composables/scoped-id'
 export default {
   name: 'ProteinStructureView',
 
-  components: {FloatLabel, Select, SelectButton},
+  components: {SelectButton},
 
   props: {
     uniprotId: {
@@ -96,9 +88,7 @@ export default {
   },
 
   data: () => ({
-    uniprotData: null,
     viewerInstance: null,
-    selectedAlphaFold: null
   }),
 
   computed: {
@@ -122,19 +112,6 @@ export default {
         color: _.get(x, this.colorBy, '#ffffff')
       }))
     },
-    alphaFoldData: function () {
-      if (!this.uniprotData) {
-        return []
-      }
-      return $('entry dbReference[type="AlphaFoldDB"]', this.uniprotData)
-        .map((i, element) => {
-          return {
-            id: $(element).attr('id')
-          }
-        })
-        .get()
-        .filter((x) => x.id != null)
-    }
   },
 
   watch: {
@@ -167,21 +144,9 @@ export default {
       },
       deep: true
     },
-    alphaFoldData: {
-      handler: function () {
-        if (!this.selectedAlphaFold && this.alphaFoldData.length > 0) {
-          this.selectedAlphaFold = this.alphaFoldData[0]
-        }
-      }
-    },
-    selectedAlphaFold: {
-      handler: function () {
-        this.render()
-      }
-    },
     uniprotId: {
       handler: async function () {
-        await this.fetchUniprotData()
+        this.render()
       },
       immediate: true
     }
@@ -192,16 +157,6 @@ export default {
   },
 
   methods: {
-    fetchUniprotData: async function () {
-      const response = await axios.get(`https://rest.uniprot.org/uniprotkb/${encodeURIComponent(this.uniprotId)}.xml`)
-      if (response.data) {
-        const parser = new DOMParser()
-        this.uniprotData = parser.parseFromString(response.data, 'text/xml')
-      } else {
-        this.uniprotData = null
-      }
-    },
-
     clickedResidue: function (e) {
       this.$emit('clickedResidue', e.eventData)
     },
@@ -209,9 +164,11 @@ export default {
       this.$emit('hoveredOverResidue', e.eventData)
     },
     fetchAlphaFoldCifUrl: async function () {
-      const response = await axios.get(`https://alphafold.ebi.ac.uk/api/prediction/${this.selectedAlphaFold.id}`)
+      const response = await axios.get(`https://alphafold.ebi.ac.uk/api/prediction/${this.uniprotId}`)
       const predictionModels = _.isArray(response.data) ? response.data : [response.data]
-      const selectedModel = predictionModels.find((x) => x.entryId === `AF-${this.selectedAlphaFold.id}-F1`)
+
+      // response may contain multiple entries (e.g. UniProt ID: P42167), we want to select the one with entryId = AF-<uniprotId>-F1
+      const selectedModel = predictionModels.find((x) => x.entryId === `AF-${this.uniprotId}-F1`)
       return selectedModel?.cifUrl || null
     },
 
@@ -226,7 +183,7 @@ export default {
     render: async function () {
       this.destroyViewer()
 
-      if (this.selectedAlphaFold) {
+      if (this.uniprotId) {
         let alphafoldCifUrl
         try {
           alphafoldCifUrl = await this.fetchAlphaFoldCifUrl()

--- a/src/components/score-set/ProteinStructureView.vue
+++ b/src/components/score-set/ProteinStructureView.vue
@@ -158,7 +158,7 @@ export default {
       }
       return _.filter(
         this.allStructureModels,
-        (m) => Math.max(0, Math.min(m.end, range.high) - Math.max(m.start, range.low)) > 0
+        (model) => this.modelScoresetOverlap(model, range) > 0
       )
     },
     // Show the structure selector whenever we're displaying a fragment of the protein — even a single
@@ -227,6 +227,9 @@ export default {
   },
 
   methods: {
+    modelScoresetOverlap: function(model, range) {
+      return Math.max(0, Math.min(model.end, range.high) - Math.max(model.start, range.low))
+    },
     clickedResidue: function (e) {
       this.$emit('clickedResidue', this.toCanonicalResidueEvent(e.eventData))
     },
@@ -317,9 +320,8 @@ export default {
       // scored residues first; fall back to the widest coverage when scores haven't loaded yet.
       const range = this.scoredResidueRange
       if (range) {
-        const overlap = (m) => Math.max(0, Math.min(m.end, range.high) - Math.max(m.start, range.low))
-        const best = _.maxBy(models, overlap)
-        if (best && overlap(best) > 0) {
+        const best = _.maxBy(models, (m) => this.modelScoresetOverlap(m, range))
+        if (best && this.modelScoresetOverlap(best, range) > 0) {
           return best
         }
       }

--- a/src/components/screens/ScoreSetView.vue
+++ b/src/components/screens/ScoreSetView.vue
@@ -281,7 +281,7 @@
                   @update:model-value="heatmapLayout = $event"
                 />
                 <PButton
-                  v-if="uniprotId != null"
+                  v-if="hasMappedVariants && uniprotId != null"
                   icon="pi pi-box"
                   label="Protein Structure"
                   severity="secondary"
@@ -625,6 +625,10 @@ export default {
   }),
 
   computed: {
+    hasMappedVariants() {
+      // A mapping state of "complete" or "incomplete" indicates that at least some variants have been mapped to a reference genome
+      return ['complete', 'incomplete'].includes(this.item?.mappingState ?? '')
+    },
     clinicalModeHelpText() {
       if (this.item?.targetGenes?.[0]?.targetSequence) {
         return 'In clinical mode, mapped variant coordinates are used when available, and start- and stop-loss codons are omitted because this score set was produced using a synthetic target sequence.'


### PR DESCRIPTION
This pull request refactors and enhances the `ProteinStructureView` component to support viewing protein structures beyond just AlphaFold, including experimental and template models from PDBe and SWISS-MODEL via 3D-Beacons. The structure selection logic is improved, and the UI is updated to allow users to choose among overlapping models. Additionally, the display of the protein structure button in `ScoreSetView` is now conditional on the presence of mapped variants.

**Protein structure viewer enhancements:**

* Refactored `ProteinStructureView.vue` to support multiple structure sources (AlphaFold, PDBe, SWISS-MODEL) using 3D-Beacons, with logic to fetch, filter, and select structures covering the scored residues. The UI now includes a segment selector when multiple or partial models are available, and the coloring logic is generalized to all structure types. [[1]](diffhunk://#diff-3886f50aa3d09ae0aad064bea77b7717d5a41ada3e997ec344507abc93e582a1L3-R19) [[2]](diffhunk://#diff-3886f50aa3d09ae0aad064bea77b7717d5a41ada3e997ec344507abc93e582a1L22-R29) [[3]](diffhunk://#diff-3886f50aa3d09ae0aad064bea77b7717d5a41ada3e997ec344507abc93e582a1L36-R41) [[4]](diffhunk://#diff-3886f50aa3d09ae0aad064bea77b7717d5a41ada3e997ec344507abc93e582a1L99-R107) [[5]](diffhunk://#diff-3886f50aa3d09ae0aad064bea77b7717d5a41ada3e997ec344507abc93e582a1L125-R197) [[6]](diffhunk://#diff-3886f50aa3d09ae0aad064bea77b7717d5a41ada3e997ec344507abc93e582a1L170-R219) [[7]](diffhunk://#diff-3886f50aa3d09ae0aad064bea77b7717d5a41ada3e997ec344507abc93e582a1L195-R426) [[8]](diffhunk://#diff-3886f50aa3d09ae0aad064bea77b7717d5a41ada3e997ec344507abc93e582a1L285)

**Improved UI logic:**

* The "Protein Structure" button in `ScoreSetView.vue` is now only shown when mapped variants are present and a UniProt ID is available, preventing display when no structure visualization is possible. [[1]](diffhunk://#diff-3f76557aa3e49806dd7a9de907576c131b2f602f0b3929852fb9efaed87b0457L284-R284) [[2]](diffhunk://#diff-3f76557aa3e49806dd7a9de907576c131b2f602f0b3929852fb9efaed87b0457R628-R631)

These changes provide more robust and flexible protein structure visualization, supporting a wider range of use cases and improving the user experience.

Some existing scoresets useful for testing these changes:
 - urn:mavedb:00000730-a-1
 - urn:mavedb:00001167-a-1
 - urn:mavedb:00000688-a-1