### PR TITLE
feat(ui): report annotation-stream variants the server could not annotate

### DIFF
--- a/src/components/score-set/ScoreSetDownloads.vue
+++ b/src/components/score-set/ScoreSetDownloads.vue
@@ -144,28 +144,19 @@ export default defineComponent({
       if (this.hasPathogenicityCalibrations) {
         options.push({
           label: 'Pathogenicity Statement',
-          command: () =>
-            this.reportingFailure('Pathogenicity Statement', () =>
-              this.streamVariantAnnotations('pathogenicity-statement', 'Pathogenicity Statement')
-            )
+          command: () => this.streamAnnotations('pathogenicity-statement', 'Pathogenicity Statement')
         })
       }
       if (this.hasFunctionalImpactCalibrations) {
         options.push({
           label: 'Functional Impact Statement',
-          command: () =>
-            this.reportingFailure('Functional Impact Statement', () =>
-              this.streamVariantAnnotations('functional-statement', 'Functional Impact Statement')
-            )
+          command: () => this.streamAnnotations('functional-statement', 'Functional Impact Statement')
         })
       }
 
       options.push({
         label: 'Functional Study Result',
-        command: () =>
-          this.reportingFailure('Functional Study Result', () =>
-            this.streamVariantAnnotations('study-result', 'Functional Study Result')
-          )
+        command: () => this.streamAnnotations('study-result', 'Functional Study Result')
       })
 
       return options
@@ -194,6 +185,29 @@ export default defineComponent({
           life: 6000
         })
       }
+    },
+
+    /**
+     * Download an annotation stream, reporting a failure as an error and a partial one as a warning.
+     *
+     * A stream in which some variants could not be annotated still completes: the file is whole, and the
+     * failed variants are in it as records carrying an `error` field. Saying nothing would let a user
+     * treat a partial export as a full one.
+     */
+    async streamAnnotations(annotationType: string, what: string) {
+      await this.reportingFailure(what, async () => {
+        const outcome = await this.streamVariantAnnotations(annotationType, what)
+        if (outcome && outcome.errored > 0) {
+          this.$toast.add({
+            severity: 'warn',
+            summary: `${what} downloaded with errors`,
+            detail:
+              `${outcome.errored} of ${outcome.received} variants could not be annotated.` +
+              ' Those records carry an "error" field instead of an annotation.',
+            life: 10000
+          })
+        }
+      })
     },
 
     async handleCustomDownload(selection: {namespaces: string[]; extras: string[]}) {

--- a/src/composables/use-score-set-downloads.test.ts
+++ b/src/composables/use-score-set-downloads.test.ts
@@ -185,9 +185,41 @@ describe('useScoreSetDownloads annotation streaming shares the indicator', () =>
     expect(downloads.fileDownloadInProgress.value).toBe(false)
   })
 
