### PR TITLE
Davereinhart/gnomad id search

### DIFF
--- a/src/api/clingen/alleles.test.ts
+++ b/src/api/clingen/alleles.test.ts
@@ -1,0 +1,94 @@
+import axios from 'axios'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+import {getAlleleByGnomad} from './alleles'
+
+vi.mock('axios', () => ({
+  default: {
+    get: vi.fn()
+  },
+  isAxiosError: (error: unknown) => Boolean((error as {isAxiosError?: boolean})?.isAxiosError)
+}))
+
+const mockedAxiosGet = vi.mocked(axios.get)
+
+/** A ClinGen allele, trimmed to the fields these tests care about. */
+const ALLELE = {'@id': 'http://reg.genome.network/allele/CA412761507'}
+
+/** The registry rejects a position whose reference allele doesn't match the assembly with a 400. */
+function referenceMismatch() {
+  return {
+    isAxiosError: true,
+    response: {status: 400, data: {errorType: 'IncorrectReferenceAllele'}}
+  }
+}
+
+/** The HGVS strings axios was asked to resolve, in order. */
+function queriedHgvs() {
+  return mockedAxiosGet.mock.calls.map((call) => call[1]?.params?.hgvs)
+}
+
+describe('getAlleleByGnomad', () => {
+  beforeEach(() => {
+    mockedAxiosGet.mockReset()
+  })
+
+  it('resolves a GRCh38 ID without trying GRCh37', async () => {
+    mockedAxiosGet.mockResolvedValueOnce({data: ALLELE} as never)
+
+    expect(await getAlleleByGnomad('X-41334274-A-C')).toEqual({allele: ALLELE, assembly: 'grch38'})
+    expect(queriedHgvs()).toEqual(['NC_000023.11:g.41334274A>C'])
+  })
+
+  it('falls back to the GRCh37 accession when the reference allele does not match GRCh38', async () => {
+    mockedAxiosGet.mockRejectedValueOnce(referenceMismatch()).mockResolvedValueOnce({data: ALLELE} as never)
+
+    expect(await getAlleleByGnomad('17-7579472-G-C')).toEqual({allele: ALLELE, assembly: 'grch37'})
+    expect(queriedHgvs()).toEqual(['NC_000017.11:g.7579472G>C', 'NC_000017.10:g.7579472G>C'])
+  })
+
+  it('propagates a server error instead of masking it as a wrong-assembly retry', async () => {
+    const outage = {isAxiosError: true, response: {status: 503, data: {}}}
+    mockedAxiosGet.mockRejectedValueOnce(outage)
+
+    await expect(getAlleleByGnomad('X-41334274-A-C')).rejects.toBe(outage)
+    expect(mockedAxiosGet).toHaveBeenCalledTimes(1)
+  })
+
+  it('propagates a network failure, which carries no response', async () => {
+    const offline = {isAxiosError: true, message: 'Network Error'}
+    mockedAxiosGet.mockRejectedValueOnce(offline)
+
+    await expect(getAlleleByGnomad('X-41334274-A-C')).rejects.toBe(offline)
+    expect(mockedAxiosGet).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces the GRCh37 failure when neither assembly resolves', async () => {
+    const mismatch = referenceMismatch()
+    mockedAxiosGet.mockRejectedValueOnce(referenceMismatch()).mockRejectedValueOnce(mismatch)
+
+    await expect(getAlleleByGnomad('17-7579472-G-C')).rejects.toBe(mismatch)
+    expect(mockedAxiosGet).toHaveBeenCalledTimes(2)
+  })
+
+  it('reads only the requested assembly when one is forced, without falling back', async () => {
+    mockedAxiosGet.mockResolvedValueOnce({data: ALLELE} as never)
+
+    expect(await getAlleleByGnomad('17-7676154-G-C', 'grch37')).toEqual({allele: ALLELE, assembly: 'grch37'})
+    expect(queriedHgvs()).toEqual(['NC_000017.10:g.7676154G>C'])
+  })
+
+  it('surfaces the failure of a forced assembly rather than trying the other one', async () => {
+    const mismatch = referenceMismatch()
+    mockedAxiosGet.mockRejectedValueOnce(mismatch)
+
+    await expect(getAlleleByGnomad('17-7676154-G-C', 'grch37')).rejects.toBe(mismatch)
+    expect(mockedAxiosGet).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects an ID it cannot translate without calling the registry', async () => {
+    // Passes gnomadIdRegex, but the alleles describe no change.
+    await expect(getAlleleByGnomad('1-11796321-A-A')).rejects.toThrow('Not a valid gnomAD variant ID')
+    expect(mockedAxiosGet).not.toHaveBeenCalled()
+  })
+})

--- a/src/api/clingen/alleles.ts
+++ b/src/api/clingen/alleles.ts
@@ -1,5 +1,5 @@
 import axios, {isAxiosError} from 'axios'
-import {gnomadIdToHgvsCandidates} from '@/lib/gnomad'
+import {type GenomeAssembly, gnomadIdToHgvsCandidates} from '@/lib/gnomad'
 import type {ClinGenAllele, ClinGenGene} from './types'
 
 const CLINGEN_BASE_URL = 'https://reg.genome.network'
@@ -37,6 +37,12 @@ export async function getGeneBySymbol(symbol: string): Promise<ClinGenGene> {
   return response.data
 }
 
+/** An allele resolved from a gnomAD ID, with the assembly whose coordinates it was read under. */
+export interface GnomadAlleleResult {
+  allele: ClinGenAllele
+  assembly: GenomeAssembly
+}
+
 /**
  * Look up an allele by gnomAD variant ID (e.g. 1-11796321-G-A).
  *
@@ -44,23 +50,34 @@ export async function getGeneBySymbol(symbol: string): Promise<ClinGenGene> {
  * cross-references: the registry computes an allele from any coordinates that match the reference, whereas its gnomAD
  * index only covers variants it has ingested a gnomAD record for.
  *
- * A gnomAD ID doesn't name the reference genome its coordinates belong to, so GRCh38 is tried first and GRCh37
- * second. A 4xx from the first attempt is how coordinates announce they belong to the older assembly — the registry
- * rejects a position whose reference allele doesn't match with `IncorrectReferenceAllele`.
+ * A gnomAD ID doesn't name the reference genome its coordinates belong to, so by default GRCh38 is tried first and
+ * GRCh37 second. A 4xx from the first attempt is how coordinates announce they belong to the older assembly — the
+ * registry rejects a position whose reference allele doesn't match with `IncorrectReferenceAllele`. Note that a
+ * position can be valid under both assemblies while naming a different variant in each, in which case the earlier
+ * assembly wins; pass `assembly` to read the ID under a specific one instead, and let any failure propagate.
+ *
+ * @returns The allele, and the assembly its coordinates were read under.
  */
