### PR TITLE
feat(variant): show gnomAD population frequency on the variant page

### DIFF
--- a/docs/content/finding-data/external-integrations.md
+++ b/docs/content/finding-data/external-integrations.md
@@ -35,6 +35,8 @@ MaveDB displays ClinVar significance classifications and **star** status alongsi
 
 Mapped variants in MaveDB are cross-referenced with the [gnomAD database](https://gnomad.broadinstitute.org/) to retrieve population allele frequency data. This integration provides context about the prevalence of variants in diverse human populations, which is an important factor in clinical variant interpretation alongside functional evidence.
 
+A variant's frequency is displayed on its [variant page](../mavemd/variant-page.md), and is available in bulk through the `gnomad` namespace of the variant data download. Each frequency is matched by ClinGen allele ID, so it is a direct assertion about that variant rather than an aggregate over related variants. Variants absent from gnomAD show no frequency.
+
 ## Ensembl VEP
 
 MaveDB uses the [Ensembl Variant Effect Predictor (VEP)](https://www.ensembl.org/info/docs/tools/vep/index.html) to annotate mapped variants with predicted functional consequences, including effects on protein coding sequences, splicing, and regulatory regions. These VEP annotations are displayed alongside variant effect scores on score set pages, providing additional context for interpreting the functional impact of each variant.

--- a/docs/content/mavemd/variant-page.md
+++ b/docs/content/mavemd/variant-page.md
@@ -36,6 +36,17 @@ Each dataset on the variant page includes an [assay fact](../reference/assay-fac
 
 For the full list of assay fact properties and their definitions, see the [assay facts reference](../reference/assay-facts.md).
 
+## Annotations
+
+Beneath the assay details, an annotations card gathers evidence about the variant itself, independent of any one assay. **Classification** reports the selected measurement's functional score, ACMG code, and OddsPath ratio.
+
+**Population frequency** reports the variant's frequency in [gnomAD](../finding-data/external-integrations.md#gnomad), where it is present:
+
+- **AF** -- The allele frequency, followed by the allele count and allele number it was computed from.
+- **FAF95** -- The filtering allele frequency at 95% confidence, a conservative sampling-adjusted estimate, with the genetic ancestry group that attains it. A variant whose FAF95 exceeds a disease's maximum credible allele frequency is too common to be pathogenic (ACMG BA1/BS1).
+
+The gnomAD release the frequencies were drawn from is shown alongside them, with a link to the variant's gnomAD page. Variants absent from gnomAD are reported as having no record rather than as having zero frequency.
+
 ## Interactive histogram
 
 The variant page includes the same interactive score histogram shown on score set pages, but with the selected variant's position highlighted within the distribution. This visualization helps you see where the variant falls relative to all other measured variants in the assay.

--- a/src/api/mavedb/score-sets.ts
+++ b/src/api/mavedb/score-sets.ts
@@ -7,7 +7,14 @@ type ScoreSetSearch = components['schemas']['ScoreSetsSearch']
 type ScoreSetsSearchResponse = components['schemas']['ScoreSetsSearchResponse']
 export type ScoreSetsSearchFilterOptionsResponse = components['schemas']['ScoreSetsSearchFilterOptionsResponse']
 
-const HISTOGRAM_VARIANT_DATA_NAMESPACES = ['vep', 'scores', 'clingen', 'mavedb']
+// Both screens read a score set's whole variant table from the same endpoint, but they render different
+// things from it, so each names the namespaces it actually consumes. Keeping these separate matters at
+// scale: a saturation-mutagenesis score set is 100k+ rows, and an unused namespace is 100k+ wasted cells.
+const SCORE_SET_CHART_NAMESPACES = ['vep', 'scores', 'clingen', 'mavedb']
+
+// The variant page additionally reads the selected measurement's gnomAD frequency out of its row; this
+// request is the only source of it. See `gnomadFromVariantRow`.
+const VARIANT_PAGE_NAMESPACES = [...SCORE_SET_CHART_NAMESPACES, 'gnomad']
 
 function scoreSetVariantDataParams(options: {namespaces?: string[]} = {}): URLSearchParams {
   const params = new URLSearchParams()
@@ -21,8 +28,14 @@ function scoreSetVariantDataUrl(urn: string, params: URLSearchParams = new URLSe
   return query ? `${baseUrl}?${query}` : baseUrl
 }
 
-export function histogramScoreSetVariantDataUrl(urn: string): string {
-  return scoreSetVariantDataUrl(urn, scoreSetVariantDataParams({namespaces: HISTOGRAM_VARIANT_DATA_NAMESPACES}))
+/** Variant data for a score set page's histogram and heatmap. */
+export function scoreSetChartVariantDataUrl(urn: string): string {
+  return scoreSetVariantDataUrl(urn, scoreSetVariantDataParams({namespaces: SCORE_SET_CHART_NAMESPACES}))
+}
+
+/** Variant data for the variant page: the score distribution chart plus the selected row's annotations. */
+export function variantPageVariantDataUrl(urn: string): string {
+  return scoreSetVariantDataUrl(urn, scoreSetVariantDataParams({namespaces: VARIANT_PAGE_NAMESPACES}))
 }
 
 // ---------------------------------------------------------------------------

--- a/src/api/mavedb/variants.ts
+++ b/src/api/mavedb/variants.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 import config from '@/config'
-import {histogramScoreSetVariantDataUrl} from '@/api/mavedb/score-sets'
+import {variantPageVariantDataUrl} from '@/api/mavedb/score-sets'
 import {components} from '@/schema/openapi'
 
 type ScoreSet = components['schemas']['ScoreSet']
@@ -31,8 +31,9 @@ export async function getVariantDetail(urn: string): Promise<VariantEffectMeasur
   return response.data
 }
 
-export async function getHistogramVariantData(scoreSetUrn: string): Promise<string> {
-  const response = await axios.get(histogramScoreSetVariantDataUrl(scoreSetUrn))
+/** The containing score set's variant table, as read by the variant page. */
+export async function getVariantPageScoreSetData(scoreSetUrn: string): Promise<string> {
+  const response = await axios.get(variantPageVariantDataUrl(scoreSetUrn))
   return response.data
 }
 

--- a/src/components/screens/ScoreSetView.vue
+++ b/src/components/screens/ScoreSetView.vue
@@ -508,7 +508,7 @@ import {
   deleteScoreSet,
   publishScoreSet,
   getScoreSetClinicalControlOptions,
-  histogramScoreSetVariantDataUrl
+  scoreSetChartVariantDataUrl
 } from '@/api/mavedb'
 import {components} from '@/schema/openapi'
 import MvLoader from '@/components/common/MvLoader.vue'
@@ -719,7 +719,7 @@ export default {
           this.setItemId(newValue)
           let scoresUrl = null
           if (this.itemType?.restCollectionName && this.itemId) {
-            scoresUrl = histogramScoreSetVariantDataUrl(this.itemId)
+            scoresUrl = scoreSetChartVariantDataUrl(this.itemId)
           }
           this.setScoresDataUrl(scoresUrl)
           this.ensureScoresDataLoaded()

--- a/src/components/screens/VariantScreen.vue
+++ b/src/components/screens/VariantScreen.vue
@@ -9,7 +9,8 @@
               :model="tableDownloadMenu"
               severity="secondary"
               size="small"
-              @click="primaryTableDownload.command()">
+              @click="primaryTableDownload.command()"
+            >
               <template #default>
                 <i class="pi pi-table mr-1.5 text-xs" />
                 Download variant CSV
@@ -21,7 +22,8 @@
               :model="annotationDownloadOptions"
               severity="secondary"
               size="small"
-              @click="primaryAnnotationDownload?.command()">
+              @click="primaryAnnotationDownload?.command()"
+            >
               <template #default>
                 <i class="pi pi-download mr-1.5 text-xs" />
                 Download VA-Spec annotations
@@ -31,7 +33,8 @@
             <span
               v-if="downloadInProgress"
               aria-live="polite"
-              class="flex items-center gap-1.5 text-xs text-text-muted">
+              class="flex items-center gap-1.5 text-xs text-text-muted"
+            >
               <i class="pi pi-spin pi-spinner text-xs" />
               Preparing {{ lookup.downloadInProgressLabel.value }}…
             </span>
@@ -66,7 +69,8 @@
       <MvEmptyState
         v-else-if="lookup.variants.value.length === 0"
         description="No variants were found for this allele."
-        title="No variants found" />
+        title="No variants found"
+      />
 
       <template v-else>
         <!-- ── MEASUREMENTS SECTION ───────────────────────────── -->
@@ -84,7 +88,8 @@
                 active-border="var(--color-nucleotide-border)"
                 color="var(--color-nucleotide)"
                 :count="lookup.nucleotideCount.value"
-                label="Nucleotide level" />
+                label="Nucleotide level"
+              />
               <MvBadgeToggle
                 v-if="lookup.proteinCount.value > 0"
                 v-model="lookup.showProtein.value"
@@ -92,7 +97,8 @@
                 active-border="var(--color-protein-border)"
                 color="var(--color-protein)"
                 :count="lookup.proteinCount.value"
-                label="Protein level" />
+                label="Protein level"
+              />
               <MvBadgeToggle
                 v-if="lookup.associatedNucleotideCount.value > 0"
                 v-model="lookup.showAssociatedNucleotide.value"
@@ -100,7 +106,8 @@
                 active-border="var(--color-synonymous-nucleotide-border)"
                 color="var(--color-synonymous-nucleotide)"
                 :count="lookup.associatedNucleotideCount.value"
-                label="Synonymous nucleotide" />
+                label="Synonymous nucleotide"
+              />
             </div>
           </div>
           <!-- Desktop: horizontal scroll strip -->
@@ -118,7 +125,8 @@
               :normal-odds-path="lookup.getNormalOddsPath(variant.content.urn)"
               :study-title="variant.content.scoreSet?.title || 'Untitled score set'"
               :type="variant.type"
-              @select="lookup.selectVariant(variant.content.urn)" />
+              @select="lookup.selectVariant(variant.content.urn)"
+            />
           </div>
           <!-- Mobile: dropdown selector -->
           <div class="tablet:hidden px-4 py-3">
@@ -128,7 +136,8 @@
               option-label="label"
               option-value="urn"
               :options="measurementOptions"
-              @update:model-value="lookup.selectVariant($event)" />
+              @update:model-value="lookup.selectVariant($event)"
+            />
           </div>
         </div>
 
@@ -136,7 +145,8 @@
         <template v-if="lookup.selectedVariantDetail.value">
           <!-- Desktop: single card with two columns -->
           <div
-            class="mave-gradient-bar relative mt-6 hidden tablet:block rounded-lg border border-border bg-surface px-[18px] py-3.5">
+            class="mave-gradient-bar relative mt-6 hidden tablet:block rounded-lg border border-border bg-surface px-[18px] py-3.5"
+          >
             <div class="grid grid-cols-2">
               <div class="border-r border-border-light pr-[18px]">
                 <VariantInfoSection
@@ -144,40 +154,47 @@
                   :classification="lookup.calibrationResolution.classification.value"
                   :clingen-allele-id="lookup.selectedClingenAlleleId.value"
                   :clinvar-allele-ids="lookup.clingenAllele.clinvarAlleleIds.value"
-                  :genomic-locations="lookup.clingenAllele.genomicLocations.value" />
+                  :genomic-locations="lookup.clingenAllele.genomicLocations.value"
+                />
               </div>
               <div class="pl-[18px]">
                 <MvAssayFactsCard
                   :columns="1"
                   :score-set="lookup.selectedScoreSet.value ?? undefined"
-                  :variant-urn="lookup.selectedVariantDetail.value?.urn ?? undefined" />
+                  :variant-urn="lookup.selectedVariantDetail.value?.urn ?? undefined"
+                />
               </div>
             </div>
           </div>
 
           <!-- Mobile: separate cards -->
           <div
-            class="mt-6 tablet:hidden mave-gradient-bar relative rounded-lg border border-border bg-surface px-4 py-3.5">
+            class="mt-6 tablet:hidden mave-gradient-bar relative rounded-lg border border-border bg-surface px-4 py-3.5"
+          >
             <VariantInfoSection
               :allele-name="lookup.clingenAllele.alleleName.value"
               :classification="lookup.calibrationResolution.classification.value"
               :clingen-allele-id="lookup.selectedClingenAlleleId.value"
               :clinvar-allele-ids="lookup.clingenAllele.clinvarAlleleIds.value"
-              :genomic-locations="lookup.clingenAllele.genomicLocations.value" />
+              :genomic-locations="lookup.clingenAllele.genomicLocations.value"
+            />
           </div>
           <div
-            class="mt-4 tablet:hidden mave-gradient-bar relative rounded-lg border border-border bg-surface px-4 py-3.5">
+            class="mt-4 tablet:hidden mave-gradient-bar relative rounded-lg border border-border bg-surface px-4 py-3.5"
+          >
             <MvAssayFactsCard
               :columns="1"
               :score-set="lookup.selectedScoreSet.value ?? undefined"
-              :variant-urn="lookup.selectedVariantDetail.value?.urn ?? undefined" />
+              :variant-urn="lookup.selectedVariantDetail.value?.urn ?? undefined"
+            />
           </div>
         </template>
 
         <!-- ── ANNOTATIONS CARD ──────────────────────────────── -->
         <div
           v-if="lookup.selectedVariantDetail.value && lookup.selectedVariantScore.value != null"
-          class="mave-gradient-bar relative mt-6 rounded-lg border border-border bg-surface px-[18px] py-3.5">
+          class="mave-gradient-bar relative mt-6 rounded-lg border border-border bg-surface px-[18px] py-3.5"
+        >
           <div class="annotations-columns grid grid-cols-1 tablet:grid-cols-3">
             <!-- Classification -->
             <div class="tablet:pr-[18px]">
@@ -188,26 +205,36 @@
                   lookup.selectedVariantScore.value !== 'NA'
                     ? Number(lookup.selectedVariantScore.value).toPrecision(4)
                     : undefined
-                " />
+                "
+              />
               <MvDetailRow label="ACMG code">
                 <MvEvidenceTag
                   v-if="lookup.calibrationResolution.formattedEvidenceCode.value"
-                  :code="lookup.calibrationResolution.formattedEvidenceCode.value" />
+                  :code="lookup.calibrationResolution.formattedEvidenceCode.value"
+                />
               </MvDetailRow>
               <MvDetailRow
                 label="OddsPath ratio"
-                :value="lookup.calibrationResolution.scoreRange.value?.oddspathsRatio ?? undefined" />
+                :value="lookup.calibrationResolution.scoreRange.value?.oddspathsRatio ?? undefined"
+              />
             </div>
-            <!-- Placeholder columns for future data -->
+            <!-- Population frequency: gnomAD links to a single mapped variant, so this is a direct
+                 assertion about the measured allele rather than an aggregate over related variants.
+                 TODO(#746) moves this to a reverse translated data model with a notion of related variants.
+                  -->
             <div
-              class="border-t border-border-light pt-4 tablet:border-t-0 tablet:pt-0 tablet:border-l tablet:border-border-light tablet:px-[18px]">
+              class="flex flex-col border-t border-border-light pt-4 tablet:border-t-0 tablet:pt-0 tablet:border-l tablet:border-border-light tablet:px-[18px]"
+            >
               <div class="mb-1.5 text-xs-minus font-bold uppercase tracking-[0.5px] text-black">
                 Population Frequency
               </div>
-              <p class="text-xs-plus italic text-text-muted">Data coming soon</p>
+              <MvGnomadSummary v-if="lookup.selectedVariantGnomad.value" :gnomad="lookup.selectedVariantGnomad.value" />
+              <p v-else class="text-xs-plus italic text-text-muted">No gnomAD record for this variant</p>
             </div>
+            <!-- Placeholder column for future data -->
             <div
-              class="border-t border-border-light pt-4 tablet:border-t-0 tablet:pt-0 tablet:border-l tablet:border-border-light tablet:pl-[18px]">
+              class="border-t border-border-light pt-4 tablet:border-t-0 tablet:pt-0 tablet:border-l tablet:border-border-light tablet:pl-[18px]"
+            >
               <div class="mb-1.5 text-xs-minus font-bold uppercase tracking-[0.5px] text-black">
                 Splicing Predictions
               </div>
@@ -219,7 +246,8 @@
         <!-- ── SCORE DISTRIBUTION CHART ──────────────────────── -->
         <div v-if="lookup.selectedScoreSet.value" class="mt-6 rounded-lg border border-border bg-surface">
           <div
-            class="flex flex-wrap items-center justify-between gap-3 border-b border-border-light px-4 tablet:px-5 py-3.5">
+            class="flex flex-wrap items-center justify-between gap-3 border-b border-border-light px-4 tablet:px-5 py-3.5"
+          >
             <div class="min-w-0">
               <router-link
                 class="text-base tablet:text-lg font-bold text-link"
@@ -227,7 +255,8 @@
                   name: 'scoreSet',
                   params: {urn: lookup.selectedScoreSet.value.urn},
                   query: {variant: lookup.selectedVariantDetail.value?.urn}
-                }">
+                }"
+              >
                 {{ lookup.selectedScoreSet.value.title }}
               </router-link>
             </div>
@@ -244,7 +273,8 @@
                 :selected-calibration="lookup.selectedCalibration.value || undefined"
                 :variants="lookup.scores.value"
                 @calibration-changed="lookup.selectedCalibration.value = $event"
-                @selection-changed="() => {}" />
+                @selection-changed="() => {}"
+              />
             </div>
             <div v-else class="flex min-h-[200px] items-center justify-center">
               <MvLoader text="Loading variant information..." />
@@ -253,7 +283,8 @@
           <div v-if="lookup.selectedCalibrationObject.value" class="border-t border-border-light p-5">
             <CalibrationTable
               :highlighted-range-label="lookup.calibrationResolution.scoreRange.value?.label || null"
-              :score-calibration="lookup.selectedCalibrationObject.value" />
+              :score-calibration="lookup.selectedCalibrationObject.value"
+            />
           </div>
         </div>
       </template>
@@ -263,7 +294,8 @@
       header="Download clinical table"
       kind="variant"
       :urn="lookup.selectedVariantUrn.value"
-      @confirm="downloadSelectedCsv" />
+      @confirm="downloadSelectedCsv"
+    />
   </MvLayout>
 </template>
 
@@ -287,6 +319,7 @@ import MvAssayFactsCard from '@/components/common/MvAssayFactsCard.vue'
 import MvCsvColumnDialog from '@/components/common/MvCsvColumnDialog.vue'
 import MvBadgeToggle from '@/components/common/MvBadgeToggle.vue'
 import ScoreSetHistogram from '@/components/score-set/ScoreSetHistogram.vue'
+import MvGnomadSummary from '@/components/variant/MvGnomadSummary.vue'
 import MvMeasurementCard from '@/components/variant/MvMeasurementCard.vue'
 import MvRowActionMenu, {type RowAction} from '@/components/common/MvRowActionMenu.vue'
 import VariantInfoSection from '@/components/variant/VariantInfoSection.vue'
@@ -311,6 +344,7 @@ export default defineComponent({
     MvEmptyState,
     MvErrorState,
     MvEvidenceTag,
+    MvGnomadSummary,
     MvLayout,
     MvLoader,
     MvMeasurementCard,

--- a/src/components/variant/MvGnomadSummary.vue
+++ b/src/components/variant/MvGnomadSummary.vue
@@ -11,7 +11,6 @@
     <div class="flex flex-wrap items-center gap-x-2 gap-y-0.5">
       <span v-if="gnomad.faf95Max !== null" class="text-text-primary"
         >FAF95: <span class="font-mono text-text-muted">{{ formatFrequency(gnomad.faf95Max) }}</span>
-        <span v-if="gnomad.faf95MaxAncestry" class="text-text-muted">({{ gnomad.faf95MaxAncestry }})</span>
       </span>
       <span v-else class="text-text-muted">FAF95 —</span>
     </div>

--- a/src/components/variant/MvGnomadSummary.vue
+++ b/src/components/variant/MvGnomadSummary.vue
@@ -1,0 +1,56 @@
+<template>
+  <div class="flex h-full flex-col gap-0.5 leading-snug">
+    <div class="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+      <span class="text-text-primary"
+        >AF: <span class="font-mono">{{ formatFrequency(gnomad.alleleFrequency) }}</span></span
+      >
+      <span class="text-sm text-text-muted"
+        >({{ gnomad.alleleCount.toLocaleString() }} / {{ gnomad.alleleNumber.toLocaleString() }})</span
+      >
+    </div>
+    <div class="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+      <span v-if="gnomad.faf95Max !== null" class="text-text-primary"
+        >FAF95: <span class="font-mono text-text-muted">{{ formatFrequency(gnomad.faf95Max) }}</span>
+        <span v-if="gnomad.faf95MaxAncestry" class="text-text-muted">({{ gnomad.faf95MaxAncestry }})</span>
+      </span>
+      <span v-else class="text-text-muted">FAF95 —</span>
+    </div>
+    <!-- Provenance sits at the bottom of the cell, so it lines up across the annotations card's columns
+         however tall the frequencies above it run. -->
+    <div class="mt-auto text-[10px] text-text-muted">
+      As of gnomAD {{ gnomad.dbVersion }} ·
+      <a
+        class="inline-flex items-center text-link hover:underline"
+        :href="url"
+        rel="noopener noreferrer"
+        target="_blank"
+        >view in gnomAD</a
+      >
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import {defineComponent, type PropType} from 'vue'
+
+import {gnomadVariantUrl, formatFrequency, type GnomadFrequency} from '@/lib/gnomad'
+
+/** Rich display of one gnomAD record: allele frequency, the AC/AN behind it, FAF95, and a deep link. */
+export default defineComponent({
+  name: 'MvGnomadSummary',
+
+  props: {
+    gnomad: {type: Object as PropType<GnomadFrequency>, required: true}
+  },
+
+  computed: {
+    url(): string {
+      return gnomadVariantUrl(this.gnomad)
+    }
+  },
+
+  methods: {
+    formatFrequency
+  }
+})
+</script>

--- a/src/composables/use-csv-namespaces.test.ts
+++ b/src/composables/use-csv-namespaces.test.ts
@@ -28,7 +28,7 @@ function entry(
 
 const SCORE_SET_ENTRIES: AvailableCsvNamespace[] = [
   entry({namespace: 'scores', label: 'Scores', group: 'data'}),
-  entry({namespace: 'gnomad', label: 'gnomAD allele frequency', group: 'annotation'}),
+  entry({namespace: 'gnomad', label: 'gnomAD population frequency', group: 'annotation'}),
   entry({namespace: 'clinvar.2024_11', label: 'ClinVar significance (November 2024)', group: 'annotation'}),
   entry({namespace: 'calibration.urn:mavedb:calibration-1', label: 'Brnich et al. 2019', group: 'calibration'}),
   entry({namespace: 'score_set', label: 'Score set and publications', group: 'provenance'})
@@ -398,7 +398,7 @@ describe('useCsvNamespaces extras', () => {
   const NAMESPACE_ENTRIES: AvailableCsvNamespace[] = [
     entry({namespace: 'scores', label: 'Score', group: 'data'}),
     entry({namespace: 'scores_custom', label: 'Investigator-provided score columns', group: 'data'}),
-    entry({namespace: 'gnomad', label: 'gnomAD allele frequency', group: 'annotation'})
+    entry({namespace: 'gnomad', label: 'gnomAD population frequency', group: 'annotation'})
   ]
 
   const EXTRAS = [{label: "Omit HGVS columns this score set doesn't use", value: 'dropUnusedHgvsColumns'}]

--- a/src/composables/use-variant-lookup.ts
+++ b/src/composables/use-variant-lookup.ts
@@ -4,7 +4,7 @@ import {
   downloadVariantCsv,
   getVariantAnnotation,
   getVariantDetail,
-  getHistogramVariantData,
+  getVariantPageScoreSetData,
   lookupVariantsByClingenId
 } from '@/api/mavedb/variants'
 import {useCalibrationResolution, type UseCalibrationResolutionReturn} from '@/composables/use-calibration-resolution'
@@ -19,6 +19,7 @@ import {
 import {triggerDownload} from '@/lib/downloads'
 import {describeRequestError} from '@/lib/errors'
 import {getExperimentKeyword} from '@/lib/experiments'
+import {gnomadFromVariantRow, type GnomadFrequency} from '@/lib/gnomad'
 import {parseScoreSetVariantData, type Variant} from '@/lib/variants'
 import type {MeasurementType} from '@/lib/measurement-types'
 import type {components} from '@/schema/openapi'
@@ -66,6 +67,7 @@ export interface UseVariantLookupReturn {
   scores: ComputedRef<Variant[] | null>
   variantScoreRow: ComputedRef<Variant | undefined>
   selectedVariantScore: ComputedRef<number | string | null>
+  selectedVariantGnomad: ComputedRef<GnomadFrequency | null>
 
   // Calibration
   selectedCalibration: Ref<string | null>
@@ -170,6 +172,7 @@ export function useVariantLookup(
   })
   const variantScoreRow = computed(() => (scores.value || []).find((s) => s.accession === selectedVariantUrn.value))
   const selectedVariantScore = computed(() => variantScoreRow.value?.scores?.score ?? null)
+  const selectedVariantGnomad = computed(() => gnomadFromVariantRow(variantScoreRow.value))
 
   // ── Calibration ───────────────────────────────────────────
   const selectedCalibrationObject = computed<ScoreCalibration | null>(() => {
@@ -222,7 +225,7 @@ export function useVariantLookup(
   async function fetchScores(scoreSetUrn: string) {
     if (scoresCache.value[scoreSetUrn]) return
     try {
-      const data = await getHistogramVariantData(scoreSetUrn)
+      const data = await getVariantPageScoreSetData(scoreSetUrn)
       scoresCache.value = {
         ...scoresCache.value,
         [scoreSetUrn]: parseScoreSetVariantData(data)
@@ -427,6 +430,7 @@ export function useVariantLookup(
     scores,
     variantScoreRow,
     selectedVariantScore,
+    selectedVariantGnomad,
     selectedCalibration,
     selectedCalibrationObject,
     calibrationResolution,

--- a/src/lib/gnomad.test.ts
+++ b/src/lib/gnomad.test.ts
@@ -1,6 +1,16 @@
-import {describe, expect, it} from 'vitest'
-
-import {CHROMOSOME_REFSEQ_IDS, gnomadIdToHgvs, gnomadIdToHgvsCandidates, otherAssembly, parseGnomadId} from './gnomad'
+import {describe, expect, it, test} from 'vitest'
+import {
+  CHROMOSOME_REFSEQ_IDS,
+  gnomadIdToHgvs,
+  gnomadIdToHgvsCandidates,
+  otherAssembly,
+  parseGnomadId,
+  formatFrequency,
+  gnomadFromVariantRow,
+  gnomadVariantUrl,
+  type GnomadFrequency
+} from './gnomad'
+import type {RawVariant} from '@/lib/variants'
 
 /** The GRCh38 translation of a gnomAD ID, which is the one tried first. */
 function grch38Hgvs(gnomadId: string): string | undefined {
@@ -142,5 +152,114 @@ describe('CHROMOSOME_REFSEQ_IDS', () => {
         expect(ids.grch38, chromosome).not.toBe(ids.grch37)
       }
     }
+  })
+})
+
+/** A variant data row whose gnomad namespace is fully populated; overrides replace individual cells. */
+function row(overrides: Partial<NonNullable<RawVariant['gnomad']>> = {}): RawVariant {
+  return {
+    accession: 'urn:mavedb:00000001-a-1#1',
+    scores: {score: 0.5},
+    gnomad: {
+      gnomad_af: 1.86e-6,
+      gnomad_ac: 3,
+      gnomad_an: 1613510,
+      gnomad_faf95_max: 6.8e-7,
+      gnomad_faf95_max_ancestry: 'nfe',
+      gnomad_id: '10-87961093-A-G',
+      gnomad_version: 'v4.1',
+      ...overrides
+    }
+  }
+}
+
+const frequency: GnomadFrequency = {
+  alleleFrequency: 1.86e-6,
+  alleleCount: 3,
+  alleleNumber: 1613510,
+  faf95Max: 6.8e-7,
+  faf95MaxAncestry: 'nfe',
+  dbIdentifier: '10-87961093-A-G',
+  dbVersion: 'v4.1'
+}
+
+describe('gnomadFromVariantRow', () => {
+  test('reads a populated namespace into the display shape', () => {
+    expect(gnomadFromVariantRow(row())).toEqual(frequency)
+  })
+
+  test('nullish row or absent namespace → null', () => {
+    expect(gnomadFromVariantRow(null)).toBeNull()
+    expect(gnomadFromVariantRow(undefined)).toBeNull()
+    expect(gnomadFromVariantRow({accession: 'x', scores: {score: 0.5}})).toBeNull()
+  })
+
+  test("a variant with no gnomAD record reports 'NA' across the namespace → null", () => {
+    const unannotated = row({
+      gnomad_af: 'NA',
+      gnomad_ac: 'NA',
+      gnomad_an: 'NA',
+      gnomad_faf95_max: 'NA',
+      gnomad_faf95_max_ancestry: 'NA',
+      gnomad_id: 'NA',
+      gnomad_version: 'NA'
+    })
+    expect(gnomadFromVariantRow(unannotated)).toBeNull()
+  })
+
+  test.each(['gnomad_af', 'gnomad_ac', 'gnomad_an', 'gnomad_id'] as const)(
+    'a missing %s makes the record unusable → null',
+    (field) => {
+      expect(gnomadFromVariantRow(row({[field]: 'NA'}))).toBeNull()
+    }
+  )
+
+  test('FAF95 is optional — absent leaves the rest intact', () => {
+    const result = gnomadFromVariantRow(row({gnomad_faf95_max: 'NA', gnomad_faf95_max_ancestry: 'NA'}))
+    expect(result).toMatchObject({alleleFrequency: 1.86e-6, faf95Max: null, faf95MaxAncestry: null})
+  })
+
+  test('a zero allele frequency is a real value, not a missing one', () => {
+    expect(gnomadFromVariantRow(row({gnomad_af: 0, gnomad_ac: 0}))).toMatchObject({
+      alleleFrequency: 0,
+      alleleCount: 0
+    })
+  })
+
+  test('an absent version degrades gracefully rather than dropping the record', () => {
+    expect(gnomadFromVariantRow(row({gnomad_version: 'NA'}))?.dbVersion).toBe('unknown')
+  })
+})
+
+describe('formatFrequency', () => {
+  test('nullish → em dash', () => {
+    expect(formatFrequency(null)).toBe('—')
+    expect(formatFrequency(undefined)).toBe('—')
+  })
+
+  test('very rare (< 1e-4) → scientific notation, else 3 significant figures', () => {
+    expect(formatFrequency(0.00001)).toBe('1.00e-5')
+    expect(formatFrequency(0.0123456)).toBe('0.0123')
+    expect(formatFrequency(0)).toBe('0.00e+0')
+  })
+})
+
+describe('gnomadVariantUrl — dataset matches the record version', () => {
+  test.each([
+    ['v4.1', 'gnomad_r4'],
+    ['v3.1.2', 'gnomad_r3'],
+    ['v2.1.1', 'gnomad_r2_1'],
+    // Bare majors, as older records and fixtures carry them.
+    ['4', 'gnomad_r4'],
+    ['3', 'gnomad_r3'],
+    ['2', 'gnomad_r2_1']
+  ])('version %s → %s', (dbVersion, dataset) => {
+    const url = gnomadVariantUrl({dbIdentifier: '1-55051215-G-A', dbVersion})
+    expect(url).toContain(`dataset=${dataset}`)
+    expect(url).toContain('/variant/1-55051215-G-A')
+  })
+
+  test('an unrecognisable version falls back to the current dataset', () => {
+    expect(gnomadVariantUrl({dbIdentifier: 'x', dbVersion: 'unknown'})).toContain('dataset=gnomad_r4')
   })
 })

--- a/src/lib/gnomad.ts
+++ b/src/lib/gnomad.ts
@@ -1,4 +1,36 @@
+/**
+ * @fileoverview
+ * gnomAD population frequency annotations and related utilities.
+ *
+ * gnomAD is a population-scale variant frequency database. MaveDB links each mapped variant to the
+ * single gnomAD record sharing its ClinGen allele ID, so a variant's frequency is a direct assertion
+ * about that variant — there is no projection or pooling to reason about.
+ *
+ * Frequencies reach the client as the `gnomad` namespace of the score-set variant data CSV, where
+ * every field arrives as a number or the string `'NA'`. {@link gnomadFromVariantRow} is the seam that
+ * turns one of those rows into the shape the display components consume.
+ */
 import {gnomadIdRegex} from './mavemd'
+import type {components} from '@/schema/openapi'
+import type {RawVariant} from '@/lib/variants'
+
+/**
+ * One gnomAD frequency record, as consumed by the display components.
+ *
+ * Picked from the generated schema rather than restated, so renaming or retyping a field on the API's
+ * model breaks compilation here.
+ *
+ * Caveat: the CSV columns come from the API's namespace specs, a different code path from the view
+ * model. Both project the same `GnomADVariant` ORM columns, so this tracks names and types but is not
+ * a guarantee that the two stay column-for-column aligned.
+ */
+export type GnomadFrequency = Pick<
+  components['schemas']['GnomADVariantWithMappedVariants'],
+  'alleleFrequency' | 'alleleCount' | 'alleleNumber' | 'faf95Max' | 'faf95MaxAncestry' | 'dbIdentifier' | 'dbVersion'
+>
+
+/** A CSV cell from the `gnomad` namespace: a number, the `'NA'` sentinel, or absent. */
+type GnomadCell = number | string | null | undefined
 
 /**
  * Translation of gnomAD variant IDs (e.g. 1-11796321-G-A) into genomic HGVS.
@@ -167,4 +199,59 @@ export function gnomadIdToHgvsCandidates(gnomadId: string): GnomadHgvsCandidate[
 /** The HGVS reading of a gnomAD ID under one assembly, or null if the ID cannot be translated. */
 export function gnomadIdToHgvs(gnomadId: string, assembly: GenomeAssembly): string | null {
   return gnomadIdToHgvsCandidates(gnomadId).find((candidate) => candidate.assembly === assembly)?.hgvs ?? null
+}
+
+function numberOrNull(value: GnomadCell): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function stringOrNull(value: GnomadCell): string | null {
+  if (typeof value === 'number') return String(value)
+  return value && value.toUpperCase() !== 'NA' ? value : null
+}
+
+/**
+ * Read a variant's gnomAD frequency out of its score-set data row.
+ *
+ * Returns null unless the row carries the fields the display depends on — the frequency itself, the
+ * AC/AN behind it, and the gnomAD variant id used to link out. Variants with no gnomAD record report
+ * `'NA'` across the namespace and yield null here.
+ *
+ * Requires the `gnomad` namespace to have been requested; see `variantPageVariantDataUrl`.
+ */
+export function gnomadFromVariantRow(variant: RawVariant | null | undefined): GnomadFrequency | null {
+  const gnomad = variant?.gnomad
+  if (!gnomad) return null
+
+  const alleleFrequency = numberOrNull(gnomad.gnomad_af)
+  const alleleCount = numberOrNull(gnomad.gnomad_ac)
+  const alleleNumber = numberOrNull(gnomad.gnomad_an)
+  const dbIdentifier = stringOrNull(gnomad.gnomad_id)
+  if (alleleFrequency == null || alleleCount == null || alleleNumber == null || dbIdentifier == null) {
+    return null
+  }
+
+  return {
+    alleleFrequency,
+    alleleCount,
+    alleleNumber,
+    faf95Max: numberOrNull(gnomad.gnomad_faf95_max),
+    faf95MaxAncestry: stringOrNull(gnomad.gnomad_faf95_max_ancestry),
+    dbIdentifier,
+    dbVersion: stringOrNull(gnomad.gnomad_version) ?? 'unknown'
+  }
+}
+
+/** Deep link to a gnomAD variant page, choosing the dataset that matches the record's version. */
+export function gnomadVariantUrl(gnomad: {dbIdentifier: string; dbVersion: string}): string {
+  // Versions are stored with a leading "v" (e.g. "v4.1"), so strip non-digits before reading the major.
+  const major = parseInt(gnomad.dbVersion.replace(/^\D+/, ''), 10)
+  const dataset = major === 3 ? 'gnomad_r3' : major === 2 ? 'gnomad_r2_1' : 'gnomad_r4'
+  return `https://gnomad.broadinstitute.org/variant/${encodeURIComponent(gnomad.dbIdentifier)}?dataset=${dataset}`
+}
+
+/** A frequency (e.g. gnomAD AF): scientific notation for the very rare, else 3 significant figures. */
+export function formatFrequency(value: number | null | undefined): string {
+  if (value == null) return '—'
+  return value < 0.0001 ? value.toExponential(2) : value.toPrecision(3)
 }

--- a/src/lib/variants.ts
+++ b/src/lib/variants.ts
@@ -53,6 +53,17 @@ export interface RawVariant {
   clingen?: {
     clingen_allele_id?: string
   }
+  // The `gnomad` namespace. Numeric fields arrive as numbers via the CSV parser's dynamic typing, or
+  // as the string 'NA' where the variant has no gnomAD record. Read via `gnomadFromVariantRow`.
+  gnomad?: {
+    gnomad_af?: number | string
+    gnomad_ac?: number | string
+    gnomad_an?: number | string
+    gnomad_faf95_max?: number | string
+    gnomad_faf95_max_ancestry?: string
+    gnomad_id?: string
+    gnomad_version?: string
+  }
 
   control?: ClinicalControlVariant
   mavedb_label?: string


### PR DESCRIPTION
Fills the annotations card's "Population Frequency" column, until now a "Data coming soon" placeholder. gnomAD is linked to a single mapped variant by ClinGen allele ID, so the frequency is a direct assertion about the measured allele rather than an aggregate over related variants.

- Add MvGnomadSummary: AF with the AC/AN behind it, FAF95 with the genetic ancestry group attaining it, and a deep link to the gnomAD variant page, bottom-aligned so provenance lines up across the card's columns.
- Read the record from the score set's variant data CSV via gnomadFromVariantRow, which normalises the namespace's NA sentinels. A variant absent from gnomAD reports as having no record, not zero frequency.
- Derive GnomadFrequency from the generated OpenAPI schema, so renaming or retyping a field on the API model breaks compilation here.
- Split HISTOGRAM_VARIANT_DATA_NAMESPACES into SCORE_SET_CHART_NAMESPACES and VARIANT_PAGE_NAMESPACES. One list fed two screens under a name describing neither, and only the variant page reads gnomAD, so the score set charts no longer fetch seven unused columns on every row.

Requires the widened gnomad CSV namespace in the API, see https://github.com/VariantEffect/mavedb-api/pull/836.