-  it('counts records by byte, so a multi-byte character cannot skew the total', async () => {
-    // The old implementation decoded each chunk to a string first; retaining bytes is both exact and what
-    // keeps a large download out of the tab's memory.
+  it('tallies variants the server could not annotate, so a caller can report them', async () => {
+    const errorRecord = '{"variant_urn":"urn:1","annotation":null,"error":{"type":"ValueError","detail":"bad"}}\n'
+    mockStream([errorRecord, '{"variant_urn":"urn:2","annotation":{"type":"Stub"}}\n'], '2')
+    const downloads = useScoreSetDownloads({scoreSet: SCORE_SET})
+
+    expect(await downloads.streamVariantAnnotations('study-result')).toEqual({received: 2, errored: 1})
+  })
+
+  it('saves a stream containing error records, since the file is complete', async () => {
+    // A variant the server could not annotate is reported in-band. The download is not a failure.
+    const errorRecord = '{"variant_urn":"urn:1","annotation":null,"error":{"type":"KeyError","detail":"score"}}\n'
+    mockStream([errorRecord], '1')
+    const downloads = useScoreSetDownloads({scoreSet: SCORE_SET})
+
+    await expect(downloads.streamVariantAnnotations('study-result')).resolves.toEqual({received: 1, errored: 1})
+  })
+
+  it('counts an error record split across chunks exactly once', async () => {
+    // Records are scanned per chunk, so a boundary landing mid-record must not lose or double it.
+    mockStream(['{"variant_urn":"urn:1","annotation":null,"err', 'or":{"type":"KeyError","detail":"s"}}\n'], '1')
+    const downloads = useScoreSetDownloads({scoreSet: SCORE_SET})
+
+    expect(await downloads.streamVariantAnnotations('study-result')).toEqual({received: 1, errored: 1})
+  })
+
+  it('does not mistake an "error" nested inside an annotation for a failed record', async () => {
+    // The substring test is only a prefilter; the record is parsed to confirm the key is its own.
+    mockStream(['{"variant_urn":"urn:1","annotation":{"notes":"see \\"error\\" handling"}}\n'], '1')
+    const downloads = useScoreSetDownloads({scoreSet: SCORE_SET})
+
+    expect(await downloads.streamVariantAnnotations('study-result')).toEqual({received: 1, errored: 0})
+  })
+
+  it('is not skewed by a multi-byte character', async () => {
+    // The body is still retained as bytes — only one chunk at a time is decoded, to scan its lines.
     mockStream(['{"p":"p.Trp26€"}\n', '{"p":"p.Met1?"}\n'], '2')
     const downloads = useScoreSetDownloads({scoreSet: SCORE_SET})
     const {values, stop} = recordProgress(downloads.fileDownloadProgress)

--- a/src/composables/use-score-set-downloads.ts
+++ b/src/composables/use-score-set-downloads.ts
@@ -11,6 +11,34 @@ type ScoreSet = components['schemas']['ScoreSet']
 
 export const TEXT_COLUMNS = ['hgvs_nt', 'hgvs_splice', 'hgvs_pro']
 
+/** What a completed annotation stream contained, tallied as it arrived. */
+export interface AnnotationStreamOutcome {
+  /** Records received. Equals `X-Total-Count` for a complete stream — the server emits one per variant. */
+  received: number
+  /**
+   * Variants the server could not annotate. Those records are in the saved file, carrying an `error`
+   * object in place of an annotation. Variants with no mapping data are not counted here: a null
+   * annotation is an expected absence, not a failure.
+   */
+  errored: number
+}
+
+/**
+ * Whether an NDJSON line is a record the server marked as failed.
+ *
+ * The substring test is a prefilter, not the decision: `"error"` can appear anywhere inside a large
+ * annotation, so a candidate line is parsed to confirm the key is the record's own. Parsing only
+ * candidates matters — these records nest deeply, and parsing every one of a large stream is slow.
+ */
+function isErrorRecord(line: string): boolean {
+  if (!line.includes('"error"')) return false
+  try {
+    return JSON.parse(line)?.error != null
+  } catch {
+    return false
+  }
+}
+
 interface UseScoreSetDownloadsOptions {
   scoreSet: Ref<ScoreSet | null>
 }
@@ -98,10 +126,11 @@ export function useScoreSetDownloads({scoreSet}: UseScoreSetDownloadsOptions) {
     }
   }
 
+  /** Resolves to what the stream contained, so the caller can report partial failures. */
   async function streamVariantAnnotations(annotationType: string, label = 'annotations') {
     const urn = scoreSet.value?.urn
     if (!urn) return
-    await withIndicator(label, () => streamAnnotationsInto(urn, annotationType))
+    return await withIndicator(label, () => streamAnnotationsInto(urn, annotationType))
   }
 
   async function streamAnnotationsInto(urn: string, annotationType: string) {
@@ -121,30 +150,40 @@ export function useScoreSetDownloads({scoreSet}: UseScoreSetDownloadsOptions) {
       const reader = response.body?.getReader()
       if (!reader) throw new Error('Response body is not readable')
 
-      // Held as raw bytes rather than decoded strings. Accumulating strings and then joining them cost
-      // roughly five times the payload — JS strings are UTF-16, so the decoded chunks alone doubled it,
-      // the join doubled that again, and the Blob copied the result. A large pathogenicity download ran
-      // the tab out of memory.
+      // The body is retained as raw bytes, never as accumulated strings. Accumulating decoded chunks and
+      // joining them cost roughly five times the payload — JS strings are UTF-16, so the chunks alone
+      // doubled it, the join doubled that again, and the Blob copied the result. A large pathogenicity
+      // download ran the tab out of memory. Each chunk is decoded to scan its lines and then dropped, so
+      // only one chunk plus a partial line is ever live.
       const parts: Uint8Array[] = []
+      const decoder = new TextDecoder()
+      let partialLine = ''
       let processedCount = 0
+      let erroredCount = 0
 
       while (true) {
         const {done, value} = await reader.read()
         if (done) break
 
         parts.push(value)
-        // NDJSON terminates every record with a newline, and 0x0A cannot appear inside a multi-byte UTF-8
-        // sequence, so counting the byte is exact and needs no decoding or chunk-boundary bookkeeping.
-        for (const byte of value) {
-          if (byte === 0x0a) processedCount += 1
+
+        // `stream: true` carries a multi-byte character split across chunks into the next decode, and
+        // popping the final element keeps a record split across chunks from being counted twice.
+        const lines = (partialLine + decoder.decode(value, {stream: true})).split('\n')
+        partialLine = lines.pop() ?? ''
+        for (const line of lines) {
+          if (!line) continue
+          processedCount += 1
+          if (isErrorRecord(line)) erroredCount += 1
         }
+
         // Without a total there is nothing to divide by; stay indeterminate rather than report Infinity.
         fileDownloadProgress.value =
           totalCount > 0 ? Math.min(100, Math.round((processedCount / totalCount) * 100)) : null
       }
 
-      // The server generator yields one line per variant, so a short body means it stopped early —
-      // status and headers went out with the first chunk, so a truncated stream is the only symptom it
+      // The server emits exactly one record per variant, so a short body means it stopped early — status
+      // and headers went out with the first chunk, so truncation is the only symptom a mid-stream failure
       // can produce. Refuse to save a file that is quietly missing records.
       if (totalCount > 0 && processedCount < totalCount) {
         throw new Error(
@@ -160,6 +199,8 @@ export function useScoreSetDownloads({scoreSet}: UseScoreSetDownloadsOptions) {
       anchor.download = `${urn}_annotated_variants_${annotationType}.ndjson`
       anchor.click()
       URL.revokeObjectURL(url)
+
+      return {received: processedCount, errored: erroredCount}
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : 'Unknown error'
       if (message !== 'The user aborted a request.') {


### PR DESCRIPTION
UI support to leverage https://github.com/VariantEffect/mavedb-api/pull/838.

The API now reports a variant it cannot annotate as a record carrying an error object instead of letting the exception truncate the body. A download containing those records is complete and worth saving, but treating it as a clean export would misrepresent it.

Tally error records as the stream arrives and raise a warning toast naming the count. Each chunk is decoded to scan its lines and then dropped, so only one chunk plus a partial line is ever live and the body is still retained as bytes. Detection prefilters on a substring and parses only candidates, since these records nest deeply and parsing every one of a large stream is slow.