-export async function getAlleleByGnomad(gnomadId: string): Promise<ClinGenAllele> {
-  const [grch38Hgvs, grch37Hgvs] = gnomadIdToHgvsCandidates(gnomadId)
-  if (!grch38Hgvs) {
+export async function getAlleleByGnomad(gnomadId: string, assembly?: GenomeAssembly): Promise<GnomadAlleleResult> {
+  const candidates = gnomadIdToHgvsCandidates(gnomadId).filter(
+    (candidate) => assembly == undefined || candidate.assembly === assembly
+  )
+  if (candidates.length === 0) {
     throw new Error(`Not a valid gnomAD variant ID: ${gnomadId}`)
   }
 
-  try {
-    return await getAlleleByHgvs(grch38Hgvs)
-  } catch (error) {
-    // Only a rejection of these coordinates warrants retrying; a network failure or registry outage should surface.
-    if (!isAxiosError(error) || !error.response || error.response.status >= 500) {
-      throw error
+  for (const [index, candidate] of candidates.entries()) {
+    const isLastCandidate = index === candidates.length - 1
+    try {
+      return {allele: await getAlleleByHgvs(candidate.hgvs), assembly: candidate.assembly}
+    } catch (error) {
+      // Only a rejection of these coordinates warrants trying the next assembly; a network failure or registry outage
+      // should surface, as should the final attempt's failure.
+      if (isLastCandidate || !isAxiosError(error) || !error.response || error.response.status >= 500) {
+        throw error
+      }
     }
   }
-  return await getAlleleByHgvs(grch37Hgvs)
+  // Unreachable: the loop either returns or throws on its final iteration.
+  throw new Error(`Could not resolve gnomAD variant ID: ${gnomadId}`)
 }

--- a/src/api/clingen/alleles.ts
+++ b/src/api/clingen/alleles.ts
@@ -1,4 +1,5 @@
-import axios from 'axios'
+import axios, {isAxiosError} from 'axios'
+import {gnomadIdToHgvsCandidates} from '@/lib/gnomad'
 import type {ClinGenAllele, ClinGenGene} from './types'
 
 const CLINGEN_BASE_URL = 'https://reg.genome.network'
@@ -15,14 +16,14 @@ export async function getAlleleByHgvs(hgvs: string): Promise<ClinGenAllele> {
   return response.data
 }
 
-export async function getAlleleByDbSnp(rsId: string): Promise<ClinGenAllele> {
+export async function getAlleleByDbSnp(rsId: string): Promise<ClinGenAllele[]> {
   const response = await axios.get(`${CLINGEN_BASE_URL}/alleles`, {
     params: {'dbSNP.rs': rsId}
   })
   return response.data
 }
 
-export async function getAlleleByClinVar(variationId: string): Promise<ClinGenAllele> {
+export async function getAlleleByClinVar(variationId: string): Promise<ClinGenAllele[]> {
   const response = await axios.get(`${CLINGEN_BASE_URL}/alleles`, {
     params: {'ClinVar.variationId': variationId}
   })
@@ -34,4 +35,32 @@ export async function getGeneBySymbol(symbol: string): Promise<ClinGenGene> {
     params: {'HGNC.symbol': symbol}
   })
   return response.data
+}
+
+/**
+ * Look up an allele by gnomAD variant ID (e.g. 1-11796321-G-A).
+ *
+ * The ID is translated into genomic HGVS and resolved as such, rather than looked up among the registry's gnomAD
+ * cross-references: the registry computes an allele from any coordinates that match the reference, whereas its gnomAD
+ * index only covers variants it has ingested a gnomAD record for.
+ *
+ * A gnomAD ID doesn't name the reference genome its coordinates belong to, so GRCh38 is tried first and GRCh37
+ * second. A 4xx from the first attempt is how coordinates announce they belong to the older assembly — the registry
+ * rejects a position whose reference allele doesn't match with `IncorrectReferenceAllele`.
+ */
+export async function getAlleleByGnomad(gnomadId: string): Promise<ClinGenAllele> {
+  const [grch38Hgvs, grch37Hgvs] = gnomadIdToHgvsCandidates(gnomadId)
+  if (!grch38Hgvs) {
+    throw new Error(`Not a valid gnomAD variant ID: ${gnomadId}`)
+  }
+
+  try {
+    return await getAlleleByHgvs(grch38Hgvs)
+  } catch (error) {
+    // Only a rejection of these coordinates warrants retrying; a network failure or registry outage should surface.
+    if (!isAxiosError(error) || !error.response || error.response.status >= 500) {
+      throw error
+    }
+  }
+  return await getAlleleByHgvs(grch37Hgvs)
 }

--- a/src/assets/app.css
+++ b/src/assets/app.css
@@ -113,8 +113,8 @@
   --color-badge-alert: #fef3c7;
 
   /* ── Search Types ──────────────────────────────────────────── */
-  --color-any: #5c6b7a;
-  --color-any-light: #eceff2;
+  --color-hgvs: #5c6b7a;
+  --color-hgvs-light: #eceff2;
   --color-dbsnp: #e6b84d;
   --color-dbsnp-light: #fdf3d7;
   --color-clinvar: #5aafa0;

--- a/src/assets/app.css
+++ b/src/assets/app.css
@@ -123,6 +123,8 @@
   --color-ga4gh-light: #e3f0f9;
   --color-gnomad: #5b4ba8;
   --color-gnomad-light: #ece9f7;
+  --color-gene: #b5446e;
+  --color-gene-light: #fbeaf1;
 
   /* ── Measurement Types (variant screen) ────────────────────── */
   --color-nucleotide: #2e7d32;

--- a/src/assets/app.css
+++ b/src/assets/app.css
@@ -119,6 +119,8 @@
   --color-clinvar-light: #c8ece5;
   --color-ga4gh: #0f6ca4;
   --color-ga4gh-light: #e3f0f9;
+  --color-gnomad: #5b4ba8;
+  --color-gnomad-light: #ece9f7;
 
   /* ── Measurement Types (variant screen) ────────────────────── */
   --color-nucleotide: #2e7d32;

--- a/src/assets/app.css
+++ b/src/assets/app.css
@@ -113,6 +113,8 @@
   --color-badge-alert: #fef3c7;
 
   /* ── Search Types ──────────────────────────────────────────── */
+  --color-any: #5c6b7a;
+  --color-any-light: #eceff2;
   --color-dbsnp: #e6b84d;
   --color-dbsnp-light: #fdf3d7;
   --color-clinvar: #5aafa0;

--- a/src/components/screens/HomeScreen.vue
+++ b/src/components/screens/HomeScreen.vue
@@ -230,6 +230,7 @@ import MvScoreSetRow from '@/components/common/MvScoreSetRow.vue'
 import {BROWSE_CATEGORIES, CONTRIBUTE_CATEGORIES, FEATURED_COLLECTIONS, WATERMARK_BARS} from '@/data/home'
 import {NEWS_ITEMS, NEWS_ITEMS_LIMIT, NEWS_TAG_STYLES} from '@/data/news'
 import {SEARCH_COLORS, SEARCH_PLACEHOLDERS, SEARCH_TYPES} from '@/data/search'
+import {geneSymbolRegex, geneSymbolSearchTarget} from '@/lib/mavemd'
 import {getRecentlyPublishedScoreSets} from '@/api/mavedb/score-sets'
 import {components} from '@/schema/openapi'
 
@@ -305,6 +306,14 @@ export default defineComponent({
     submitSearch() {
       const text = this.searchText.trim()
       if (!text) return
+      // A gene symbol resolves to a gene page, so go straight there. Routing through the variant search screen would
+      // otherwise leave a page the user never asked for sitting between the two in their history. A malformed symbol
+      // is left to the search screen, which owns the error message for it.
+      const geneSymbol = geneSymbolSearchTarget(text, this.searchType)
+      if (geneSymbol && geneSymbolRegex.test(geneSymbol)) {
+        this.router.push({name: 'gene', params: {symbol: geneSymbol}})
+        return
+      }
       this.router.push({path: '/mavemd', query: {search: text, searchType: this.searchType}})
     }
   }

--- a/src/components/screens/HomeScreen.vue
+++ b/src/components/screens/HomeScreen.vue
@@ -259,7 +259,7 @@ export default defineComponent({
 
   data() {
     return {
-      searchType: 'hgvs',
+      searchType: 'any',
       searchText: '',
       isDesktop: false,
       mdQuery: null as MediaQueryList | null,
@@ -271,10 +271,10 @@ export default defineComponent({
 
   computed: {
     activeSearchColor(): {accent: string; bg: string; activeText?: string} {
-      return SEARCH_COLORS[this.searchType] || SEARCH_COLORS.hgvs
+      return SEARCH_COLORS[this.searchType] || SEARCH_COLORS.any
     },
     activeSearchPlaceholder(): string {
-      const p = SEARCH_PLACEHOLDERS[this.searchType] || SEARCH_PLACEHOLDERS.hgvs
+      const p = SEARCH_PLACEHOLDERS[this.searchType] || SEARCH_PLACEHOLDERS.any
       return this.isDesktop ? p.full : p.short
     }
   },

--- a/src/components/screens/SearchVariantsScreen.vue
+++ b/src/components/screens/SearchVariantsScreen.vue
@@ -286,9 +286,12 @@
           <span aria-hidden="true">&larr;</span> New search
         </button>
       </div>
-      <!-- Which reference genome the gnomAD ID was read under -->
+      <!--
+        Which reference genome the gnomAD ID was read under. A reading that hit a mismatch says so in the empty state
+        below instead, which can explain what went wrong rather than implying the coordinates were understood.
+      -->
       <div
-        v-if="gnomadInterpretation"
+        v-if="gnomadInterpretation && !gnomadInterpretation.mismatch"
         class="mb-5 flex flex-col gap-2.5 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
       >
         <div class="min-w-0">
@@ -320,11 +323,18 @@
           A resolved reading always yields an allele, registered or not, so an empty result alongside an attempted
           reading means the coordinates don't exist in that assembly rather than that MaveDB lacks the data.
         -->
-        <template v-if="gnomadInterpretation">
+        <template v-if="gnomadInterpretation?.mismatch">
           <div class="text-base font-semibold text-gray-600">Not {{ gnomadInterpretation.name }} coordinates</div>
-          <div class="mt-1.5 text-sm text-gray-500">
-            {{ searchText }} does not match the {{ gnomadInterpretation.name }} reference sequence at that position.
+          <div v-if="gnomadInterpretation.mismatch === 'reference'" class="mt-1.5 text-sm text-gray-500">
+            {{ gnomadInterpretation.id }} does not match the {{ gnomadInterpretation.name }} reference sequence at that
+            position.
           </div>
+          <div v-else class="mt-1.5 text-sm text-gray-500">
+            {{ gnomadInterpretation.id }} lies past the end of that chromosome in {{ gnomadInterpretation.name }}.
+          </div>
+          <code v-if="gnomadInterpretation.hgvs" class="mt-1 block font-mono text-xs text-gray-400">
+            {{ gnomadInterpretation.hgvs }}
+          </code>
           <button
             class="mt-3 cursor-pointer rounded-full border-[1.5px] px-3 py-1 text-xs font-semibold"
             :style="searchColorStyle('gnomadId')"
@@ -820,8 +830,15 @@ export default defineComponent({
       inputAlternateAllele: null as string | null,
       allAlleleOptions: ALLELE_OPTIONS,
       alleles: [] as AlleleResult[],
-      /** Which assembly the current gnomAD ID was read under; null when the search wasn't a gnomAD ID search. */
-      gnomadAssembly: null as GenomeAssembly | null,
+      /**
+       * The gnomAD reading currently on screen: the ID exactly as searched, the assembly it was read (or attempted)
+       * under, and how the registry answered. A null mismatch means no verdict on the assembly — either the reading
+       * resolved, or it failed for a reason that says nothing about the coordinates.
+       *
+       * This records what the last search did, rather than tracking the form: the results must not restate
+       * themselves as the user types a new identifier into the box.
+       */
+      gnomadReading: null as {id: string; assembly: GenomeAssembly; mismatch: 'reference' | 'position' | null} | null,
       /** What an "Any" search resolved the string to; null when the search type was chosen explicitly. */
       detectedSearchType: null as string | null,
       nucleotideScoreSetListIsExpanded: [] as Array<boolean>,
@@ -894,15 +911,22 @@ export default defineComponent({
       }
       return this.searchTypeOptions.find((option) => option.code === this.detectedSearchType) ?? null
     },
-    /** How the current gnomAD ID was read, and how it would read under the other assembly. */
-    gnomadInterpretation(): {name: string; hgvs: string | null; otherName: string} | null {
-      if (!this.gnomadAssembly || !this.searchText) {
-        return null
-      }
+    /** How the gnomAD ID that was searched got read, how it would read under the other assembly, and how that went. */
+    gnomadInterpretation(): {
+      id: string
+      name: string
+      hgvs: string | null
+      otherName: string
+      mismatch: 'reference' | 'position' | null
+    } | null {
+      if (!this.gnomadReading) return null
+      const {id, assembly, mismatch} = this.gnomadReading
       return {
-        name: GENOME_ASSEMBLY_NAMES[this.gnomadAssembly],
-        hgvs: gnomadIdToHgvs(this.searchText, this.gnomadAssembly),
-        otherName: GENOME_ASSEMBLY_NAMES[otherAssembly(this.gnomadAssembly)]
+        id,
+        name: GENOME_ASSEMBLY_NAMES[assembly],
+        hgvs: gnomadIdToHgvs(id, assembly),
+        otherName: GENOME_ASSEMBLY_NAMES[otherAssembly(assembly)],
+        mismatch
       }
     }
   },
@@ -1095,6 +1119,9 @@ export default defineComponent({
       }
       this.searchType = searchType
       this.showSearch('default')
+      // Let the search type watcher run before the box is filled. It clears the box on a type change, and queued as
+      // it is, it would otherwise flush during the search below and wipe out the example we just put there.
+      await this.$nextTick()
       this.searchText = example
       await this.defaultSearch()
       this.router.replace({query: {searchType: this.searchType, search: this.searchText}})
@@ -1108,7 +1135,7 @@ export default defineComponent({
       this.inputAlternateAllele = null
       this.searchResultsVisible = false
       this.alleles = []
-      this.gnomadAssembly = null
+      this.gnomadReading = null
       this.detectedSearchType = null
       this.router.replace({query: {}})
     },
@@ -1158,9 +1185,10 @@ export default defineComponent({
       }
 
       this.searchResultsVisible = true
-      // Show the assembly being attempted, so a forced reading that fails to resolve still reports what was tried
-      // rather than leaving the previous, now-discarded result on screen.
-      this.gnomadAssembly = forcedAssembly ?? null
+      // Record the assembly being attempted, so a forced reading that fails to resolve still reports what was
+      // tried rather than leaving the previous, now-discarded result on screen.
+      this.gnomadReading =
+        forcedAssembly && this.searchText ? {id: this.searchText, assembly: forcedAssembly, mismatch: null} : null
       this.detectedSearchType = null
       const query = {...this.route.query}
       delete query.mode
@@ -1190,8 +1218,8 @@ export default defineComponent({
      * the user correct an ID that resolved under the wrong one.
      */
     switchGnomadAssembly: async function () {
-      if (!this.gnomadAssembly) return
-      await this.defaultSearch(otherAssembly(this.gnomadAssembly))
+      if (!this.gnomadReading) return
+      await this.defaultSearch(otherAssembly(this.gnomadReading.assembly))
     },
     fetchDefaultSearchResults: async function (
       searchString: string,
@@ -1266,38 +1294,55 @@ export default defineComponent({
           }
           try {
             const gnomadResult = await getAlleleByGnomad(searchStr, forcedAssembly ?? undefined)
-            this.gnomadAssembly = gnomadResult.assembly
+            this.gnomadReading = {id: searchStr, assembly: gnomadResult.assembly, mismatch: null}
             responseData = gnomadResult.allele
           } catch (error: unknown) {
-            // A gnomAD ID that doesn't match an assembly's reference sequence isn't a failure to report as one: it is
-            // the answer, and the useful thing to say is which base is actually there.
+            // Coordinates that don't fit an assembly aren't a failure to report as one: that is the answer. Which way
+            // they fail to fit decides what can be said about them, so classify it and hand it to the template too,
+            // rather than confining it to a toast that has to guess.
             const {data} = getErrorResponse(error)
-            if (data?.errorType !== 'IncorrectReferenceAllele') {
-              throw error
-            }
-            const actualAllele = data.actualAllele as string | undefined
-            const givenAllele = data.givenAllele as string | undefined
-            const baseNote =
-              actualAllele && givenAllele
-                ? ` The reference base at that position is ${actualAllele}, not ${givenAllele}.`
-                : ''
+            const mismatch =
+              data?.errorType === 'IncorrectReferenceAllele'
+                ? 'reference'
+                : data?.errorType === 'IncorrectHgvsPosition'
+                  ? 'position'
+                  : null
+            if (!mismatch) throw error
+            if (this.gnomadReading) this.gnomadReading.mismatch = mismatch
+
+            const actualAllele = data?.actualAllele as string | undefined
+            const givenAllele = data?.givenAllele as string | undefined
+            const reason =
+              mismatch === 'position'
+                ? 'That position lies past the end of the chromosome there.'
+                : actualAllele && givenAllele
+                  ? `The reference base at that position is ${actualAllele}, not ${givenAllele}.`
+                  : ''
             this.toast.add(
               forcedAssembly
                 ? {
                     severity: 'warn',
                     summary: `Not ${GENOME_ASSEMBLY_NAMES[forcedAssembly]} coordinates`,
-                    detail:
-                      `${searchStr} cannot be read as ${GENOME_ASSEMBLY_NAMES[forcedAssembly]}.${baseNote} ` +
-                      `It is only valid as ${GENOME_ASSEMBLY_NAMES[otherAssembly(forcedAssembly)]}.`,
+                    detail: [
+                      `${searchStr} cannot be read as ${GENOME_ASSEMBLY_NAMES[forcedAssembly]}.`,
+                      reason,
+                      `It may only be valid as ${GENOME_ASSEMBLY_NAMES[otherAssembly(forcedAssembly)]}.`
+                    ]
+                      .filter(Boolean)
+                      .join(' '),
                     life: 10000
                   }
                 : {
                     severity: 'warn',
                     summary: 'Variant not found',
-                    detail:
-                      `${searchStr} does not match the reference sequence in either ` +
-                      `${GENOME_ASSEMBLY_NAMES.grch38} or ${GENOME_ASSEMBLY_NAMES.grch37}.${baseNote} ` +
-                      'Check the position and reference allele.',
+                    detail: [
+                      `${searchStr} does not fit the reference sequence in either ` +
+                        `${GENOME_ASSEMBLY_NAMES.grch38} or ${GENOME_ASSEMBLY_NAMES.grch37}.`,
+                      reason,
+                      'Check the position and reference allele.'
+                    ]
+                      .filter(Boolean)
+                      .join(' '),
                     life: 10000
                   }
             )

--- a/src/components/screens/SearchVariantsScreen.vue
+++ b/src/components/screens/SearchVariantsScreen.vue
@@ -44,7 +44,7 @@
               v-for="option in searchTypeOptions"
               :key="option.code"
               :aria-selected="searchType === option.code"
-              class="cursor-pointer rounded-full border-[1.5px] px-3 py-1 text-xs font-semibold transition-all md:px-4 md:py-1.5 md:text-sm"
+              class="cursor-pointer rounded-full border-[1.5px] px-3 py-1 text-xs font-semibold transition-all md:px-4 md:py-1.5 md:text-xs"
               role="tab"
               :style="searchColorStyle(option.code, searchType === option.code ? 'active' : 'inactive')"
               :tabindex="searchType === option.code ? 0 : -1"
@@ -266,6 +266,16 @@
         <div aria-live="polite" role="status">
           <div class="text-lg font-bold text-dark">
             {{ alleles.length }} allele{{ alleles.length !== 1 ? 's' : '' }} found
+          </div>
+          <!-- An "Any" search leaves the selected type as "Any", so report what the string was taken to be. -->
+          <div v-if="detectedSearchTypeOption" class="mt-1 flex flex-wrap items-center gap-1.5 text-sm text-gray-500">
+            <span>Searched as</span>
+            <span
+              class="rounded-full border-[1.5px] px-2.5 py-0.5 text-xs font-semibold"
+              :style="searchColorStyle(detectedSearchTypeOption.code)"
+            >
+              {{ detectedSearchTypeOption.name }}
+            </span>
           </div>
         </div>
         <button
@@ -726,6 +736,7 @@ import {
   type AlleleResult,
   clinGenAlleleIdRegex,
   clinVarVariationIdRegex,
+  detectSearchType,
   gnomadIdRegex,
   rsIdRegex,
   vrsDigestRegex,
@@ -809,6 +820,8 @@ export default defineComponent({
       alleles: [] as AlleleResult[],
       /** Which assembly the current gnomAD ID was read under; null when the search wasn't a gnomAD ID search. */
       gnomadAssembly: null as GenomeAssembly | null,
+      /** What an "Any" search resolved the string to; null when the search type was chosen explicitly. */
+      detectedSearchType: null as string | null,
       nucleotideScoreSetListIsExpanded: [] as Array<boolean>,
       proteinScoreSetListIsExpanded: [] as Array<boolean>,
       associatedNucleotideScoreSetListIsExpanded: [] as Array<boolean>,
@@ -861,11 +874,18 @@ export default defineComponent({
       )
     },
     currentSearchColor(): {accent: string; bg: string; activeText?: string} {
-      return SEARCH_COLORS[this.searchType || 'hgvs'] || SEARCH_COLORS.hgvs
+      return SEARCH_COLORS[this.searchType || 'any'] || SEARCH_COLORS.any
     },
     currentPlaceholder(): string {
       const option = this.searchTypeOptions.find((o) => o.code === this.searchType)
       return option?.examples?.[0] || 'Enter a value'
+    },
+    /** The search type an "Any" search resolved to, for display alongside the results. */
+    detectedSearchTypeOption(): {code: string; name: string} | null {
+      if (!this.detectedSearchType) {
+        return null
+      }
+      return this.searchTypeOptions.find((option) => option.code === this.detectedSearchType) ?? null
     },
     /** How the current gnomAD ID was read, and how it would read under the other assembly. */
     gnomadInterpretation(): {name: string; hgvs: string | null; otherName: string} | null {
@@ -918,7 +938,7 @@ export default defineComponent({
         if (typeof newVal === 'string') {
           this.searchType = newVal
         } else if (!newVal && this.defaultSearchVisible) {
-          this.searchType = 'hgvs'
+          this.searchType = 'any'
         }
       }
     },
@@ -1074,6 +1094,7 @@ export default defineComponent({
       this.searchResultsVisible = false
       this.alleles = []
       this.gnomadAssembly = null
+      this.detectedSearchType = null
       this.router.replace({query: {}})
     },
     showSearch(searchMethod: 'guided' | 'default' = 'default') {
@@ -1085,7 +1106,7 @@ export default defineComponent({
         delete query.search
         delete query.searchType
         query.mode = 'guided'
-        this.searchType = 'hgvs'
+        this.searchType = 'any'
       } else {
         delete query.gene
         delete query.variantType
@@ -1103,6 +1124,7 @@ export default defineComponent({
       // Show the assembly being attempted, so a forced reading that fails to resolve still reports what was tried
       // rather than leaving the previous, now-discarded result on screen.
       this.gnomadAssembly = forcedAssembly ?? null
+      this.detectedSearchType = null
       const query = {...this.route.query}
       delete query.mode
       delete query.gene
@@ -1140,8 +1162,25 @@ export default defineComponent({
       forcedSearchType?: string,
       forcedAssembly?: GenomeAssembly | null
     ) {
-      const searchType = forcedSearchType ?? this.searchType
+      let searchType = forcedSearchType ?? this.searchType
       let searchStr = searchString.trim()
+
+      // The "Any" type is a stand-in: work out what the string actually is, then take the usual path for that type.
+      if (searchType === 'any') {
+        const detectedSearchType = detectSearchType(searchStr)
+        if (!detectedSearchType) {
+          this.toast.add({
+            severity: 'error',
+            summary: 'Unrecognized identifier',
+            detail: `${searchStr} does not look like any supported variant identifier. Choose a search type to see examples of what is accepted.`,
+            life: 10000
+          })
+          return
+        }
+        searchType = detectedSearchType
+        // Record it for display: the selected type stays "Any", but the user should see what it was taken to be.
+        this.detectedSearchType = detectedSearchType
+      }
 
       try {
         let responseData
@@ -1407,6 +1446,7 @@ export default defineComponent({
       this.searchResultsVisible = true
       this.syncGuidedQueryParams()
       this.alleles = []
+      this.detectedSearchType = null
       this.loading = true
       await this.fetchGuidedSearchResults()
       this.loading = false
@@ -1478,7 +1518,7 @@ export default defineComponent({
     },
 
     searchColorStyle(code: string, variant: 'active' | 'inactive' | 'chip' = 'chip'): Record<string, string> {
-      const colors = SEARCH_COLORS[code] || SEARCH_COLORS.hgvs
+      const colors = SEARCH_COLORS[code] || SEARCH_COLORS.any
       switch (variant) {
         case 'active':
           return {

--- a/src/components/screens/SearchVariantsScreen.vue
+++ b/src/components/screens/SearchVariantsScreen.vue
@@ -1085,14 +1085,19 @@ export default defineComponent({
       }
     },
     searchForText: async function (example: string, searchType: string) {
+      // A gene symbol example is really a link to its gene page, so navigate before touching any search state.
+      // Selecting a type and resetting the form queues watchers that clear the search text and rewrite the query
+      // params, and those rewrites would abort the navigation out from under us.
+      const geneSymbol = geneSymbolSearchTarget(example, searchType)
+      if (geneSymbol && geneSymbolRegex.test(geneSymbol)) {
+        this.router.push({name: 'gene', params: {symbol: geneSymbol}})
+        return
+      }
       this.searchType = searchType
       this.showSearch('default')
       this.searchText = example
       await this.defaultSearch()
-      // A gene symbol example navigates to its gene page, so only record the search when we are still on this screen.
-      if (this.route.name === 'mavemd') {
-        this.router.replace({query: {searchType: this.searchType, search: this.searchText}})
-      }
+      this.router.replace({query: {searchType: this.searchType, search: this.searchText}})
     },
     clearSearch() {
       this.searchText = null
@@ -1204,7 +1209,7 @@ export default defineComponent({
           this.toast.add({
             severity: 'error',
             summary: 'Unrecognized identifier',
-            detail: `${searchStr} does not look like any supported variant identifier. Choose a search type to see examples of what is accepted.`,
+            detail: `${searchStr} does not look like any supported variant identifier or gene symbol. Choose a search type to see examples of what is accepted.`,
             life: 10000
           })
           return

--- a/src/components/screens/SearchVariantsScreen.vue
+++ b/src/components/screens/SearchVariantsScreen.vue
@@ -68,7 +68,7 @@
               class="min-w-0 flex-1 !rounded-none !border-none !shadow-none placeholder:font-mono placeholder:text-xs md:placeholder:text-sm"
               :placeholder="currentPlaceholder"
               type="search"
-              @keyup.enter="defaultSearch"
+              @keyup.enter="defaultSearch()"
             />
             <button
               class="cursor-pointer whitespace-nowrap border-none px-4 text-sm font-semibold transition-colors hover:brightness-85 md:px-7"
@@ -76,7 +76,7 @@
                 backgroundColor: currentSearchColor.accent,
                 color: currentSearchColor.activeText || 'var(--color-text-dark)'
               }"
-              @click="defaultSearch"
+              @click="defaultSearch()"
             >
               Search
             </button>
@@ -276,15 +276,59 @@
           <span aria-hidden="true">&larr;</span> New search
         </button>
       </div>
+      <!-- Which reference genome the gnomAD ID was read under -->
+      <div
+        v-if="gnomadInterpretation"
+        class="mb-5 flex flex-col gap-2.5 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
+      >
+        <div class="min-w-0">
+          <div class="text-sm text-gray-600">
+            Read as
+            <span class="font-semibold text-dark">{{ gnomadInterpretation.name }}</span>
+            coordinates
+          </div>
+          <code v-if="gnomadInterpretation.hgvs" class="mt-0.5 block truncate font-mono text-xs text-gray-500">
+            {{ gnomadInterpretation.hgvs }}
+          </code>
+        </div>
+        <button
+          class="shrink-0 cursor-pointer rounded-full border-[1.5px] px-3 py-1 text-xs font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+          :disabled="loading"
+          :style="searchColorStyle('gnomadId')"
+          @click="switchGnomadAssembly"
+        >
+          Read as {{ gnomadInterpretation.otherName }} instead
+        </button>
+      </div>
+
       <div v-if="loading">
         <MvLoader text="Finding matching variants..." />
       </div>
 
       <div v-else-if="alleles.length === 0" class="py-10 text-center">
-        <div class="text-base font-semibold text-gray-600">No variants found</div>
-        <div class="mt-1.5 text-sm text-gray-500">
-          No matching variants were found in MaveDB. Try a different identifier or search type.
-        </div>
+        <!--
+          A resolved reading always yields an allele, registered or not, so an empty result alongside an attempted
+          reading means the coordinates don't exist in that assembly rather than that MaveDB lacks the data.
+        -->
+        <template v-if="gnomadInterpretation">
+          <div class="text-base font-semibold text-gray-600">Not {{ gnomadInterpretation.name }} coordinates</div>
+          <div class="mt-1.5 text-sm text-gray-500">
+            {{ searchText }} does not match the {{ gnomadInterpretation.name }} reference sequence at that position.
+          </div>
+          <button
+            class="mt-3 cursor-pointer rounded-full border-[1.5px] px-3 py-1 text-xs font-semibold"
+            :style="searchColorStyle('gnomadId')"
+            @click="switchGnomadAssembly"
+          >
+            Read as {{ gnomadInterpretation.otherName }} instead
+          </button>
+        </template>
+        <template v-else>
+          <div class="text-base font-semibold text-gray-600">No variants found</div>
+          <div class="mt-1.5 text-sm text-gray-500">
+            No matching variants were found in MaveDB. Try a different identifier or search type.
+          </div>
+        </template>
       </div>
 
       <article
@@ -295,14 +339,23 @@
       >
         <!-- Card header -->
         <div class="border-b border-gray-100 px-5 pt-4 pb-3.5">
-          <router-link
-            v-if="allele.clingenAlleleId"
-            :aria-label="'View variant detail for ' + allele.canonicalAlleleName"
+          <!--
+            Alleles the registry resolved but has not registered have no ClinGen ID to link to, so the heading renders
+            as plain text for those. Everything else about the header is shared.
+          -->
+          <component
+            :is="allele.clingenAlleleId ? 'router-link' : 'div'"
+            :aria-label="allele.clingenAlleleId ? 'View variant detail for ' + allele.canonicalAlleleName : undefined"
             class="group flex flex-col gap-2 no-underline sm:flex-row sm:items-start sm:justify-between sm:gap-4"
-            :to="{name: 'variant', params: {clingenAlleleId: allele.clingenAlleleId}}"
+            :to="
+              allele.clingenAlleleId ? {name: 'variant', params: {clingenAlleleId: allele.clingenAlleleId}} : undefined
+            "
           >
             <div class="min-w-0">
-              <span class="text-base font-bold leading-snug text-link group-hover:underline sm:text-lg">
+              <span
+                class="text-base font-bold leading-snug sm:text-lg"
+                :class="allele.clingenAlleleId ? 'text-link group-hover:underline' : 'text-dark'"
+              >
                 {{ allele.canonicalAlleleName }}
               </span>
               <div v-if="allele.grch38Hgvs || allele.grch37Hgvs" class="mt-1.5 flex flex-wrap items-center gap-2">
@@ -322,17 +375,14 @@
                 </span>
               </div>
             </div>
-            <span class="shrink-0 text-sm font-semibold text-link group-hover:underline sm:text-md">
+            <span
+              v-if="allele.clingenAlleleId"
+              class="shrink-0 text-sm font-semibold text-link group-hover:underline sm:text-md"
+            >
               View variant &rarr;
             </span>
-          </router-link>
-          <div v-else class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
-            <div class="min-w-0">
-              <span class="font-mono text-base font-bold leading-snug text-dark sm:text-lg">
-                {{ allele.canonicalAlleleName }}
-              </span>
-            </div>
-          </div>
+            <span v-else class="shrink-0 text-xs italic text-gray-400"> Not in the ClinGen registry </span>
+          </component>
 
           <!-- MANE coordinates (collapsible) -->
           <MvCollapsible v-if="allele.maneCoordinates.length > 0" class="mt-3" :open="false" title="MANE transcripts">
@@ -686,6 +736,7 @@ import {
 import {getTargetGeneName} from '@/lib/target-genes'
 import {components} from '@/schema/openapi'
 import {getScoreSetShortName} from '@/lib/score-sets'
+import {type GenomeAssembly, GENOME_ASSEMBLY_NAMES, gnomadIdToHgvs, otherAssembly} from '@/lib/gnomad'
 import {clinVarHgvsSearchStringRegex, hgvsSearchStringRegex} from '@/lib/mave-hgvs'
 import {SEARCH_COLORS} from '@/data/search'
 import {AVE_CLINICAL_APPLICATION} from '@/lib/links'
@@ -756,6 +807,8 @@ export default defineComponent({
       inputAlternateAllele: null as string | null,
       allAlleleOptions: ALLELE_OPTIONS,
       alleles: [] as AlleleResult[],
+      /** Which assembly the current gnomAD ID was read under; null when the search wasn't a gnomAD ID search. */
+      gnomadAssembly: null as GenomeAssembly | null,
       nucleotideScoreSetListIsExpanded: [] as Array<boolean>,
       proteinScoreSetListIsExpanded: [] as Array<boolean>,
       associatedNucleotideScoreSetListIsExpanded: [] as Array<boolean>,
@@ -813,6 +866,17 @@ export default defineComponent({
     currentPlaceholder(): string {
       const option = this.searchTypeOptions.find((o) => o.code === this.searchType)
       return option?.examples?.[0] || 'Enter a value'
+    },
+    /** How the current gnomAD ID was read, and how it would read under the other assembly. */
+    gnomadInterpretation(): {name: string; hgvs: string | null; otherName: string} | null {
+      if (!this.gnomadAssembly || !this.searchText) {
+        return null
+      }
+      return {
+        name: GENOME_ASSEMBLY_NAMES[this.gnomadAssembly],
+        hgvs: gnomadIdToHgvs(this.searchText, this.gnomadAssembly),
+        otherName: GENOME_ASSEMBLY_NAMES[otherAssembly(this.gnomadAssembly)]
+      }
     }
   },
 
@@ -1009,6 +1073,7 @@ export default defineComponent({
       this.inputAlternateAllele = null
       this.searchResultsVisible = false
       this.alleles = []
+      this.gnomadAssembly = null
       this.router.replace({query: {}})
     },
     showSearch(searchMethod: 'guided' | 'default' = 'default') {
@@ -1032,9 +1097,12 @@ export default defineComponent({
       this.router.replace({query})
       this.clearSearch()
     },
-    defaultSearch: async function () {
+    defaultSearch: async function (forcedAssembly?: GenomeAssembly) {
       if (this.searchText) this.searchText = this.searchText.trim()
       this.searchResultsVisible = true
+      // Show the assembly being attempted, so a forced reading that fails to resolve still reports what was tried
+      // rather than leaving the previous, now-discarded result on screen.
+      this.gnomadAssembly = forcedAssembly ?? null
       const query = {...this.route.query}
       delete query.mode
       delete query.gene
@@ -1051,12 +1119,27 @@ export default defineComponent({
       this.alleles = []
       this.loading = true
       if (this.searchText !== null && this.searchText !== '') {
-        await this.fetchDefaultSearchResults(this.searchText)
+        await this.fetchDefaultSearchResults(this.searchText, null, undefined, forcedAssembly)
       }
       this.loading = false
       await this.searchVariants()
     },
-    fetchDefaultSearchResults: async function (searchString: string, maneStatus: string | null = null, forcedSearchType?: string) {
+    /**
+     * Re-read the current gnomAD ID under the other assembly.
+     *
+     * The same coordinates can be valid under both assemblies while naming a different variant in each, so this lets
+     * the user correct an ID that resolved under the wrong one.
+     */
+    switchGnomadAssembly: async function () {
+      if (!this.gnomadAssembly) return
+      await this.defaultSearch(otherAssembly(this.gnomadAssembly))
+    },
+    fetchDefaultSearchResults: async function (
+      searchString: string,
+      maneStatus: string | null = null,
+      forcedSearchType?: string,
+      forcedAssembly?: GenomeAssembly | null
+    ) {
       const searchType = forcedSearchType ?? this.searchType
       let searchStr = searchString.trim()
 
@@ -1105,7 +1188,45 @@ export default defineComponent({
             })
             return
           }
-          responseData = await getAlleleByGnomad(searchStr)
+          try {
+            const gnomadResult = await getAlleleByGnomad(searchStr, forcedAssembly ?? undefined)
+            this.gnomadAssembly = gnomadResult.assembly
+            responseData = gnomadResult.allele
+          } catch (error: unknown) {
+            // A gnomAD ID that doesn't match an assembly's reference sequence isn't a failure to report as one: it is
+            // the answer, and the useful thing to say is which base is actually there.
+            const {data} = getErrorResponse(error)
+            if (data?.errorType !== 'IncorrectReferenceAllele') {
+              throw error
+            }
+            const actualAllele = data.actualAllele as string | undefined
+            const givenAllele = data.givenAllele as string | undefined
+            const baseNote =
+              actualAllele && givenAllele
+                ? ` The reference base at that position is ${actualAllele}, not ${givenAllele}.`
+                : ''
+            this.toast.add(
+              forcedAssembly
+                ? {
+                    severity: 'warn',
+                    summary: `Not ${GENOME_ASSEMBLY_NAMES[forcedAssembly]} coordinates`,
+                    detail:
+                      `${searchStr} cannot be read as ${GENOME_ASSEMBLY_NAMES[forcedAssembly]}.${baseNote} ` +
+                      `It is only valid as ${GENOME_ASSEMBLY_NAMES[otherAssembly(forcedAssembly)]}.`,
+                    life: 10000
+                  }
+                : {
+                    severity: 'warn',
+                    summary: 'Variant not found',
+                    detail:
+                      `${searchStr} does not match the reference sequence in either ` +
+                      `${GENOME_ASSEMBLY_NAMES.grch38} or ${GENOME_ASSEMBLY_NAMES.grch37}.${baseNote} ` +
+                      'Check the position and reference allele.',
+                    life: 10000
+                  }
+            )
+            return
+          }
         } else if (searchType === 'vrsDigest') {
           if (!vrsDigestRegex.test(searchStr)) {
             this.toast.add({
@@ -1198,6 +1319,15 @@ export default defineComponent({
               }
               break
             }
+          } else if (result.genomicAlleles?.length || result.transcriptAlleles?.length) {
+            // The registry resolved these coordinates against the reference but holds no registered allele for them,
+            // so it answers with a blank node id (_:CA) rather than a CA id. Show what the coordinates resolve to
+            // instead of discarding it; an unregistered allele can have no MaveDB measurements either way.
+            const unregisteredAllele = createAlleleResult(result, maneStatus)
+            unregisteredAllele.clingenAlleleId = undefined
+            unregisteredAllele.clingenAlleleUrl = undefined
+            unregisteredAllele.variantsStatus = 'Loaded'
+            this.alleles.push(unregisteredAllele)
           }
         }
         if (this.alleles.length > 0) {

--- a/src/components/screens/SearchVariantsScreen.vue
+++ b/src/components/screens/SearchVariantsScreen.vue
@@ -738,6 +738,7 @@ import {
   clinVarVariationIdRegex,
   detectSearchType,
   geneSymbolRegex,
+  geneSymbolSearchTarget,
   gnomadIdRegex,
   rsIdRegex,
   vrsDigestRegex,
@@ -1083,12 +1084,15 @@ export default defineComponent({
         this.maveMdScoreSetsError = true
       }
     },
-    searchForText: function (example: string, searchType: string) {
+    searchForText: async function (example: string, searchType: string) {
       this.searchType = searchType
       this.showSearch('default')
       this.searchText = example
-      this.defaultSearch()
-      this.router.replace({query: {searchType: this.searchType, search: this.searchText}})
+      await this.defaultSearch()
+      // A gene symbol example navigates to its gene page, so only record the search when we are still on this screen.
+      if (this.route.name === 'mavemd') {
+        this.router.replace({query: {searchType: this.searchType, search: this.searchText}})
+      }
     },
     clearSearch() {
       this.searchText = null
@@ -1126,6 +1130,28 @@ export default defineComponent({
     },
     defaultSearch: async function (forcedAssembly?: GenomeAssembly) {
       if (this.searchText) this.searchText = this.searchText.trim()
+
+      // A gene symbol navigates away instead of producing results here, so it is handled before this screen records
+      // the search in its query params. The search is also stripped from the entry being left behind: were it to
+      // remain, returning here would re-run it on mount and bounce the user straight back to the gene page.
+      const geneSymbol = geneSymbolSearchTarget(this.searchText ?? '', this.searchType)
+      if (geneSymbol) {
+        if (!geneSymbolRegex.test(geneSymbol)) {
+          this.toast.add({
+            severity: 'error',
+            summary: 'Invalid search',
+            detail: `Please provide a valid gene symbol (e.g. ${this.searchTypeOptions.find((o) => o.code === 'geneSymbol')?.examples?.join(', ')})`,
+            life: 10000
+          })
+          return
+        }
+        const query = {...this.route.query}
+        delete query.search
+        await this.router.replace({query})
+        this.router.push({name: 'gene', params: {symbol: geneSymbol}})
+        return
+      }
+
       this.searchResultsVisible = true
       // Show the assembly being attempted, so a forced reading that fails to resolve still reports what was tried
       // rather than leaving the previous, now-discarded result on screen.
@@ -1223,21 +1249,6 @@ export default defineComponent({
             return
           }
           responseData = await getAlleleByClinVar(searchStr)
-        } else if (searchType === 'geneSymbol') {
-          const geneSymbol = searchStr.toUpperCase()
-          if (!geneSymbolRegex.test(geneSymbol)) {
-            this.toast.add({
-              severity: 'error',
-              summary: 'Invalid search',
-              detail: `Please provide a valid gene symbol (e.g. ${this.searchTypeOptions.find((o) => o.code === searchType)?.examples?.join(', ')})`,
-              life: 10000
-            })
-            return
-          }
-          // Replace rather than push: this screen re-runs its search from the query params on mount, so a pushed
-          // entry would send the back button straight here and forward again to the gene page.
-          this.router.replace({name: 'gene', params: {symbol: geneSymbol}})
-          return
         } else if (searchType === 'gnomadId') {
           if (!gnomadIdRegex.test(searchStr)) {
             this.toast.add({

--- a/src/components/screens/SearchVariantsScreen.vue
+++ b/src/components/screens/SearchVariantsScreen.vue
@@ -737,6 +737,7 @@ import {
   clinGenAlleleIdRegex,
   clinVarVariationIdRegex,
   detectSearchType,
+  geneSymbolRegex,
   gnomadIdRegex,
   rsIdRegex,
   vrsDigestRegex,
@@ -749,7 +750,7 @@ import {components} from '@/schema/openapi'
 import {getScoreSetShortName} from '@/lib/score-sets'
 import {type GenomeAssembly, GENOME_ASSEMBLY_NAMES, gnomadIdToHgvs, otherAssembly} from '@/lib/gnomad'
 import {clinVarHgvsSearchStringRegex, hgvsSearchStringRegex} from '@/lib/mave-hgvs'
-import {SEARCH_COLORS} from '@/data/search'
+import {SEARCH_COLORS, SEARCH_PLACEHOLDERS} from '@/data/search'
 import {AVE_CLINICAL_APPLICATION} from '@/lib/links'
 import {
   HOW_IT_WORKS_STEPS,
@@ -877,6 +878,11 @@ export default defineComponent({
       return SEARCH_COLORS[this.searchType || 'any'] || SEARCH_COLORS.any
     },
     currentPlaceholder(): string {
+      // A specific search type prompts with one of its own examples, but "Any" accepts too many shapes for one
+      // example to describe, so it shares the homepage's wording instead.
+      if (this.searchType === 'any') {
+        return SEARCH_PLACEHOLDERS.any.full
+      }
       const option = this.searchTypeOptions.find((o) => o.code === this.searchType)
       return option?.examples?.[0] || 'Enter a value'
     },
@@ -1217,6 +1223,21 @@ export default defineComponent({
             return
           }
           responseData = await getAlleleByClinVar(searchStr)
+        } else if (searchType === 'geneSymbol') {
+          const geneSymbol = searchStr.toUpperCase()
+          if (!geneSymbolRegex.test(geneSymbol)) {
+            this.toast.add({
+              severity: 'error',
+              summary: 'Invalid search',
+              detail: `Please provide a valid gene symbol (e.g. ${this.searchTypeOptions.find((o) => o.code === searchType)?.examples?.join(', ')})`,
+              life: 10000
+            })
+            return
+          }
+          // Replace rather than push: this screen re-runs its search from the query params on mount, so a pushed
+          // entry would send the back button straight here and forward again to the gene page.
+          this.router.replace({name: 'gene', params: {symbol: geneSymbol}})
+          return
         } else if (searchType === 'gnomadId') {
           if (!gnomadIdRegex.test(searchStr)) {
             this.toast.add({

--- a/src/components/screens/SearchVariantsScreen.vue
+++ b/src/components/screens/SearchVariantsScreen.vue
@@ -676,6 +676,7 @@ import {
   type AlleleResult,
   clinGenAlleleIdRegex,
   clinVarVariationIdRegex,
+  gnomadIdRegex,
   rsIdRegex,
   vrsDigestRegex,
   scoreSetUrnFromVariantUrn,
@@ -695,7 +696,14 @@ import {
   VARIANT_TYPE_OPTIONS,
   ALLELE_OPTIONS
 } from '@/data/mavemd'
-import {getAlleleByCaId, getAlleleByHgvs, getAlleleByDbSnp, getAlleleByClinVar, getGeneBySymbol} from '@/api/clingen'
+import {
+  getAlleleByCaId,
+  getAlleleByHgvs,
+  getAlleleByDbSnp,
+  getAlleleByClinVar,
+  getAlleleByGnomad,
+  getGeneBySymbol
+} from '@/api/clingen'
 import {getCollection, getErrorResponse, lookupVariantsByClingenId} from '@/api/mavedb'
 import {lookupVariantsByVrsDigest} from '@/api/mavedb/variants'
 import {useEntityCache} from '@/composables/entity-cache'
@@ -1087,6 +1095,17 @@ export default defineComponent({
             return
           }
           responseData = await getAlleleByClinVar(searchStr)
+        } else if (searchType === 'gnomadId') {
+          if (!gnomadIdRegex.test(searchStr)) {
+            this.toast.add({
+              severity: 'error',
+              summary: 'Invalid search',
+              detail: `Please provide a valid gnomAD variant ID (e.g. ${this.searchTypeOptions.find((o) => o.code === searchType)?.examples?.join(', ')})`,
+              life: 10000
+            })
+            return
+          }
+          responseData = await getAlleleByGnomad(searchStr)
         } else if (searchType === 'vrsDigest') {
           if (!vrsDigestRegex.test(searchStr)) {
             this.toast.add({

--- a/src/data/mavemd.ts
+++ b/src/data/mavemd.ts
@@ -9,7 +9,8 @@ export const SEARCH_TYPE_OPTIONS = [
   {code: 'clinGenAlleleId', name: 'ClinGen Allele ID', examples: ['CA10590195', 'PA2579983208']},
   {code: 'dbSnpRsId', name: 'dbSNP rsID', examples: ['rs900082291', '900082291']},
   {code: 'clinVarVariationId', name: 'ClinVar Variation ID', examples: ['869058']},
-  {code: 'vrsDigest', name: 'VRS Digest', examples: ['ga4gh:VA.-US8Ap1kUYvW3DzeFEYrNXgk3Xk9toKy']}
+  {code: 'vrsDigest', name: 'VRS Digest', examples: ['ga4gh:VA.-US8Ap1kUYvW3DzeFEYrNXgk3Xk9toKy']},
+  {code: 'gnomadId', name: 'gnomAD ID', examples: ['17-7676154-G-C', '17-7579472-G-C']}
 ]
 
 /** Variant type options for guided search. */

--- a/src/data/mavemd.ts
+++ b/src/data/mavemd.ts
@@ -11,7 +11,8 @@ export const SEARCH_TYPE_OPTIONS = [
   {code: 'dbSnpRsId', name: 'dbSNP rsID', examples: ['rs900082291', '900082291']},
   {code: 'clinVarVariationId', name: 'ClinVar Variation ID', examples: ['869058']},
   {code: 'vrsDigest', name: 'VRS Digest', examples: ['ga4gh:VA.-US8Ap1kUYvW3DzeFEYrNXgk3Xk9toKy']},
-  {code: 'gnomadId', name: 'gnomAD ID', examples: ['17-7676154-G-C', '17-7579472-G-C']}
+  {code: 'gnomadId', name: 'gnomAD ID', examples: ['17-7676154-G-C', '17-7579472-G-C']},
+  {code: 'geneSymbol', name: 'Gene symbol', examples: ['BRCA1', 'TP53']}
 ]
 
 /** Variant type options for guided search. */

--- a/src/data/mavemd.ts
+++ b/src/data/mavemd.ts
@@ -5,6 +5,7 @@ export const MAVEMD_COLLECTION_URN = 'urn:mavedb:collection-603dafbf-4a3f-4d70-a
 
 /** Available search types on the MaveMD search page, with example queries. */
 export const SEARCH_TYPE_OPTIONS = [
+  {code: 'any', name: 'Any', examples: ['NP_000242.1:p.Asn566Thr', 'CA10590195', 'rs900082291', '17-7676154-G-C']},
   {code: 'hgvs', name: 'HGVS', examples: ['ENST00000473961.6:c.-19-2A>T', 'NP_000242.1:p.Asn566Thr']},
   {code: 'clinGenAlleleId', name: 'ClinGen Allele ID', examples: ['CA10590195', 'PA2579983208']},
   {code: 'dbSnpRsId', name: 'dbSNP rsID', examples: ['rs900082291', '900082291']},

--- a/src/data/search.test.ts
+++ b/src/data/search.test.ts
@@ -1,0 +1,51 @@
+import {describe, expect, it} from 'vitest'
+
+import {SEARCH_COLORS, SEARCH_PLACEHOLDERS, SEARCH_TYPES} from './search'
+import {SEARCH_TYPE_OPTIONS} from './mavemd'
+import {detectSearchType} from '@/lib/mavemd'
+
+/**
+ * A dbSNP rsID may be written without its rs prefix, but only the ClinVar pattern matches a bare number, so this
+ * example resolves to ClinVar under the "Any" search type. Searching it needs the dbSNP type chosen explicitly.
+ */
+const AMBIGUOUS_EXAMPLES: Record<string, string> = {'900082291': 'clinVarVariationId'}
+
+describe('SEARCH_TYPE_OPTIONS examples', () => {
+  it('each resolve to their own search type under "Any"', () => {
+    for (const {code, examples} of SEARCH_TYPE_OPTIONS) {
+      if (code === 'any') continue
+      for (const example of examples ?? []) {
+        expect(detectSearchType(example), example).toBe(AMBIGUOUS_EXAMPLES[example] ?? code)
+      }
+    }
+  })
+
+  it('resolve the examples "Any" itself advertises', () => {
+    const anyExamples = SEARCH_TYPE_OPTIONS.find((option) => option.code === 'any')?.examples ?? []
+    expect(anyExamples.length).toBeGreaterThan(0)
+    for (const example of anyExamples) {
+      expect(detectSearchType(example), example).not.toBeNull()
+    }
+  })
+})
+
+describe('SEARCH_TYPES', () => {
+  it('has a color for every type, which the homepage dropdown indexes without a fallback', () => {
+    for (const {value} of SEARCH_TYPES) {
+      expect(SEARCH_COLORS[value], value).toBeDefined()
+    }
+  })
+
+  it('has a placeholder for every type', () => {
+    for (const {value} of SEARCH_TYPES) {
+      expect(SEARCH_PLACEHOLDERS[value], value).toBeDefined()
+    }
+  })
+
+  it('uses values the MaveMD search screen recognizes, since they pass through as query params', () => {
+    const supported = SEARCH_TYPE_OPTIONS.map((option) => option.code)
+    for (const {value} of SEARCH_TYPES) {
+      expect(supported, value).toContain(value)
+    }
+  })
+})

--- a/src/data/search.ts
+++ b/src/data/search.ts
@@ -10,7 +10,8 @@ export const SEARCH_TYPES = [
   {value: 'dbSnpRsId', label: 'dbSNP'},
   {value: 'clinVarVariationId', label: 'ClinVar'},
   {value: 'clinGenAlleleId', label: 'ClinGen'},
-  {value: 'vrsDigest', label: 'VRS'}
+  {value: 'vrsDigest', label: 'VRS'},
+  {value: 'gnomadId', label: 'gnomAD'}
 ]
 
 export const SEARCH_COLORS: Record<string, {accent: string; bg: string; activeText?: string}> = {
@@ -18,7 +19,8 @@ export const SEARCH_COLORS: Record<string, {accent: string; bg: string; activeTe
   dbSnpRsId: {accent: 'var(--color-dbsnp)', bg: 'var(--color-dbsnp-light)'},
   clinVarVariationId: {accent: 'var(--color-clinvar)', bg: 'var(--color-clinvar-light)'},
   clinGenAlleleId: {accent: 'var(--color-orange-cta)', bg: 'var(--color-orange-light)'},
-  vrsDigest: {accent: 'var(--color-ga4gh)', bg: 'var(--color-ga4gh-light)', activeText: '#ffffff'}
+  vrsDigest: {accent: 'var(--color-ga4gh)', bg: 'var(--color-ga4gh-light)', activeText: '#ffffff'},
+  gnomadId: {accent: 'var(--color-gnomad)', bg: 'var(--color-gnomad-light)', activeText: '#ffffff'}
 }
 
 export const SEARCH_PLACEHOLDERS: Record<string, {full: string; short: string}> = {
@@ -26,5 +28,6 @@ export const SEARCH_PLACEHOLDERS: Record<string, {full: string; short: string}> 
   dbSnpRsId: {full: 'Search by dbSNP rsID, e.g. rs28897672', short: 'Search by dbSNP rsID'},
   clinVarVariationId: {full: 'Search by ClinVar Variation ID, e.g. 37610', short: 'Search by ClinVar ID'},
   clinGenAlleleId: {full: 'Search by ClinGen Allele ID, e.g. CA003746', short: 'Search by ClinGen Allele ID'},
-  vrsDigest: {full: 'Search by VRS ID, e.g. ga4gh:VA.n9ax-9x6gOC0OEt73VMYqCBfqfxG1XUH', short: 'Search by VRS ID'}
+  vrsDigest: {full: 'Search by VRS ID, e.g. ga4gh:VA.n9ax-9x6gOC0OEt73VMYqCBfqfxG1XUH', short: 'Search by VRS ID'},
+  gnomadId: {full: 'Search by gnomAD ID, e.g. 17-7676154-G-C', short: 'Search by gnomAD ID'}
 }

--- a/src/data/search.ts
+++ b/src/data/search.ts
@@ -12,7 +12,8 @@ export const SEARCH_TYPES = [
   {value: 'clinVarVariationId', label: 'ClinVar'},
   {value: 'clinGenAlleleId', label: 'ClinGen'},
   {value: 'vrsDigest', label: 'VRS'},
-  {value: 'gnomadId', label: 'gnomAD'}
+  {value: 'gnomadId', label: 'gnomAD'},
+  {value: 'geneSymbol', label: 'Gene'}
 ]
 
 export const SEARCH_COLORS: Record<string, {accent: string; bg: string; activeText?: string}> = {
@@ -22,15 +23,17 @@ export const SEARCH_COLORS: Record<string, {accent: string; bg: string; activeTe
   clinVarVariationId: {accent: 'var(--color-clinvar)', bg: 'var(--color-clinvar-light)'},
   clinGenAlleleId: {accent: 'var(--color-orange-cta)', bg: 'var(--color-orange-light)'},
   vrsDigest: {accent: 'var(--color-ga4gh)', bg: 'var(--color-ga4gh-light)', activeText: '#ffffff'},
-  gnomadId: {accent: 'var(--color-gnomad)', bg: 'var(--color-gnomad-light)', activeText: '#ffffff'}
+  gnomadId: {accent: 'var(--color-gnomad)', bg: 'var(--color-gnomad-light)', activeText: '#ffffff'},
+  geneSymbol: {accent: 'var(--color-gene)', bg: 'var(--color-gene-light)', activeText: '#ffffff'}
 }
 
 export const SEARCH_PLACEHOLDERS: Record<string, {full: string; short: string}> = {
-  any: {full: 'Search by any variant identifier', short: 'Search by any identifier'},
+  any: {full: 'Search by any variant identifier or gene symbol', short: 'Search by any identifier'},
   hgvs: {full: 'Search by HGVS, e.g. NM_007294.3:c.211A>G', short: 'Search by HGVS'},
   dbSnpRsId: {full: 'Search by dbSNP rsID, e.g. rs28897672', short: 'Search by dbSNP rsID'},
   clinVarVariationId: {full: 'Search by ClinVar Variation ID, e.g. 37610', short: 'Search by ClinVar ID'},
   clinGenAlleleId: {full: 'Search by ClinGen Allele ID, e.g. CA003746', short: 'Search by ClinGen Allele ID'},
   vrsDigest: {full: 'Search by VRS ID, e.g. ga4gh:VA.n9ax-9x6gOC0OEt73VMYqCBfqfxG1XUH', short: 'Search by VRS ID'},
-  gnomadId: {full: 'Search by gnomAD ID, e.g. 17-7676154-G-C', short: 'Search by gnomAD ID'}
+  gnomadId: {full: 'Search by gnomAD ID, e.g. 17-7676154-G-C', short: 'Search by gnomAD ID'},
+  geneSymbol: {full: 'Search by gene symbol, e.g. BRCA1', short: 'Search by gene symbol'}
 }

--- a/src/data/search.ts
+++ b/src/data/search.ts
@@ -6,6 +6,7 @@
  */
 
 export const SEARCH_TYPES = [
+  {value: 'any', label: 'Any'},
   {value: 'hgvs', label: 'HGVS'},
   {value: 'dbSnpRsId', label: 'dbSNP'},
   {value: 'clinVarVariationId', label: 'ClinVar'},
@@ -15,6 +16,7 @@ export const SEARCH_TYPES = [
 ]
 
 export const SEARCH_COLORS: Record<string, {accent: string; bg: string; activeText?: string}> = {
+  any: {accent: 'var(--color-any)', bg: 'var(--color-any-light)', activeText: '#ffffff'},
   hgvs: {accent: 'var(--color-sage)', bg: 'var(--color-sage-light)'},
   dbSnpRsId: {accent: 'var(--color-dbsnp)', bg: 'var(--color-dbsnp-light)'},
   clinVarVariationId: {accent: 'var(--color-clinvar)', bg: 'var(--color-clinvar-light)'},
@@ -24,6 +26,7 @@ export const SEARCH_COLORS: Record<string, {accent: string; bg: string; activeTe
 }
 
 export const SEARCH_PLACEHOLDERS: Record<string, {full: string; short: string}> = {
+  any: {full: 'Search by any variant identifier', short: 'Search by any identifier'},
   hgvs: {full: 'Search by HGVS, e.g. NM_007294.3:c.211A>G', short: 'Search by HGVS'},
   dbSnpRsId: {full: 'Search by dbSNP rsID, e.g. rs28897672', short: 'Search by dbSNP rsID'},
   clinVarVariationId: {full: 'Search by ClinVar Variation ID, e.g. 37610', short: 'Search by ClinVar ID'},

--- a/src/data/search.ts
+++ b/src/data/search.ts
@@ -17,8 +17,8 @@ export const SEARCH_TYPES = [
 ]
 
 export const SEARCH_COLORS: Record<string, {accent: string; bg: string; activeText?: string}> = {
-  any: {accent: 'var(--color-any)', bg: 'var(--color-any-light)', activeText: '#ffffff'},
-  hgvs: {accent: 'var(--color-sage)', bg: 'var(--color-sage-light)'},
+  any: {accent: 'var(--color-sage)', bg: 'var(--color-sage-light)'},
+  hgvs: {accent: 'var(--color-hgvs)', bg: 'var(--color-hgvs-light)', activeText: '#ffffff'},
   dbSnpRsId: {accent: 'var(--color-dbsnp)', bg: 'var(--color-dbsnp-light)'},
   clinVarVariationId: {accent: 'var(--color-clinvar)', bg: 'var(--color-clinvar-light)'},
   clinGenAlleleId: {accent: 'var(--color-orange-cta)', bg: 'var(--color-orange-light)'},

--- a/src/lib/gnomad.test.ts
+++ b/src/lib/gnomad.test.ts
@@ -1,10 +1,10 @@
 import {describe, expect, it} from 'vitest'
 
-import {CHROMOSOME_REFSEQ_IDS, gnomadIdToHgvsCandidates, parseGnomadId} from './gnomad'
+import {CHROMOSOME_REFSEQ_IDS, gnomadIdToHgvs, gnomadIdToHgvsCandidates, otherAssembly, parseGnomadId} from './gnomad'
 
 /** The GRCh38 translation of a gnomAD ID, which is the one tried first. */
 function grch38Hgvs(gnomadId: string): string | undefined {
-  return gnomadIdToHgvsCandidates(gnomadId)[0]
+  return gnomadIdToHgvsCandidates(gnomadId)[0]?.hgvs
 }
 
 describe('parseGnomadId', () => {
@@ -80,15 +80,18 @@ describe('gnomadIdToHgvsCandidates', () => {
     expect(grch38Hgvs('1-55516888-AT-T')).toBe('NC_000001.11:g.55516888del')
   })
 
-  it('returns GRCh38 first, then GRCh37', () => {
+  it('returns GRCh38 first, then GRCh37, each labelled with its assembly', () => {
     expect(gnomadIdToHgvsCandidates('17-7676154-G-C')).toEqual([
-      'NC_000017.11:g.7676154G>C',
-      'NC_000017.10:g.7676154G>C'
+      {assembly: 'grch38', hgvs: 'NC_000017.11:g.7676154G>C'},
+      {assembly: 'grch37', hgvs: 'NC_000017.10:g.7676154G>C'}
     ])
   })
 
   it('uses the shared rCRS accession for the mitochondrion in both assemblies', () => {
-    expect(gnomadIdToHgvsCandidates('M-8993-T-G')).toEqual(['NC_012920.1:g.8993T>G', 'NC_012920.1:g.8993T>G'])
+    expect(gnomadIdToHgvsCandidates('M-8993-T-G')).toEqual([
+      {assembly: 'grch38', hgvs: 'NC_012920.1:g.8993T>G'},
+      {assembly: 'grch37', hgvs: 'NC_012920.1:g.8993T>G'}
+    ])
   })
 
   it('returns no candidates for an unparseable ID', () => {
@@ -98,6 +101,24 @@ describe('gnomadIdToHgvsCandidates', () => {
   it('returns no candidates when the alleles describe no change', () => {
     expect(gnomadIdToHgvsCandidates('1-55516888-A-A')).toEqual([])
     expect(gnomadIdToHgvsCandidates('1-55516888-AT-AT')).toEqual([])
+  })
+})
+
+describe('gnomadIdToHgvs', () => {
+  it('reads an ID under the requested assembly', () => {
+    expect(gnomadIdToHgvs('17-7676154-G-C', 'grch38')).toBe('NC_000017.11:g.7676154G>C')
+    expect(gnomadIdToHgvs('17-7676154-G-C', 'grch37')).toBe('NC_000017.10:g.7676154G>C')
+  })
+
+  it('returns null for an ID it cannot translate', () => {
+    expect(gnomadIdToHgvs('not-an-id', 'grch38')).toBeNull()
+  })
+})
+
+describe('otherAssembly', () => {
+  it('pairs the two assemblies', () => {
+    expect(otherAssembly('grch38')).toBe('grch37')
+    expect(otherAssembly('grch37')).toBe('grch38')
   })
 })
 

--- a/src/lib/gnomad.test.ts
+++ b/src/lib/gnomad.test.ts
@@ -1,0 +1,125 @@
+import {describe, expect, it} from 'vitest'
+
+import {CHROMOSOME_REFSEQ_IDS, gnomadIdToHgvsCandidates, parseGnomadId} from './gnomad'
+
+/** The GRCh38 translation of a gnomAD ID, which is the one tried first. */
+function grch38Hgvs(gnomadId: string): string | undefined {
+  return gnomadIdToHgvsCandidates(gnomadId)[0]
+}
+
+describe('parseGnomadId', () => {
+  it('parses a substitution', () => {
+    expect(parseGnomadId('X-41334274-A-C')).toEqual({
+      chromosome: 'X',
+      position: 41334274,
+      referenceAllele: 'A',
+      alternateAllele: 'C'
+    })
+  })
+
+  it('uppercases alleles and ignores surrounding whitespace', () => {
+    expect(parseGnomadId('  1-11796321-g-a  ')).toEqual({
+      chromosome: '1',
+      position: 11796321,
+      referenceAllele: 'G',
+      alternateAllele: 'A'
+    })
+  })
+
+  it('normalizes the mitochondrion to a single key', () => {
+    expect(parseGnomadId('M-8993-T-G')?.chromosome).toBe('M')
+    expect(parseGnomadId('MT-8993-T-G')?.chromosome).toBe('M')
+  })
+
+  it('rejects malformed IDs', () => {
+    for (const id of ['X-41334274-A', 'X:41334274:A:C', 'chr1-11796321-G-A', '1-11796321-N-A', 'rs1801133', '']) {
+      expect(parseGnomadId(id), id).toBeNull()
+    }
+  })
+
+  it('rejects chromosomes that do not exist', () => {
+    for (const id of ['0-100-A-C', '23-100-A-C', 'Z-100-A-C']) {
+      expect(parseGnomadId(id), id).toBeNull()
+    }
+  })
+})
+
+describe('gnomadIdToHgvsCandidates', () => {
+  it('translates a substitution', () => {
+    expect(grch38Hgvs('X-41334274-A-C')).toBe('NC_000023.11:g.41334274A>C')
+  })
+
+  it('translates an insertion', () => {
+    expect(grch38Hgvs('1-55516888-G-GA')).toBe('NC_000001.11:g.55516888_55516889insA')
+  })
+
+  it('translates a multi-base insertion', () => {
+    expect(grch38Hgvs('1-55516888-G-GATC')).toBe('NC_000001.11:g.55516888_55516889insATC')
+  })
+
+  it('translates a single-base deletion', () => {
+    expect(grch38Hgvs('1-55516888-GA-G')).toBe('NC_000001.11:g.55516889del')
+  })
+
+  it('translates a multi-base deletion', () => {
+    expect(grch38Hgvs('1-55516888-GATC-G')).toBe('NC_000001.11:g.55516889_55516891del')
+  })
+
+  it('translates a delins', () => {
+    expect(grch38Hgvs('1-55516888-GA-CT')).toBe('NC_000001.11:g.55516888_55516889delinsCT')
+  })
+
+  it('translates a single-base delins', () => {
+    expect(grch38Hgvs('1-55516888-G-CT')).toBe('NC_000001.11:g.55516888delinsCT')
+  })
+
+  it('trims a common suffix as well as a common prefix', () => {
+    // AGA>AA leaves only the G at 55516889 deleted.
+    expect(grch38Hgvs('1-55516888-AGA-AA')).toBe('NC_000001.11:g.55516889del')
+    // AT>T leaves only the A at 55516888 deleted.
+    expect(grch38Hgvs('1-55516888-AT-T')).toBe('NC_000001.11:g.55516888del')
+  })
+
+  it('returns GRCh38 first, then GRCh37', () => {
+    expect(gnomadIdToHgvsCandidates('17-7676154-G-C')).toEqual([
+      'NC_000017.11:g.7676154G>C',
+      'NC_000017.10:g.7676154G>C'
+    ])
+  })
+
+  it('uses the shared rCRS accession for the mitochondrion in both assemblies', () => {
+    expect(gnomadIdToHgvsCandidates('M-8993-T-G')).toEqual(['NC_012920.1:g.8993T>G', 'NC_012920.1:g.8993T>G'])
+  })
+
+  it('returns no candidates for an unparseable ID', () => {
+    expect(gnomadIdToHgvsCandidates('not-an-id')).toEqual([])
+  })
+
+  it('returns no candidates when the alleles describe no change', () => {
+    expect(gnomadIdToHgvsCandidates('1-55516888-A-A')).toEqual([])
+    expect(gnomadIdToHgvsCandidates('1-55516888-AT-AT')).toEqual([])
+  })
+})
+
+describe('CHROMOSOME_REFSEQ_IDS', () => {
+  it('covers all 24 chromosomes plus the mitochondrion', () => {
+    expect(Object.keys(CHROMOSOME_REFSEQ_IDS)).toHaveLength(25)
+  })
+
+  it('assigns a distinct accession to every chromosome within an assembly', () => {
+    for (const assembly of ['grch38', 'grch37'] as const) {
+      const accessions = Object.values(CHROMOSOME_REFSEQ_IDS).map((ids) => ids[assembly])
+      expect(new Set(accessions).size, assembly).toBe(accessions.length)
+    }
+  })
+
+  it('uses different accessions per assembly for every chromosome but the mitochondrion', () => {
+    for (const [chromosome, ids] of Object.entries(CHROMOSOME_REFSEQ_IDS)) {
+      if (chromosome === 'M') {
+        expect(ids.grch38).toBe(ids.grch37)
+      } else {
+        expect(ids.grch38, chromosome).not.toBe(ids.grch37)
+      }
+    }
+  })
+})

--- a/src/lib/gnomad.ts
+++ b/src/lib/gnomad.ts
@@ -13,6 +13,17 @@ export const GNOMAD_ASSEMBLY_SEARCH_ORDER = ['grch38', 'grch37'] as const
 
 export type GenomeAssembly = (typeof GNOMAD_ASSEMBLY_SEARCH_ORDER)[number]
 
+/** Display names for the assemblies, for use in user-facing text. */
+export const GENOME_ASSEMBLY_NAMES: Record<GenomeAssembly, string> = {
+  grch38: 'GRCh38',
+  grch37: 'GRCh37'
+}
+
+/** The assembly to offer as an alternative interpretation of the same gnomAD ID. */
+export function otherAssembly(assembly: GenomeAssembly): GenomeAssembly {
+  return assembly === 'grch38' ? 'grch37' : 'grch38'
+}
+
 /**
  * RefSeq chromosome accessions per assembly, keyed by gnomAD chromosome name.
  *
@@ -128,11 +139,17 @@ function describeGenomicChange(position: number, referenceAllele: string, altern
   return reference.length === 1 ? `g.${start}delins${alternate}` : `g.${start}_${end}delins${alternate}`
 }
 
+/** An HGVS reading of a gnomAD ID, valid only if the ID's coordinates belong to `assembly`. */
+export interface GnomadHgvsCandidate {
+  assembly: GenomeAssembly
+  hgvs: string
+}
+
 /**
  * Translate a gnomAD variant ID into genomic HGVS strings, one per supported assembly, in the order they should be
  * tried. Returns an empty array if the ID cannot be translated.
  */
-export function gnomadIdToHgvsCandidates(gnomadId: string): string[] {
+export function gnomadIdToHgvsCandidates(gnomadId: string): GnomadHgvsCandidate[] {
   const variant = parseGnomadId(gnomadId)
   if (!variant) {
     return []
@@ -141,7 +158,13 @@ export function gnomadIdToHgvsCandidates(gnomadId: string): string[] {
   if (!description) {
     return []
   }
-  return GNOMAD_ASSEMBLY_SEARCH_ORDER.map(
-    (assembly) => `${CHROMOSOME_REFSEQ_IDS[variant.chromosome][assembly]}:${description}`
-  )
+  return GNOMAD_ASSEMBLY_SEARCH_ORDER.map((assembly) => ({
+    assembly,
+    hgvs: `${CHROMOSOME_REFSEQ_IDS[variant.chromosome][assembly]}:${description}`
+  }))
+}
+
+/** The HGVS reading of a gnomAD ID under one assembly, or null if the ID cannot be translated. */
+export function gnomadIdToHgvs(gnomadId: string, assembly: GenomeAssembly): string | null {
+  return gnomadIdToHgvsCandidates(gnomadId).find((candidate) => candidate.assembly === assembly)?.hgvs ?? null
 }

--- a/src/lib/gnomad.ts
+++ b/src/lib/gnomad.ts
@@ -1,0 +1,147 @@
+import {gnomadIdRegex} from './mavemd'
+
+/**
+ * Translation of gnomAD variant IDs (e.g. 1-11796321-G-A) into genomic HGVS.
+ *
+ * A gnomAD ID is a VCF-style chromosome-position-reference-alternate tuple that doesn't name the reference genome its
+ * coordinates belong to, so it is translated against each supported assembly in turn and the ClinGen Allele Registry
+ * decides which one the coordinates actually match.
+ */
+
+/** Assemblies tried, in order, when resolving a gnomAD ID. */
+export const GNOMAD_ASSEMBLY_SEARCH_ORDER = ['grch38', 'grch37'] as const
+
+export type GenomeAssembly = (typeof GNOMAD_ASSEMBLY_SEARCH_ORDER)[number]
+
+/**
+ * RefSeq chromosome accessions per assembly, keyed by gnomAD chromosome name.
+ *
+ * These are GRCh37 accessions rather than UCSC hg19 ones, which is a distinction that matters only for the
+ * mitochondrion: GRCh37 and GRCh38 both use the revised Cambridge Reference Sequence, so it shares one accession here,
+ * whereas UCSC hg19 uses the older NC_001807 sequence. gnomAD's mitochondrial calls are GRCh38/rCRS in any case.
+ */
+export const CHROMOSOME_REFSEQ_IDS: Record<string, Record<GenomeAssembly, string>> = {
+  '1': {grch38: 'NC_000001.11', grch37: 'NC_000001.10'},
+  '2': {grch38: 'NC_000002.12', grch37: 'NC_000002.11'},
+  '3': {grch38: 'NC_000003.12', grch37: 'NC_000003.11'},
+  '4': {grch38: 'NC_000004.12', grch37: 'NC_000004.11'},
+  '5': {grch38: 'NC_000005.10', grch37: 'NC_000005.9'},
+  '6': {grch38: 'NC_000006.12', grch37: 'NC_000006.11'},
+  '7': {grch38: 'NC_000007.14', grch37: 'NC_000007.13'},
+  '8': {grch38: 'NC_000008.11', grch37: 'NC_000008.10'},
+  '9': {grch38: 'NC_000009.12', grch37: 'NC_000009.11'},
+  '10': {grch38: 'NC_000010.11', grch37: 'NC_000010.10'},
+  '11': {grch38: 'NC_000011.10', grch37: 'NC_000011.9'},
+  '12': {grch38: 'NC_000012.12', grch37: 'NC_000012.11'},
+  '13': {grch38: 'NC_000013.11', grch37: 'NC_000013.10'},
+  '14': {grch38: 'NC_000014.9', grch37: 'NC_000014.8'},
+  '15': {grch38: 'NC_000015.10', grch37: 'NC_000015.9'},
+  '16': {grch38: 'NC_000016.10', grch37: 'NC_000016.9'},
+  '17': {grch38: 'NC_000017.11', grch37: 'NC_000017.10'},
+  '18': {grch38: 'NC_000018.10', grch37: 'NC_000018.9'},
+  '19': {grch38: 'NC_000019.10', grch37: 'NC_000019.9'},
+  '20': {grch38: 'NC_000020.11', grch37: 'NC_000020.10'},
+  '21': {grch38: 'NC_000021.9', grch37: 'NC_000021.8'},
+  '22': {grch38: 'NC_000022.11', grch37: 'NC_000022.10'},
+  X: {grch38: 'NC_000023.11', grch37: 'NC_000023.10'},
+  Y: {grch38: 'NC_000024.10', grch37: 'NC_000024.9'},
+  M: {grch38: 'NC_012920.1', grch37: 'NC_012920.1'}
+}
+
+/** A gnomAD variant ID parsed into its parts, with the chromosome normalized to a {@link CHROMOSOME_REFSEQ_IDS} key. */
+export interface GnomadVariant {
+  chromosome: string
+  position: number
+  referenceAllele: string
+  alternateAllele: string
+}
+
+/** Parse a gnomAD variant ID. Returns null if it is malformed or names a chromosome we have no accessions for. */
+export function parseGnomadId(gnomadId: string): GnomadVariant | null {
+  const match = gnomadIdRegex.exec(gnomadId.trim())
+  if (!match) {
+    return null
+  }
+  const [, chromosome, position, referenceAllele, alternateAllele] = match
+  // gnomAD writes the mitochondrion as either M or MT.
+  const normalizedChromosome = chromosome.toUpperCase() === 'MT' ? 'M' : chromosome.toUpperCase()
+  if (!(normalizedChromosome in CHROMOSOME_REFSEQ_IDS)) {
+    return null
+  }
+  return {
+    chromosome: normalizedChromosome,
+    position: parseInt(position),
+    referenceAllele: referenceAllele.toUpperCase(),
+    alternateAllele: alternateAllele.toUpperCase()
+  }
+}
+
+/**
+ * Build the HGVS description (the part after the colon) for a VCF-style change at a genomic position.
+ *
+ * gnomAD anchors indels on the base preceding the change, so the alleles are first reduced to a minimal
+ * representation: the common prefix is trimmed before any common suffix, which keeps the resulting coordinates as far
+ * 3' as the input allows. The registry applies full HGVS 3' normalization on its end.
+ *
+ * @returns The description, or null if the reference and alternate alleles describe no change.
+ */
+function describeGenomicChange(position: number, referenceAllele: string, alternateAllele: string): string | null {
+  let reference = referenceAllele
+  let alternate = alternateAllele
+  let start = position
+
+  let prefixLength = 0
+  while (
+    prefixLength < reference.length &&
+    prefixLength < alternate.length &&
+    reference[prefixLength] === alternate[prefixLength]
+  ) {
+    prefixLength++
+  }
+  reference = reference.slice(prefixLength)
+  alternate = alternate.slice(prefixLength)
+  start += prefixLength
+
+  while (
+    reference.length > 0 &&
+    alternate.length > 0 &&
+    reference[reference.length - 1] === alternate[alternate.length - 1]
+  ) {
+    reference = reference.slice(0, -1)
+    alternate = alternate.slice(0, -1)
+  }
+
+  const end = start + reference.length - 1
+
+  if (reference.length === 0 && alternate.length === 0) {
+    return null
+  }
+  if (reference.length === 0) {
+    return `g.${start - 1}_${start}ins${alternate}`
+  }
+  if (alternate.length === 0) {
+    return reference.length === 1 ? `g.${start}del` : `g.${start}_${end}del`
+  }
+  if (reference.length === 1 && alternate.length === 1) {
+    return `g.${start}${reference}>${alternate}`
+  }
+  return reference.length === 1 ? `g.${start}delins${alternate}` : `g.${start}_${end}delins${alternate}`
+}
+
+/**
+ * Translate a gnomAD variant ID into genomic HGVS strings, one per supported assembly, in the order they should be
+ * tried. Returns an empty array if the ID cannot be translated.
+ */
+export function gnomadIdToHgvsCandidates(gnomadId: string): string[] {
+  const variant = parseGnomadId(gnomadId)
+  if (!variant) {
+    return []
+  }
+  const description = describeGenomicChange(variant.position, variant.referenceAllele, variant.alternateAllele)
+  if (!description) {
+    return []
+  }
+  return GNOMAD_ASSEMBLY_SEARCH_ORDER.map(
+    (assembly) => `${CHROMOSOME_REFSEQ_IDS[variant.chromosome][assembly]}:${description}`
+  )
+}

--- a/src/lib/mavemd.test.ts
+++ b/src/lib/mavemd.test.ts
@@ -1,0 +1,119 @@
+import {describe, expect, it} from 'vitest'
+
+import {detectSearchType, geneSymbolSearchTarget, gnomadIdRegex} from './mavemd'
+
+describe('detectSearchType', () => {
+  it('recognizes each supported identifier', () => {
+    const expected: [string, string][] = [
+      ['ga4gh:VA.-US8Ap1kUYvW3DzeFEYrNXgk3Xk9toKy', 'vrsDigest'],
+      ['CA10590195', 'clinGenAlleleId'],
+      ['PA2579983208', 'clinGenAlleleId'],
+      ['rs900082291', 'dbSnpRsId'],
+      ['17-7676154-G-C', 'gnomadId'],
+      ['1-55516888-G-GA', 'gnomadId'],
+      ['ENST00000473961.6:c.-19-2A>T', 'hgvs'],
+      ['NP_000242.1:p.Asn566Thr', 'hgvs'],
+      ['NM_007294.3(BRCA1):c.211A>G', 'hgvs'],
+      ['869058', 'clinVarVariationId'],
+      ['BRCA1', 'geneSymbol'],
+      ['TP53', 'geneSymbol'],
+      ['MYC', 'geneSymbol'],
+      ['HLA-A', 'geneSymbol'],
+      ['MT-CO1', 'geneSymbol'],
+      ['C1orf100', 'geneSymbol'],
+      ['IGH@', 'geneSymbol']
+    ]
+    for (const [searchString, searchType] of expected) {
+      expect(detectSearchType(searchString), searchString).toBe(searchType)
+    }
+  })
+
+  it('ignores surrounding whitespace', () => {
+    expect(detectSearchType('  CA10590195  ')).toBe('clinGenAlleleId')
+  })
+
+  it('prefers a VRS digest over HGVS, which its colon would otherwise match', () => {
+    expect(detectSearchType('ga4gh:VA.-US8Ap1kUYvW3DzeFEYrNXgk3Xk9toKy')).toBe('vrsDigest')
+  })
+
+  it('treats a bare number as a ClinVar Variation ID', () => {
+    // dbSNP rsIDs are also accepted without their rs prefix, but only the ClinVar pattern matches a bare number, so
+    // that is what an unprefixed number resolves to.
+    expect(detectSearchType('869058')).toBe('clinVarVariationId')
+    expect(detectSearchType('900082291')).toBe('clinVarVariationId')
+  })
+
+  it('detects a gene symbol case-insensitively, since the search uppercases it', () => {
+    expect(detectSearchType('brca1')).toBe('geneSymbol')
+    expect(detectSearchType('  Tp53  ')).toBe('geneSymbol')
+  })
+
+  it('prefers the variant identifier where a gene symbol collides with one', () => {
+    // CA1-CA14 (carbonic anhydrases) and RS1 (retinoschisin 1) are real gene symbols that also satisfy the ClinGen
+    // and dbSNP patterns. The variant identifier wins, so reaching those gene pages needs the type chosen explicitly.
+    expect(detectSearchType('CA9')).toBe('clinGenAlleleId')
+    expect(detectSearchType('RS1')).toBe('dbSnpRsId')
+  })
+
+  it('reads a hyphenated string as a gene symbol, which it cannot be told apart from', () => {
+    // A mistyped ClinGen ID has the same shape as HLA-A or MT-CO1, so it resolves to a gene page rather than an error.
+    expect(detectSearchType('CA-10590195')).toBe('geneSymbol')
+  })
+
+  it('returns null for a string resembling no supported identifier', () => {
+    for (const searchString of ['', '   ', 'not an identifier', 'BRCA1/2', '???']) {
+      expect(detectSearchType(searchString), JSON.stringify(searchString)).toBeNull()
+    }
+  })
+})
+
+describe('geneSymbolSearchTarget', () => {
+  it('uppercases the symbol when the gene symbol type is chosen', () => {
+    expect(geneSymbolSearchTarget('brca1', 'geneSymbol')).toBe('BRCA1')
+    expect(geneSymbolSearchTarget('  tp53  ', 'geneSymbol')).toBe('TP53')
+  })
+
+  it('detects a gene symbol under the "Any" type', () => {
+    expect(geneSymbolSearchTarget('brca1', 'any')).toBe('BRCA1')
+  })
+
+  it('returns null when the search is for something else', () => {
+    expect(geneSymbolSearchTarget('CA10590195', 'any')).toBeNull()
+    expect(geneSymbolSearchTarget('17-7676154-G-C', 'any')).toBeNull()
+    expect(geneSymbolSearchTarget('BRCA1', 'hgvs')).toBeNull()
+    expect(geneSymbolSearchTarget('', 'geneSymbol')).toBeNull()
+    expect(geneSymbolSearchTarget('   ', 'any')).toBeNull()
+  })
+
+  it('returns a malformed symbol for the caller to reject, when the type was chosen explicitly', () => {
+    // Only the "Any" path has already applied geneSymbolRegex, so this is what callers must still validate.
+    expect(geneSymbolSearchTarget('BRCA1/2', 'geneSymbol')).toBe('BRCA1/2')
+    expect(geneSymbolSearchTarget('BRCA1/2', 'any')).toBeNull()
+  })
+})
+
+/**
+ * gnomad.test.ts already drives this pattern through parseGnomadId, covering alleles, indels, case and the malformed
+ * shapes. What it cannot cover is the chromosome alternation: parseGnomadId also gates on CHROMOSOME_REFSEQ_IDS, so it
+ * rejects an impossible chromosome whatever the pattern does. detectSearchType applies the pattern directly, with no
+ * such gate, so these tests exist for that path.
+ */
+describe('gnomadIdRegex', () => {
+  it('accepts chromosomes at the edges of the range', () => {
+    for (const id of ['1-11796321-G-A', '22-42126611-C-T', 'X-41334274-A-C', 'Y-2787175-C-T', 'MT-8993-T-G']) {
+      expect(gnomadIdRegex.test(id), id).toBe(true)
+    }
+  })
+
+  it('rejects chromosomes outside it', () => {
+    for (const id of ['0-11796321-G-A', '23-11796321-G-A', '30-11796321-G-A', 'Z-11796321-G-A']) {
+      expect(gnomadIdRegex.test(id), id).toBe(false)
+    }
+  })
+
+  it('anchors the whole string, rejecting a trailing field or an empty position', () => {
+    for (const id of ['1-11796321-G-A-T', '1--G-A']) {
+      expect(gnomadIdRegex.test(id), id).toBe(false)
+    }
+  })
+})

--- a/src/lib/mavemd.ts
+++ b/src/lib/mavemd.ts
@@ -79,6 +79,22 @@ export function detectSearchType(searchString: string): string | null {
   return SEARCH_TYPE_PATTERNS.find(([, pattern]) => pattern.test(trimmedSearchString))?.[0] ?? null
 }
 
+/**
+ * The gene symbol a search is for, standardized to uppercase, or null when the search isn't for a gene symbol.
+ *
+ * Uppercase is how gene pages are addressed everywhere else. A symbol arrived at through the "Any" type has already
+ * satisfied {@link geneSymbolRegex}; one from an explicitly chosen gene symbol search has not, so callers that care
+ * about malformed input should still validate what they get back.
+ */
+export function geneSymbolSearchTarget(searchText: string, searchType: string | null): string | null {
+  const trimmedSearchText = searchText.trim()
+  if (!trimmedSearchText) {
+    return null
+  }
+  const resolvedSearchType = searchType === 'any' ? detectSearchType(trimmedSearchText) : searchType
+  return resolvedSearchType === 'geneSymbol' ? trimmedSearchText.toUpperCase() : null
+}
+
 /** A single MANE coordinate extracted from a ClinGen transcript allele. */
 export interface ManeCoordinate {
   sequenceType: string

--- a/src/lib/mavemd.ts
+++ b/src/lib/mavemd.ts
@@ -33,6 +33,14 @@ export const clinVarVariationIdRegex = /^[0-9]+$/m
  */
 export const rsIdRegex = /^rs[0-9]+$/im
 
+/**
+ * Regular expression for valid gnomAD variant IDs that can be used in ClinGen searches.
+ *
+ * gnomAD writes these as chromosome-position-reference-alternate (e.g. 1-11796321-G-A). The capture groups are those
+ * four parts, in that order, which parseGnomadId relies on to translate an ID into HGVS.
+ */
+export const gnomadIdRegex = /^(1[0-9]|2[0-2]|[1-9]|X|Y|MT?)-([0-9]+)-([ACGT]+)-([ACGT]+)$/i
+
 /** A single MANE coordinate extracted from a ClinGen transcript allele. */
 export interface ManeCoordinate {
   sequenceType: string

--- a/src/lib/mavemd.ts
+++ b/src/lib/mavemd.ts
@@ -1,5 +1,6 @@
 import type {ClinGenAllele, ClinGenGenomicAllele, ClinGenTranscriptAllele} from '@/api/clingen'
 import type {components} from '@/schema/openapi'
+import {hgvsSearchStringRegex} from './mave-hgvs'
 
 type VariantMeasurement = components['schemas']['VariantEffectMeasurementWithShortScoreSet']
 
@@ -40,6 +41,32 @@ export const rsIdRegex = /^rs[0-9]+$/im
  * four parts, in that order, which parseGnomadId relies on to translate an ID into HGVS.
  */
 export const gnomadIdRegex = /^(1[0-9]|2[0-2]|[1-9]|X|Y|MT?)-([0-9]+)-([ACGT]+)-([ACGT]+)$/i
+
+/**
+ * Identifier patterns in the order they are tried when detecting what a search string is.
+ *
+ * Order matters wherever the patterns overlap. A VRS digest also satisfies the deliberately loose HGVS pattern, since
+ * that only asks for an identifier, a colon and a description, so it has to be recognized first. A bare number is a
+ * ClinVar Variation ID only once the more specific forms have been ruled out.
+ */
+const SEARCH_TYPE_PATTERNS: [string, RegExp][] = [
+  ['vrsDigest', vrsDigestRegex],
+  ['clinGenAlleleId', clinGenAlleleIdRegex],
+  ['dbSnpRsId', rsIdRegex],
+  ['gnomadId', gnomadIdRegex],
+  ['hgvs', hgvsSearchStringRegex],
+  ['clinVarVariationId', clinVarVariationIdRegex]
+]
+
+/**
+ * Work out which kind of identifier a search string is, for the "Any" search type.
+ *
+ * @returns The matching search type code, or null if the string resembles no supported identifier.
+ */
+export function detectSearchType(searchString: string): string | null {
+  const trimmedSearchString = searchString.trim()
+  return SEARCH_TYPE_PATTERNS.find(([, pattern]) => pattern.test(trimmedSearchString))?.[0] ?? null
+}
 
 /** A single MANE coordinate extracted from a ClinGen transcript allele. */
 export interface ManeCoordinate {

--- a/src/lib/mavemd.ts
+++ b/src/lib/mavemd.ts
@@ -43,11 +43,21 @@ export const rsIdRegex = /^rs[0-9]+$/im
 export const gnomadIdRegex = /^(1[0-9]|2[0-2]|[1-9]|X|Y|MT?)-([0-9]+)-([ACGT]+)-([ACGT]+)$/i
 
 /**
+ * Regular expression for HGNC gene symbols.
+ *
+ * A symbol begins with a letter and may carry digits, hyphenated parts (HLA-A, MT-CO1) and a trailing @ for cluster
+ * symbols (IGH@). This is by far the most permissive of the identifier patterns — any bare word satisfies it — so it
+ * is only ever applied once every more specific form has been ruled out.
+ */
+export const geneSymbolRegex = /^[A-Z][A-Z0-9]*(?:-[A-Z0-9]+)*@?$/i
+
+/**
  * Identifier patterns in the order they are tried when detecting what a search string is.
  *
  * Order matters wherever the patterns overlap. A VRS digest also satisfies the deliberately loose HGVS pattern, since
  * that only asks for an identifier, a colon and a description, so it has to be recognized first. A bare number is a
- * ClinVar Variation ID only once the more specific forms have been ruled out.
+ * ClinVar Variation ID only once the more specific forms have been ruled out, and a gene symbol — which any bare word
+ * resembles — only once everything else has been.
  */
 const SEARCH_TYPE_PATTERNS: [string, RegExp][] = [
   ['vrsDigest', vrsDigestRegex],
@@ -55,7 +65,8 @@ const SEARCH_TYPE_PATTERNS: [string, RegExp][] = [
   ['dbSnpRsId', rsIdRegex],
   ['gnomadId', gnomadIdRegex],
   ['hgvs', hgvsSearchStringRegex],
-  ['clinVarVariationId', clinVarVariationIdRegex]
+  ['clinVarVariationId', clinVarVariationIdRegex],
+  ['geneSymbol', geneSymbolRegex]
 ]
 
 /**

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -250,7 +250,28 @@ const routes: RouteRecordRaw[] = [
 
 const router = createRouter({
   history: createWebHistory(),
-  routes
+  routes,
+  /**
+   * Start a new page at the top, the way a full page load would.
+   *
+   * The history API never scrolls on its own, so without this a route change leaves the window wherever the previous
+   * page left it — arriving part way down a page the user has not seen before.
+   */
+  scrollBehavior(to, from, savedPosition) {
+    // Going back or forward returns to where that entry was left.
+    if (savedPosition) {
+      return savedPosition
+    }
+    if (to.hash) {
+      return {el: to.hash}
+    }
+    // Screens that mirror their state into the query string, such as the search screens, navigate on every keystroke
+    // of state change. Those are not new pages, so leave the scroll position alone.
+    if (to.path === from.path) {
+      return false
+    }
+    return {top: 0}
+  }
 })
 
 export default router


### PR DESCRIPTION
This pull request introduces several improvements and new features to the variant search experience, particularly around searching by gnomAD variant IDs and handling gene symbol searches. It also includes UI enhancements and code refactoring for clarity and maintainability.

### Variant Search Improvements

* Added support for searching by gnomAD variant IDs (`getAlleleByGnomad`), including automatic detection of the correct genome assembly (GRCh38 or GRCh37), fallback logic, and user interface to switch assemblies if needed. The UI now clearly reports which assembly was used and allows users to retry with the other assembly. [[1]](diffhunk://#diff-2bdd422ef0e03bd3a9acc87beb04f6276fb18f0297f424945a6ca626575d1472R39-R83) [[2]](diffhunk://#diff-f588bed0e1f93a557eeb6be191d51dc5a16cde2a00d249de4bd32ddac158b585R823-R826) [[3]](diffhunk://#diff-f588bed0e1f93a557eeb6be191d51dc5a16cde2a00d249de4bd32ddac158b585R289-R341)
* Enhanced the "Any" search option to detect the type of identifier entered and report how the input was interpreted. This provides better feedback to users about their query. [[1]](diffhunk://#diff-f588bed0e1f93a557eeb6be191d51dc5a16cde2a00d249de4bd32ddac158b585R270-R279) [[2]](diffhunk://#diff-f588bed0e1f93a557eeb6be191d51dc5a16cde2a00d249de4bd32ddac158b585R823-R826)

### Gene Symbol Search Improvements

* Improved gene symbol searches: when a valid gene symbol is entered, users are taken directly to the gene page, bypassing the variant search screen, which streamlines navigation and avoids unnecessary history entries.

### API and Data Structure Updates

* Updated the ClinGen API methods: `getAlleleByDbSnp` and `getAlleleByClinVar` now return arrays of alleles instead of a single allele, improving consistency with the API and supporting multiple results.
* Added a comprehensive test suite for the new `getAlleleByGnomad` function, covering various edge cases and error handling.

### UI and Styling Enhancements

* Added new color variables for search types (including gnomAD and gene) for consistent theming across the application.
* Refactored variant result cards to render as plain text when a ClinGen ID is not available, improving clarity for unregistered variants. [[1]](diffhunk://#diff-f588bed0e1f93a557eeb6be191d51dc5a16cde2a00d249de4bd32ddac158b585L298-R368) [[2]](diffhunk://#diff-f588bed0e1f93a557eeb6be191d51dc5a16cde2a00d249de4bd32ddac158b585L325-R395)

### Default Search Behavior

* Changed the default search type on the home screen from "HGVS" to "Any", making the search experience more flexible and user-friendly. [[1]](diffhunk://#diff-4038d17cf80b83a85e6759f9dfbd50c445cad55b83e21c96f28eaf1d8856fec4L262-R263) [[2]](diffhunk://#diff-4038d17cf80b83a85e6759f9dfbd50c445cad55b83e21c96f28eaf1d8856fec4L274-R278)

These changes collectively enhance the search experience, provide clearer feedback to users, and improve code maintainability.